### PR TITLE
Disable EIP-2028 gas reduction for Viction (PoSV) networks

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -245,7 +245,9 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	contractCreation := msg.To() == nil
 
 	// Check clauses 4-5, subtract intrinsic gas if everything is correct
-	gas, err := IntrinsicGas(st.data, contractCreation, homestead, istanbul)
+	// On Viction (Posv) networks, EIP-2028 data gas reduction is intentionally not applied:
+	isEIP2028 := istanbul && st.evm.ChainConfig().Posv == nil
+	gas, err := IntrinsicGas(st.data, contractCreation, homestead, isEIP2028)
 	if err != nil {
 		return nil, err
 	}

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -549,7 +549,9 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		return err
 	}
 	// Ensure the transaction has more gas than the basic tx fee.
-	intrGas, err := IntrinsicGas(tx.Data(), tx.To() == nil, true, pool.istanbul)
+	// On Viction (Posv) networks, EIP-2028 data gas reduction is intentionally not applied:
+	isEIP2028 := pool.istanbul && pool.chainconfig.Posv == nil
+	intrGas, err := IntrinsicGas(tx.Data(), tx.To() == nil, true, isEIP2028)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Viction does not apply EIP 2028 to the Istanbul update, so we have disabled it.