### PR TITLE
fix(core): update VRC25 config access to match ChainConfig refactor

### DIFF
--- a/core/state_transition_viction.go
+++ b/core/state_transition_viction.go
@@ -21,10 +21,10 @@ func (st *StateTransition) vrc25BuyGas() error {
 	if feeCap == nil {
 		return nil // Not sponsored, proceed with standard user payment
 	}
-	chainConfig := st.evm.ChainConfig().Viction
+	victionConfig := st.evm.ChainConfig().Viction
 
 	// 2. Calculate Gas Cost with VRC25 Gas Price
-	vrc25GasFee := new(big.Int).Mul(new(big.Int).SetUint64(st.msg.Gas()), (*big.Int)(chainConfig.VRC25GasPrice))
+	vrc25GasFee := new(big.Int).Mul(new(big.Int).SetUint64(st.msg.Gas()), (*big.Int)(victionConfig.VRC25GasPrice))
 
 	// 3. Check sufficiency
 	if feeCap.Cmp(vrc25GasFee) < 0 {
@@ -35,12 +35,12 @@ func (st *StateTransition) vrc25BuyGas() error {
 	// Note: The native ETH deduction happens in state_transition.go via st.state.SubBalance(st.payer)
 	newFeeCap := new(big.Int).Sub(feeCap, vrc25GasFee)
 	feeCapKey := state.GetStorageKeyForMapping(st.msg.To().Hash(), slotTokensState)
-	st.state.SetState(chainConfig.VRC25Contract, feeCapKey, common.BigToHash(newFeeCap))
+	st.state.SetState(victionConfig.VRC25Contract, feeCapKey, common.BigToHash(newFeeCap))
 
 	// 5. Set Payer to System Contract
 	// This ensures buyGas() deducts native ETH from the system contract
-	st.gasPrice = (*big.Int)(chainConfig.VRC25GasPrice)
-	st.payer = chainConfig.VRC25Contract
+	st.gasPrice = (*big.Int)(victionConfig.VRC25GasPrice)
+	st.payer = victionConfig.VRC25Contract
 
 	return nil
 }

--- a/core/state_transition_viction.go
+++ b/core/state_transition_viction.go
@@ -17,14 +17,14 @@ func (st *StateTransition) vrc25BuyGas() error {
 	st.payer = st.msg.From()
 
 	// 1. Check if contract is sponsored (has fee capacity)
-	feeCap := vrc25.GetFeeCapacity(st.state, st.evm.ChainConfig().VRC25Contract, st.msg.To())
+	feeCap := vrc25.GetFeeCapacity(st.state, st.evm.ChainConfig().Viction.VRC25Contract, st.msg.To())
 	if feeCap == nil {
 		return nil // Not sponsored, proceed with standard user payment
 	}
-	chainConfig := st.evm.ChainConfig()
+	chainConfig := st.evm.ChainConfig().Viction
 
 	// 2. Calculate Gas Cost with VRC25 Gas Price
-	vrc25GasFee := new(big.Int).Mul(new(big.Int).SetUint64(st.msg.Gas()), chainConfig.VRC25GasPrice)
+	vrc25GasFee := new(big.Int).Mul(new(big.Int).SetUint64(st.msg.Gas()), (*big.Int)(chainConfig.VRC25GasPrice))
 
 	// 3. Check sufficiency
 	if feeCap.Cmp(vrc25GasFee) < 0 {
@@ -39,7 +39,7 @@ func (st *StateTransition) vrc25BuyGas() error {
 
 	// 5. Set Payer to System Contract
 	// This ensures buyGas() deducts native ETH from the system contract
-	st.gasPrice = chainConfig.VRC25GasPrice
+	st.gasPrice = (*big.Int)(chainConfig.VRC25GasPrice)
 	st.payer = chainConfig.VRC25Contract
 
 	return nil
@@ -52,7 +52,7 @@ func (st *StateTransition) isVRC25Transaction() bool {
 func (st *StateTransition) vrc25RefundGas(remaining *big.Int) {
 	addr := st.msg.To()
 	// Get current balance
-	feeCap := vrc25.GetFeeCapacity(st.state, st.evm.ChainConfig().VRC25Contract, addr)
+	feeCap := vrc25.GetFeeCapacity(st.state, st.evm.ChainConfig().Viction.VRC25Contract, addr)
 	if feeCap == nil {
 		// Should not happen if isSponsoringTransaction is true, but handle safely
 		return
@@ -61,5 +61,5 @@ func (st *StateTransition) vrc25RefundGas(remaining *big.Int) {
 	// Refund to Contract's Storage Balance
 	newFeeCap := new(big.Int).Add(feeCap, remaining)
 	feeCapKey := state.GetStorageKeyForMapping(addr.Hash(), slotTokensState)
-	st.state.SetState(st.evm.ChainConfig().VRC25Contract, feeCapKey, common.BigToHash(newFeeCap))
+	st.state.SetState(st.evm.ChainConfig().Viction.VRC25Contract, feeCapKey, common.BigToHash(newFeeCap))
 }

--- a/core/tx_pool_viction.go
+++ b/core/tx_pool_viction.go
@@ -13,16 +13,16 @@ func (pool *TxPool) validateSufficientTransaction(tx *types.Transaction, from co
 	balance := pool.currentState.GetBalance(from)
 	requiredBalance := tx.Cost()
 
-	feeCap := vrc25.GetFeeCapacity(pool.currentState, pool.chainconfig.VRC25Contract, tx.To())
+	feeCap := vrc25.GetFeeCapacity(pool.currentState, pool.chainconfig.Viction.VRC25Contract, tx.To())
 	if feeCap != nil {
 		if tx.To() != nil {
 			// VRC25 transaction
-			if err := vrc25.ValidateVRC25Transaction(pool.currentState, pool.chainconfig.VRC25Contract, from, *tx.To(), tx.Data()); err != nil {
+			if err := vrc25.ValidateVRC25Transaction(pool.currentState, pool.chainconfig.Viction.VRC25Contract, from, *tx.To(), tx.Data()); err != nil {
 				return err
 			}
 		}
 
-		requiredFee := new(big.Int).Mul(new(big.Int).SetUint64(tx.Gas()), pool.chainconfig.VRC25GasPrice)
+		requiredFee := new(big.Int).Mul(new(big.Int).SetUint64(tx.Gas()), (*big.Int)(pool.chainconfig.Viction.VRC25GasPrice))
 		if feeCap.Cmp(requiredFee) >= 0 {
 			// if fee capacity is sufficient, reduce the required balance by gas fee
 			requiredBalance = tx.Value()


### PR DESCRIPTION
This PR updates the VRC25 contract and gas price access patterns in `core/tx_pool_viction.go` and `core/state_transition_viction.go`. 

It addresses the recent refactor where `VRC25Contract` and `VRC25GasPrice` were moved into the `Viction` struct within `ChainConfig` and changed to `math.Decimal256`.

**Changes:**
- Updated access paths to `chainConfig.Viction.*`
- Added type casting for `Decimal256` to `*big.Int` where necessary.