### PR TITLE
feat(tx_pool_viction): impl Viction logic for tx_pools

### DIFF
--- a/core/state/vrc25.go
+++ b/core/state/vrc25.go
@@ -29,15 +29,13 @@ var (
 	ErrInsufficientFee = errors.New("insufficient VRC25 token fee")
 )
 
-func ValidateVRC25Transaction(statedb *StateDB, vrc25Contract common.Address, from common.Address, to common.Address, data []byte) error {
-	// only validate if to is a VRC25 contract
-	feeCapKey := GetStorageKeyForMapping(to.Hash(), SlotVRC25Contract["tokensState"])
+func GetFeeCapacity(statedb *StateDB, vrc25Contract common.Address, addr common.Address) *big.Int {
+	feeCapKey := GetStorageKeyForMapping(addr.Hash(), SlotVRC25Contract["tokensState"])
 	feeCapHash := statedb.GetState(vrc25Contract, feeCapKey)
-	if feeCapHash == (common.Hash{}) {
-		return nil
-	}
+	return feeCapHash.Big()
+}
 
-	
+func ValidateVRC25Transaction(statedb *StateDB, vrc25Contract common.Address, from common.Address, to common.Address, data []byte) error {
 	if data == nil || statedb == nil {
 		return ErrInvalidParams
 	}

--- a/core/state_transition_viction.go
+++ b/core/state_transition_viction.go
@@ -6,23 +6,10 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/vrc25"
 )
 
-var slotTokensState = state.SlotVRC25Contract["tokensState"]
-
-func (st *StateTransition) getFeeCapacity(contract *common.Address) *big.Int {
-	if contract == nil {
-		return nil
-	}
-	feeCapKey := state.GetStorageKeyForMapping(contract.Hash(), slotTokensState)
-	feeCap := st.state.GetState(st.evm.ChainConfig().VRC25Contract, feeCapKey)
-
-	if feeCap == (common.Hash{}) {
-		return nil
-	}
-
-	return feeCap.Big()
-}
+var slotTokensState = vrc25.SlotVRC25Contract["tokensState"]
 
 // buyVRC25Gas checks sponsorship eligibility and deducts the gas fee from the sponsor's storage balance.
 func (st *StateTransition) vrc25BuyGas() error {
@@ -30,7 +17,7 @@ func (st *StateTransition) vrc25BuyGas() error {
 	st.payer = st.msg.From()
 
 	// 1. Check if contract is sponsored (has fee capacity)
-	feeCap := st.getFeeCapacity(st.msg.To())
+	feeCap := vrc25.GetFeeCapacity(st.state, st.evm.ChainConfig().VRC25Contract, st.msg.To())
 	if feeCap == nil {
 		return nil // Not sponsored, proceed with standard user payment
 	}
@@ -65,7 +52,7 @@ func (st *StateTransition) isVRC25Transaction() bool {
 func (st *StateTransition) vrc25RefundGas(remaining *big.Int) {
 	addr := st.msg.To()
 	// Get current balance
-	feeCap := st.getFeeCapacity(addr)
+	feeCap := vrc25.GetFeeCapacity(st.state, st.evm.ChainConfig().VRC25Contract, addr)
 	if feeCap == nil {
 		// Should not happen if isSponsoringTransaction is true, but handle safely
 		return

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -544,9 +544,12 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	if pool.currentState.GetNonce(from) > tx.Nonce() {
 		return ErrNonceTooLow
 	}
+	if shouldReturn, err := pool.validateSpecialTransaction(tx, from); shouldReturn {
+		return err
+	}
 	// Transactor should have enough funds to cover the costs
-	// We custom this check to support VRC25 sponsored transactions
-	if !pool.isSufficientFunds(tx, from) {
+	// cost == V + GP * GL
+	if pool.currentState.GetBalance(from).Cmp(tx.Cost()) < 0 {
 		return ErrInsufficientFunds
 	}
 	// Ensure the transaction has more gas than the basic tx fee.

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -544,13 +544,10 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	if pool.currentState.GetNonce(from) > tx.Nonce() {
 		return ErrNonceTooLow
 	}
-	if shouldReturn, err := pool.validateSpecialTransaction(tx, from); shouldReturn {
+	
+	// Use custom VRC25 balance validation
+	if err := pool.validateSufficientTransaction(tx, from); err != nil {
 		return err
-	}
-	// Transactor should have enough funds to cover the costs
-	// cost == V + GP * GL
-	if pool.currentState.GetBalance(from).Cmp(tx.Cost()) < 0 {
-		return ErrInsufficientFunds
 	}
 	// Ensure the transaction has more gas than the basic tx fee.
 	intrGas, err := IntrinsicGas(tx.Data(), tx.To() == nil, true, pool.istanbul)

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -544,7 +544,6 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	if pool.currentState.GetNonce(from) > tx.Nonce() {
 		return ErrNonceTooLow
 	}
-	
 	// Use custom VRC25 balance validation
 	if err := pool.validateSufficientTransaction(tx, from); err != nil {
 		return err

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -545,8 +545,8 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		return ErrNonceTooLow
 	}
 	// Transactor should have enough funds to cover the costs
-	// cost == V + GP * GL
-	if pool.currentState.GetBalance(from).Cmp(tx.Cost()) < 0 {
+	// We custom this check to support VRC25 sponsored transactions
+	if !pool.isSufficientFunds(tx, from) {
 		return ErrInsufficientFunds
 	}
 	// Ensure the transaction has more gas than the basic tx fee.

--- a/core/tx_pool_viction.go
+++ b/core/tx_pool_viction.go
@@ -15,9 +15,11 @@ func (pool *TxPool) validateSufficientTransaction(tx *types.Transaction, from co
 
 	feeCap := vrc25.GetFeeCapacity(pool.currentState, pool.chainconfig.VRC25Contract, tx.To())
 	if feeCap != nil {
-		// VRC25 transaction
-		if err := vrc25.ValidateVRC25Transaction(pool.currentState, pool.chainconfig.VRC25Contract, from, *tx.To(), tx.Data()); err != nil {
-			return err
+		if tx.To() != nil {
+			// VRC25 transaction
+			if err := vrc25.ValidateVRC25Transaction(pool.currentState, pool.chainconfig.VRC25Contract, from, *tx.To(), tx.Data()); err != nil {
+				return err
+			}
 		}
 
 		requiredFee := new(big.Int).Mul(new(big.Int).SetUint64(tx.Gas()), pool.chainconfig.VRC25GasPrice)

--- a/core/tx_pool_viction.go
+++ b/core/tx_pool_viction.go
@@ -4,8 +4,8 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vrc25"
 )
 
 // validate sufficient balance for transaction execution, considering VRC25 fee cap if applicable
@@ -13,22 +13,19 @@ func (pool *TxPool) validateSufficientTransaction(tx *types.Transaction, from co
 	balance := pool.currentState.GetBalance(from)
 	requiredBalance := tx.Cost()
 
-	if tx.To() != nil {
-		feeCap := state.GetFeeCapacity(pool.currentState, pool.chainconfig.VRC25Contract, from)
-		if feeCap != nil {
-			// VRC25 transaction
-			if err := state.ValidateVRC25Transaction(pool.currentState, pool.chainconfig.VRC25Contract, from, *tx.To(), tx.Data()); err != nil {
-				return err
-			}
+	feeCap := vrc25.GetFeeCapacity(pool.currentState, pool.chainconfig.VRC25Contract, tx.To())
+	if feeCap != nil {
+		// VRC25 transaction
+		if err := vrc25.ValidateVRC25Transaction(pool.currentState, pool.chainconfig.VRC25Contract, from, *tx.To(), tx.Data()); err != nil {
+			return err
+		}
 
-			requiredFee := new(big.Int).Mul(new(big.Int).SetUint64(tx.Gas()), pool.chainconfig.VRC25GasPrice)
-			if feeCap.Cmp(requiredFee) >= 0 {
-				// if fee capacity is sufficient, reduce the required balance by gas fee
-				requiredBalance = tx.Value()
-			}
+		requiredFee := new(big.Int).Mul(new(big.Int).SetUint64(tx.Gas()), pool.chainconfig.VRC25GasPrice)
+		if feeCap.Cmp(requiredFee) >= 0 {
+			// if fee capacity is sufficient, reduce the required balance by gas fee
+			requiredBalance = tx.Value()
 		}
 	}
-
 	if balance.Cmp(requiredBalance) < 0 {
 		return ErrInsufficientFunds
 	}

--- a/core/tx_pool_viction.go
+++ b/core/tx_pool_viction.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
@@ -9,11 +10,13 @@ func (pool *TxPool) isSufficientFunds(tx *types.Transaction, from common.Address
 	return pool.currentState.GetBalance(from).Cmp(tx.Cost()) < 0
 }
 
-func (pool *TxPool) validateVRC25Transaction(tx *types.Transaction, from common.Address) error {
-	return nil
-}
-
 // validate customize Viction transaction (black list, special transaction) return bool to skip other validation
-func (pool *TxPool) validateVictionTransaciton(tx *types.Transaction, from common.Address) (bool, error) {
+func (pool *TxPool) validateSpecialTransaction(tx *types.Transaction, from common.Address) (bool, error) {
+	if err := state.ValidateVRC25Transaction(pool.currentState, pool.chainconfig.VRC25Contract, from, *tx.To(), tx.Data()); err != nil {
+		return false, err
+	}
+	if pool.isSufficientFunds(tx, from) {
+		return true, nil
+	}
 	return false, nil
 }

--- a/core/tx_pool_viction.go
+++ b/core/tx_pool_viction.go
@@ -1,0 +1,19 @@
+package core
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+func (pool *TxPool) isSufficientFunds(tx *types.Transaction, from common.Address) bool {
+	return pool.currentState.GetBalance(from).Cmp(tx.Cost()) < 0
+}
+
+func (pool *TxPool) validateVRC25Transaction(tx *types.Transaction, from common.Address) error {
+	return nil
+}
+
+// validate customize Viction transaction (black list, special transaction) return bool to skip other validation
+func (pool *TxPool) validateVictionTransaciton(tx *types.Transaction, from common.Address) (bool, error) {
+	return false, nil
+}

--- a/core/vrc25/vrc25.go
+++ b/core/vrc25/vrc25.go
@@ -22,8 +22,8 @@ var (
 		"minFee":   1,
 		"issuer":   2,
 	}
-	transferFuncHex     = common.Hex2Bytes("0xa9059cbb")
-	transferFromFuncHex = common.Hex2Bytes("0x23b872dd")
+	transferFunctionSelector     = common.Hex2Bytes("0xa9059cbb")
+	transferFromFunctionSelector = common.Hex2Bytes("0x23b872dd")
 )
 
 var (
@@ -66,10 +66,10 @@ func ValidateVRC25Transaction(statedb vm.StateDB, vrc25Contract common.Address, 
 
 		if len(data) > 4 {
 			funcHex := data[:4]
-			if bytes.Equal(funcHex, transferFuncHex) && len(data) == 68 {
+			if bytes.Equal(funcHex, transferFunctionSelector) && len(data) == 68 {
 				value = common.BytesToHash(data[36:]).Big()
 			} else {
-				if bytes.Equal(funcHex, transferFromFuncHex) && len(data) == 80 {
+				if bytes.Equal(funcHex, transferFromFunctionSelector) && len(data) == 80 {
 					// Small fix here: only consider the value if 'from' matches
 					if from.Hex() == common.BytesToAddress(data[4:36]).Hex() {
 						value = common.BytesToHash(data[68:]).Big()

--- a/core/vrc25/vrc25.go
+++ b/core/vrc25/vrc25.go
@@ -41,7 +41,7 @@ func GetFeeCapacity(statedb vm.StateDB, vrc25Contract common.Address, addr *comm
 	return feeCapHash.Big()
 }
 
-// This function validate VRC25 transaction
+// This function validates VRC25 transactions
 // User's balance must be greater than or equal to the required fee
 func ValidateVRC25Transaction(statedb vm.StateDB, vrc25Contract common.Address, from common.Address, to common.Address, data []byte) error {
 	if data == nil || statedb == nil {


### PR DESCRIPTION
This PR refactors the VRC25 protocol logic by moving it from the core/state package to a new dedicated core/vrc25 package.
Motivation
*   Separation of Concerns: core/state is responsible for low-level storage primitives (Merkle Trie, Database). High-level protocol rules like VRC25 fee validation shouldn't reside there.
*   Modularity: Allows other packages to access VRC25 constants and validation logic without pulling in the heavy state package dependencies.
*   Cleaner Architecture: Prevents potential circular dependencies between vm and state packages, as the VRC25 logic relies on the vm.StateDB interface.
Changes
*   Moved core/state/vrc25.go to core/vrc25/vrc25.go.
*   Created new package vrc25.
*   Updated GetFeeCapacity and ValidateVRC25Transaction to use state.GetStorageKeyForMapping via import.
*   Updated consumers in core/tx_pool_viction.go and core/state_transition_viction.go to use the new package.