### PR TITLE
feat(vrc25): implement PayFeeWithVRC25

### DIFF
--- a/core/vrc25/vrc25.go
+++ b/core/vrc25/vrc25.go
@@ -44,10 +44,10 @@ func PayFeeWithVRC25(statedb vm.StateDB, from common.Address, token common.Addre
 	if balanceHash != (common.Hash{}) {
 		// 3. Check if balance is positive
 		balance := balanceHash.Big()
-		feeUsed := big.NewInt(0)
-		if balance.Cmp(feeUsed) <= 0 {
+		if balance.Sign() <= 0 {
 			return nil
 		}
+		feeUsed := big.NewInt(0)
 
 		// 4. Retrieve the issuer address of the token
 		issuerKey := state.GetStorageKeyForSlot(SlotVRC25Token["issuer"])

--- a/core/vrc25/vrc25.go
+++ b/core/vrc25/vrc25.go
@@ -70,15 +70,15 @@ func PayFeeWithVRC25(statedb vm.StateDB, from common.Address, token common.Addre
 		}
 
 		// 7. Deduct the fee from the user's balance and update state
-		balance.Sub(balance, feeUsed)
-		statedb.SetState(token, balanceKey, common.BigToHash(balance))
+		newBalance := new(big.Int).Sub(balance, feeUsed)
+		statedb.SetState(token, balanceKey, common.BigToHash(newBalance))
 
 		// 8. Add the fee to the issuer's balance and update state
 		issuerBalanceKey := state.GetStorageKeyForMapping(issuerAddr.Hash(), slotBalances)
 		issuerBalanceHash := statedb.GetState(token, issuerBalanceKey)
 		issuerBalance := issuerBalanceHash.Big()
-		issuerBalance.Add(issuerBalance, feeUsed)
-		statedb.SetState(token, issuerBalanceKey, common.BigToHash(issuerBalance))
+		newIssuerBalance := new(big.Int).Add(issuerBalance, feeUsed)
+		statedb.SetState(token, issuerBalanceKey, common.BigToHash(newIssuerBalance))
 	}
 	return nil
 }

--- a/core/vrc25/vrc25.go
+++ b/core/vrc25/vrc25.go
@@ -47,8 +47,6 @@ func PayFeeWithVRC25(statedb vm.StateDB, from common.Address, token common.Addre
 		if balance.Sign() <= 0 {
 			return nil
 		}
-		feeUsed := big.NewInt(0)
-
 		// 4. Retrieve the issuer address of the token
 		issuerKey := state.GetStorageKeyForSlot(SlotVRC25Token["issuer"])
 		issuerHash := statedb.GetState(token, issuerKey)
@@ -63,10 +61,9 @@ func PayFeeWithVRC25(statedb vm.StateDB, from common.Address, token common.Addre
 		minFee := minFeeHash.Big()
 
 		// 6. Determine the actual fee to charge (lesser of balance or minFee)
+		feeUsed := new(big.Int).Set(minFee)
 		if balance.Cmp(minFee) < 0 {
-			feeUsed = balance
-		} else {
-			feeUsed = minFee
+			feeUsed.Set(balance)
 		}
 
 		// 7. Deduct the fee from the user's balance and update state

--- a/core/vrc25/vrc25.go
+++ b/core/vrc25/vrc25.go
@@ -31,6 +31,58 @@ var (
 	ErrInsufficientFee = errors.New("insufficient VRC25 token fee")
 )
 
+func PayFeeWithVRC25(statedb vm.StateDB, from common.Address, token common.Address) error {
+	// 1. Check for valid statedb
+	if statedb == nil {
+		return ErrInvalidParams
+	}
+	// 2. Retrieve the balance of the from address for the VRC25 token
+	slotBalances := SlotVRC25Token["balances"]
+	balanceKey := state.GetStorageKeyForMapping(from.Hash(), slotBalances)
+	balanceHash := statedb.GetState(token, balanceKey)
+
+	if balanceHash != (common.Hash{}) {
+		// 3. Check if balance is positive
+		balance := balanceHash.Big()
+		feeUsed := big.NewInt(0)
+		if balance.Cmp(feeUsed) <= 0 {
+			return nil
+		}
+
+		// 4. Retrieve the issuer address of the token
+		issuerKey := state.GetStorageKeyForSlot(SlotVRC25Token["issuer"])
+		issuerHash := statedb.GetState(token, issuerKey)
+		if issuerHash == (common.Hash{}) {
+			return nil
+		}
+		issuerAddr := common.BytesToAddress(issuerHash.Bytes())
+
+		// 5. Retrieve the minimum fee required by the token
+		minFeeKey := state.GetStorageKeyForSlot(SlotVRC25Token["minFee"])
+		minFeeHash := statedb.GetState(token, minFeeKey)
+		minFee := minFeeHash.Big()
+
+		// 6. Determine the actual fee to charge (lesser of balance or minFee)
+		if balance.Cmp(minFee) < 0 {
+			feeUsed = balance
+		} else {
+			feeUsed = minFee
+		}
+
+		// 7. Deduct the fee from the user's balance and update state
+		balance.Sub(balance, feeUsed)
+		statedb.SetState(token, balanceKey, common.BigToHash(balance))
+
+		// 8. Add the fee to the issuer's balance and update state
+		issuerBalanceKey := state.GetStorageKeyForMapping(issuerAddr.Hash(), slotBalances)
+		issuerBalanceHash := statedb.GetState(token, issuerBalanceKey)
+		issuerBalance := issuerBalanceHash.Big()
+		issuerBalance.Add(issuerBalance, feeUsed)
+		statedb.SetState(token, issuerBalanceKey, common.BigToHash(issuerBalance))
+	}
+	return nil
+}
+
 // we use vm.StateDB interface instead of *StateDB
 func GetFeeCapacity(statedb vm.StateDB, vrc25Contract common.Address, addr *common.Address) *big.Int {
 	if addr == nil {


### PR DESCRIPTION
This PR implements `PayFeeWithVRC25` in the `core/vrc25` package. This function handles the deduction of VRC25 token fees from a user's balance and credits them to the token issuer.

It is a port of the legacy TRC21 implementation found here:
https://github.com/BuildOnViction/victionchain/blob/master/core/state/trc21_reader.go#L81

**Changes:**
- Added `PayFeeWithVRC25` to `core/vrc25/vrc25.go`
- Added detailed step-by-step comments for clarity.