### PR TITLE
 Handling of TomoX and Lending transactions 

### DIFF
--- a/params/viction_config.go
+++ b/params/viction_config.go
@@ -12,6 +12,7 @@ type VictionConfig struct {
 	AtlasVRC25MinCap *math.Decimal256 `json:"atlasVRC25MinCap,omitempty"`
 
 	LendingContract            common.Address   `json:"lendingContract,omitempty"`
+	LendingFinalizedContract   common.Address   `json:"lendingFinalizedContract,omitempty"`
 	LendingInterestAmount      *math.Decimal256 `json:"lendingInterestAmount,omitempty"`
 	LendingLiquidateTradeBlock uint64           `json:"lendingLiquidateTradeBlock,omitempty"`
 
@@ -44,13 +45,14 @@ type VictionConfig struct {
 	SaigonFundRepeat     uint64           `json:"saigonFundRepeat,omitempty"`
 	SaigonRewardPerEpoch *math.Decimal256 `json:"saigonRewardPerEpoch,omitempty"`
 
-	TomoXBaseCancelFee *math.Decimal256 `json:"tomoxBaseCancelFee,omitempty"`
-	TomoXBaseFee       *math.Decimal256 `json:"tomoxBaseFee,omitempty"`
-	TomoXBasePrice     *math.Decimal256 `json:"tomoxBasePrice,omitempty"`
-	TomoXBaseRecall    *math.Decimal256 `json:"tomoxBaseRecall,omitempty"`
-	TomoXContract      common.Address   `json:"tomoxContract,omitempty"`
-	TomoXTopupDenom    uint64           `json:"tomoxTopupDenom,omitempty"`
-	TomoXTopupNumer    uint64           `json:"tomoxTopupNumer,omitempty"`
+	TomoXBaseCancelFee   *math.Decimal256 `json:"tomoxBaseCancelFee,omitempty"`
+	TomoXBaseFee         *math.Decimal256 `json:"tomoxBaseFee,omitempty"`
+	TomoXBasePrice       *math.Decimal256 `json:"tomoxBasePrice,omitempty"`
+	TomoXBaseRecall      *math.Decimal256 `json:"tomoxBaseRecall,omitempty"`
+	TomoXContract        common.Address   `json:"tomoxContract,omitempty"`
+	TradingStateContract common.Address   `json:"tradingStateContract,omitempty"`
+	TomoXTopupDenom      uint64           `json:"tomoxTopupDenom,omitempty"`
+	TomoXTopupNumer      uint64           `json:"tomoxTopupNumer,omitempty"`
 
 	ValidatorBlockSignContract     common.Address `json:"validatorBlockSignContract,omitempty"`
 	ValidatorContract              common.Address `json:"validatorContract,omitempty"`
@@ -258,7 +260,12 @@ var victionBypassBlocks = map[uint64]string{
 	9147459: "0xe187cf86c2274b1f16e8225a7da9a75aba4f1f5f",
 }
 
+const victionMaxBypassBlock uint64 = 9147459
+
 func (c *VictionConfig) GetVictionBypassBalance(blockNum uint64, addr common.Address) *big.Int {
+	if blockNum > victionMaxBypassBlock {
+		return nil
+	}
 	if bypassAddrHex, ok := victionBypassBlocks[blockNum]; ok {
 		if strings.EqualFold(bypassAddrHex, addr.Hex()) {
 			if balanceStr, ok := victionBypassBalances[bypassAddrHex]; ok {


### PR DESCRIPTION
This pull request introduces significant improvements to the handling of TomoX and Lending transactions in the Viction blockchain codebase, along with some configuration enhancements and a small bug fix for bypass balance logic. The changes ensure that certain DEX-related transactions are now correctly routed to no-op handlers when the DEX system is disabled, and they improve configuration flexibility for contract addresses. Additionally, the logic for bypassing the blacklist for legacy blocks is clarified and centralized.

**DEX and Lending Transaction Handling:**
- Added logic in `core/state_processor_viction.go` to route TomoX and Lending protocol transactions (e.g., Trading, State Sync, Lending, Lending Finalization) to a new no-op handler (`applyEmptyTransaction`) when the DEX system is disabled, preventing these transactions from executing any business logic.
- Introduced the `applyEmptyTransaction` method to generate a receipt and log for such no-op transactions, ensuring proper accounting and logging.

**Configuration Enhancements:**
- Added `LendingFinalizedContract` and `TradingStateContract` fields to the `VictionConfig` struct to allow configuration of additional contract addresses used in the new routing logic. [[1]](diffhunk://#diff-9bd1f05b8a2ad9adaeda28828063ff3294681012a93dc4b564159dbc8ee71fb6R15) [[2]](diffhunk://#diff-9bd1f05b8a2ad9adaeda28828063ff3294681012a93dc4b564159dbc8ee71fb6R53)

**Bypass Blacklist Logic:**
- Centralized the max bypass block number as a constant (`victionMaxBypassBlock`) and updated `GetVictionBypassBalance` to enforce this limit, ensuring bypasses only occur for legacy blocks.
- Simplified the bypass blacklist check in `beforeApplyTransaction` to use the new logic from `GetVictionBypassBalance`, improving maintainability and correctness.