### PR TITLE
feat: add flags for quick run viction testnet and mainnet

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -301,7 +301,7 @@ func prepare(ctx *cli.Context) {
 		log.Info("Starting Geth on Viction mainnet...")
 
 	case ctx.GlobalIsSet(utils.VictestFlag.Name):
-		log.Info("Starting Geth on Victest testnet...")
+		log.Info("Starting Geth on Viction testnet...")
 
 	case ctx.GlobalIsSet(utils.DeveloperFlag.Name):
 		log.Info("Starting Geth in ephemeral dev mode...")

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -146,6 +146,8 @@ var (
 		utils.RinkebyFlag,
 		utils.GoerliFlag,
 		utils.YoloV2Flag,
+		utils.VictionFlag,
+		utils.VictestFlag,
 		utils.VMEnableDebugFlag,
 		utils.NetworkIdFlag,
 		utils.EthStatsURLFlag,
@@ -294,6 +296,12 @@ func prepare(ctx *cli.Context) {
 
 	case ctx.GlobalIsSet(utils.GoerliFlag.Name):
 		log.Info("Starting Geth on Görli testnet...")
+
+	case ctx.GlobalIsSet(utils.VictionFlag.Name):
+		log.Info("Starting Geth on Viction mainnet...")
+
+	case ctx.GlobalIsSet(utils.VictestFlag.Name):
+		log.Info("Starting Geth on Victest testnet...")
 
 	case ctx.GlobalIsSet(utils.DeveloperFlag.Name):
 		log.Info("Starting Geth in ephemeral dev mode...")

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -147,6 +147,14 @@ var (
 		Name:  "ropsten",
 		Usage: "Ropsten network: pre-configured proof-of-work test network",
 	}
+	VictionFlag = cli.BoolFlag{
+		Name:  "viction",
+		Usage: "Viction network: pre-configured proof-of-stake-voting main network",
+	}
+	VictestFlag = cli.BoolFlag{
+		Name:  "victest",
+		Usage: "Victest network: pre-configured proof-of-stake-voting test network",
+	}
 	DeveloperFlag = cli.BoolFlag{
 		Name:  "dev",
 		Usage: "Ephemeral proof-of-authority network with a pre-funded developer account, mining enabled",
@@ -1487,7 +1495,7 @@ func SetShhConfig(ctx *cli.Context, stack *node.Node) {
 // SetEthConfig applies eth-related command line flags to the config.
 func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 	// Avoid conflicting network flags
-	CheckExclusive(ctx, DeveloperFlag, LegacyTestnetFlag, RopstenFlag, RinkebyFlag, GoerliFlag, YoloV2Flag)
+	CheckExclusive(ctx, DeveloperFlag, LegacyTestnetFlag, RopstenFlag, RinkebyFlag, GoerliFlag, YoloV2Flag, VictionFlag, VictestFlag)
 	CheckExclusive(ctx, LegacyLightServFlag, LightServeFlag, SyncModeFlag, "light")
 	CheckExclusive(ctx, DeveloperFlag, ExternalSignerFlag) // Can't use both ephemeral unlocked and external signer
 	CheckExclusive(ctx, GCModeFlag, "archive", TxLookupLimitFlag)
@@ -1620,6 +1628,18 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 			cfg.NetworkId = 133519467574834 // "yolov2"
 		}
 		cfg.Genesis = core.DefaultYoloV2GenesisBlock()
+	case ctx.GlobalBool(VictionFlag.Name):
+		if !ctx.GlobalIsSet(NetworkIdFlag.Name) {
+			cfg.NetworkId = 88
+		}
+		cfg.Genesis = core.DefaultVictionGenesisBlock()
+		SetDNSDiscoveryDefaults(cfg, params.VictionGenesisHash)
+	case ctx.GlobalBool(VictestFlag.Name):
+		if !ctx.GlobalIsSet(NetworkIdFlag.Name) {
+			cfg.NetworkId = 89
+		}
+		cfg.Genesis = core.DefaultVictestGenesisBlock()
+		SetDNSDiscoveryDefaults(cfg, params.VictestGenesisHash)
 	case ctx.GlobalBool(DeveloperFlag.Name):
 		if !ctx.GlobalIsSet(NetworkIdFlag.Name) {
 			cfg.NetworkId = 1337
@@ -1804,6 +1824,10 @@ func MakeGenesis(ctx *cli.Context) *core.Genesis {
 		genesis = core.DefaultGoerliGenesisBlock()
 	case ctx.GlobalBool(YoloV2Flag.Name):
 		genesis = core.DefaultYoloV2GenesisBlock()
+	case ctx.GlobalBool(VictionFlag.Name):
+		genesis = core.DefaultVictionGenesisBlock()
+	case ctx.GlobalBool(VictestFlag.Name):
+		genesis = core.DefaultVictestGenesisBlock()
 	case ctx.GlobalBool(DeveloperFlag.Name):
 		Fatalf("Developer chains are ephemeral")
 	}


### PR DESCRIPTION
feat: add --viction and --victest network flags for Viction blockchain

Add convenience flags for Viction mainnet and Victest testnet networks,
similar to existing --ropsten, --rinkeby, and --goerli flags.

Changes:
- Add VictionFlag and VictestFlag definitions in cmd/utils/flags.go
- Register flags in nodeFlags array in cmd/geth/main.go
- Add network ID 88 (Viction) and 89 (Victest) auto-configuration
- Automatically load DefaultVictionGenesisBlock() and DefaultVictestGenesisBlock()
- Configure DNS discovery for Viction and Victest networks
- Add startup logging for Viction and Victest networks
- Include flags in CheckExclusive to prevent conflicting network flags

Usage:
  geth --viction --datadir ./viction-data
  geth --victest --datadir ./victest-data

These flags automatically:
- Set network ID to 88 (Viction) or 89 (Victest)
- Load the appropriate genesis block with Posv consensus
- Configure DNS discovery
- Log which network is starting