### PR TITLE
Implement transaction fee distribution logic

### DIFF
--- a/core/state/viction_state.go
+++ b/core/state/viction_state.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 )
 
 const SignMethodHex = "e341eaa4"
@@ -68,4 +69,9 @@ func (statedb *StateDB) VicGetValidatorVoterCap(contractAddress common.Address, 
 	voterElemSlot := StorageLocationOfMappingElement(votersMappingSlot, voter.Hash().Bytes())
 
 	return new(big.Int).SetBytes(statedb.GetState(contractAddress, voterElemSlot.Hash()).Bytes())
+}
+
+func GetValidatorOwnerSlot(candidate common.Address) common.Hash {
+	validatorMappingSlot := vicValidatorStorageMap["validatorsState"]
+	return crypto.Keccak256Hash(candidate.Hash().Bytes(), common.BigToHash(big.NewInt(int64(validatorMappingSlot))).Bytes())
 }

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -270,7 +270,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		ret, st.gas, vmerr = st.evm.Call(sender, st.to(), st.data, st.gas, st.value)
 	}
 	st.refundGas()
-	st.state.AddBalance(st.evm.Context.Coinbase, new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.gasPrice))
+	st.applyTransactionFee()
 
 	return &ExecutionResult{
 		UsedGas:    st.gasUsed(),

--- a/core/state_transition_viction.go
+++ b/core/state_transition_viction.go
@@ -101,7 +101,7 @@ func (st *StateTransition) applyTransactionFee() {
 	}
 
 	// After TIPTRC21Fee fork: route fee to the registered owner of the validator.
-	slot := victionCfg.GetValidatorOwnerSlot(st.evm.Context.Coinbase)
+	slot := state.GetValidatorOwnerSlot(st.evm.Context.Coinbase)
 	ownerHash := st.state.GetState(victionCfg.ValidatorContract, slot)
 	owner := common.BytesToAddress(ownerHash.Bytes())
 	if owner != (common.Address{}) {

--- a/core/state_transition_viction.go
+++ b/core/state_transition_viction.go
@@ -63,3 +63,48 @@ func (st *StateTransition) vrc25RefundGas(remaining *big.Int) {
 	feeCapKey := state.GetStorageKeyForMapping(addr.Hash(), slotTokensState)
 	st.state.SetState(st.evm.ChainConfig().Viction.VRC25Contract, feeCapKey, common.BigToHash(newFeeCap))
 }
+
+// applyTransactionFee distributes the transaction fee to the correct recipient.
+//
+// After the TIPTRC21Fee fork the fee goes to the validator-owner stored on-chain
+// inside VictionConfig.ValidatorContract. Before that fork, or when no owner is
+// registered, the fee falls back to the block coinbase.
+//
+// When the Atlas fork is active and this is a VRC25-sponsored transaction the fee
+// amount is re-derived using VictionConfig.VRC25GasPrice (which matches the price
+// already used in buyGas / refundGas) instead of the regular gasPrice.
+func (st *StateTransition) applyTransactionFee() {
+	victionCfg := st.evm.ChainConfig().Viction
+	blockNum := st.evm.Context.BlockNumber
+
+	txFee := new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.gasPrice)
+
+	if victionCfg == nil {
+		// Non-Viction chain: fee always goes to the coinbase.
+		st.state.AddBalance(st.evm.Context.Coinbase, txFee)
+		return
+	}
+
+	// After Atlas HF, VRC25-sponsored transactions carry a different gas price that
+	// was set on st.gasPrice in vrc25BuyGas. However, if IsAtlas and we are a VRC25
+	// transaction the gasPrice was already overridden to VRC25GasPrice, so txFee is
+	// already correct. Explicitly recalculate only when VRC25GasPrice is set and the
+	// current gasPrice could have been overridden (i.e., IsAtlas is active).
+	if st.evm.ChainConfig().IsAtlas(blockNum) && st.isVRC25Transaction() && victionCfg.VRC25GasPrice != nil {
+		txFee = new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), (*big.Int)(victionCfg.VRC25GasPrice))
+	}
+
+	// Before TIPTRC21Fee fork: fee goes to the block coinbase.
+	if !st.evm.ChainConfig().IsTIPTRC21Fee(blockNum) {
+		st.state.AddBalance(st.evm.Context.Coinbase, txFee)
+		return
+	}
+
+	// After TIPTRC21Fee fork: route fee to the registered owner of the validator.
+	slot := victionCfg.GetValidatorOwnerSlot(st.evm.Context.Coinbase)
+	ownerHash := st.state.GetState(victionCfg.ValidatorContract, slot)
+	owner := common.BytesToAddress(ownerHash.Bytes())
+	if owner != (common.Address{}) {
+		st.state.AddBalance(owner, txFee)
+	}
+}

--- a/params/viction_config.go
+++ b/params/viction_config.go
@@ -6,6 +6,11 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+var (
+	ValidatorsStateSlot = big.NewInt(1)
 )
 
 type VictionConfig struct {
@@ -269,4 +274,8 @@ func (c *VictionConfig) GetVictionBypassBalance(blockNum uint64, addr common.Add
 		}
 	}
 	return nil
+}
+
+func (c *VictionConfig) GetValidatorOwnerSlot(candidate common.Address) common.Hash {
+	return crypto.Keccak256Hash(candidate.Hash().Bytes(), common.BigToHash(ValidatorsStateSlot).Bytes())
 }

--- a/params/viction_config.go
+++ b/params/viction_config.go
@@ -6,11 +6,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
-	"github.com/ethereum/go-ethereum/crypto"
-)
-
-var (
-	ValidatorsStateSlot = big.NewInt(1)
 )
 
 type VictionConfig struct {
@@ -274,8 +269,4 @@ func (c *VictionConfig) GetVictionBypassBalance(blockNum uint64, addr common.Add
 		}
 	}
 	return nil
-}
-
-func (c *VictionConfig) GetValidatorOwnerSlot(candidate common.Address) common.Hash {
-	return crypto.Keccak256Hash(candidate.Hash().Bytes(), common.BigToHash(ValidatorsStateSlot).Bytes())
 }


### PR DESCRIPTION
This pull request introduces a new mechanism for distributing transaction fees in the Viction protocol, primarily by routing fees to validator owners after a specific fork, and by refactoring the fee application logic. The changes also include a utility for computing the validator owner storage slot.

**Transaction Fee Distribution Logic:**

* Added the `applyTransactionFee` method to `StateTransition`, which routes transaction fees to the validator owner (retrieved from on-chain storage) after the TIPTRC21Fee fork, or to the block coinbase otherwise. For VRC25-sponsored transactions after the Atlas fork, the fee is recalculated using the VRC25 gas price.
* Updated `TransitionDb` to use the new `applyTransactionFee` method instead of directly crediting the coinbase, ensuring the new fee distribution logic is applied.

**Utilities and Supporting Changes:**

* Added `GetValidatorOwnerSlot` to compute the storage slot for a validator's owner in the validator contract, used by the new fee distribution logic.
* Imported the `crypto` package to support Keccak256 hashing for storage slot computation.

**`applyTransactionFee` logic :** 

***1. Initial Calculation:***
- Computes `txFee = gasUsed * gasPrice` as the baseline.
- Standard Behavior: If `victionCfg` is nil (Non-Viction chain), it maintains the default Ethereum logic by paying the Coinbase.

***2. Atlas Fork Handling (VRC25 Sponsored Gas):***
- If *Atlas HF* is active and the transaction is *VRC25-sponsored*:
- It re-derives the `txFee` using `VRC25GasPrice`. This ensures the fee collected from the sponsor matches the fee distributed to the network.

***3. Recipient Routing (Post-TIPTRC21Fee):***
- Pre-TIPTRC21Fee: Fees are sent directly to the Coinbase.
- Post-TIPTRC21Fee: The recipient is shifted from the node operator to the Validator Owner.
- It looks up the `owner` address from the `ValidatorContract` state using the Coinbase's specific slot. If an owner is found, the balance is added to the Owner instead of the Coinbase.
