### PR TITLE
 streamline VRC25 fee handling and refund logic in state transitions

### DIFF
--- a/core/state_processor_viction.go
+++ b/core/state_processor_viction.go
@@ -7,7 +7,6 @@ import (
 	"runtime"
 	"sync"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/misc"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -17,22 +16,14 @@ import (
 
 type victionProcessorState struct {
 	currentBlockNumber *big.Int
-	parrentState       *state.StateDB
-	balanceFee         map[common.Address]*big.Int
-	balanceUpdated     map[common.Address]*big.Int
-	totalFeeUsed       *big.Int
 }
 
 func (p *StateProcessor) beforeProcess(block *types.Block, statedb *state.StateDB) error {
 	header := block.Header()
 
-	// Initialize victionState
+	// Initialize victionState for this block.
 	p.victionState = &victionProcessorState{
 		currentBlockNumber: new(big.Int).Set(header.Number),
-		balanceFee:         make(map[common.Address]*big.Int),
-		balanceUpdated:     make(map[common.Address]*big.Int),
-		totalFeeUsed:       big.NewInt(0),
-		parrentState:       statedb.Copy(),
 	}
 
 	if p.config.TIPSigningBlock != nil && p.config.TIPSigningBlock.Cmp(header.Number) == 0 {
@@ -52,9 +43,6 @@ func (p *StateProcessor) beforeProcess(block *types.Block, statedb *state.StateD
 }
 
 func (p *StateProcessor) afterProcess(block *types.Block, statedb *state.StateDB) error {
-	if !p.config.IsAtlas(block.Number()) {
-		vrc25.UpdateFeeCapacity(statedb, p.config.Viction.VRC25Contract, p.victionState.balanceUpdated, p.victionState.totalFeeUsed)
-	}
 	return nil
 }
 
@@ -145,35 +133,16 @@ func (p *StateProcessor) afterApplyTransaction(tx *types.Transaction, msg types.
 	}
 
 	blockNum := p.victionState.currentBlockNumber
-	isAtlas := p.config.IsAtlas(blockNum)
 
-	// VRC25 / TRC21 Fee Logic
-	if !isAtlas && tx.To() != nil {
-		if p.config.IsTIPTRC21Fee(blockNum) {
-			fee := new(big.Int).SetUint64(usedGas)
-			if p.config.Viction.TRC21GasPrice != nil {
-				price := (*big.Int)(p.config.Viction.TRC21GasPrice)
-				fee = fee.Mul(fee, price)
-			}
+	// For failed VRC25-sponsored transactions the EVM reverts so no token transfer
+	// executes. Charge a minimum token fee to prevent free failed-tx abuse.
+	if !p.config.IsAtlas(blockNum) && tx.To() != nil &&
+		p.config.IsTIPTRC21Fee(blockNum) &&
+		receipt.Status == types.ReceiptStatusFailed {
 
-			balanceFee := vrc25.GetFeeCapacity(statedb, p.config.Viction.VRC25Contract, tx.To())
-
-			if receipt.Status == types.ReceiptStatusFailed {
-				if balanceFee != nil && balanceFee.Cmp(fee) > 0 {
-					vrc25.PayFeeWithVRC25(statedb, msg.From(), *tx.To())
-				}
-			}
-
-			if balanceFee != nil && balanceFee.Cmp(fee) >= 0 {
-				currentVal, ok := p.victionState.balanceFee[*tx.To()]
-				if !ok {
-					currentVal = balanceFee
-				}
-				newVal := new(big.Int).Sub(currentVal, fee)
-				p.victionState.balanceFee[*tx.To()] = newVal
-				p.victionState.balanceUpdated[*tx.To()] = newVal
-				p.victionState.totalFeeUsed = new(big.Int).Add(p.victionState.totalFeeUsed, fee)
-			}
+		feeCap := vrc25.GetFeeCapacity(statedb, p.config.Viction.VRC25Contract, tx.To())
+		if feeCap != nil && feeCap.Sign() > 0 {
+			vrc25.PayFeeWithVRC25(statedb, msg.From(), *tx.To())
 		}
 	}
 	return nil

--- a/core/state_transition_viction.go
+++ b/core/state_transition_viction.go
@@ -49,19 +49,23 @@ func (st *StateTransition) isVRC25Transaction() bool {
 	return st.payer != st.msg.From()
 }
 
+// vrc25RefundGas is called for VRC25-sponsored transactions and all Atlas-block transactions.
+// For sponsored transactions it also restores the unused portion to the fee capacity storage slot.
+// For non-sponsored Atlas transactions it only returns native ETH to the sender.
 func (st *StateTransition) vrc25RefundGas(remaining *big.Int) {
-	addr := st.msg.To()
-	// Get current balance
-	feeCap := vrc25.GetFeeCapacity(st.state, st.evm.ChainConfig().Viction.VRC25Contract, addr)
-	if feeCap == nil {
-		// Should not happen if isSponsoringTransaction is true, but handle safely
-		return
+	if st.isVRC25Transaction() {
+		addr := st.msg.To()
+		vrc25Contract := st.evm.ChainConfig().Viction.VRC25Contract
+		feeCap := vrc25.GetFeeCapacity(st.state, vrc25Contract, addr)
+		if feeCap != nil { // always non-nil for non-nil addr; guard defensively
+			newFeeCap := new(big.Int).Add(feeCap, remaining)
+			feeCapKey := state.GetStorageKeyForMapping(addr.Hash(), slotTokensState)
+			st.state.SetState(vrc25Contract, feeCapKey, common.BigToHash(newFeeCap))
+		}
 	}
 
-	// Refund to Contract's Storage Balance
-	newFeeCap := new(big.Int).Add(feeCap, remaining)
-	feeCapKey := state.GetStorageKeyForMapping(addr.Hash(), slotTokensState)
-	st.state.SetState(st.evm.ChainConfig().Viction.VRC25Contract, feeCapKey, common.BigToHash(newFeeCap))
+	// Return native ETH to the payer (VRC25Contract for sponsored txs, sender otherwise).
+	st.state.AddBalance(st.payer, remaining)
 }
 
 // applyTransactionFee distributes the transaction fee to the correct recipient.


### PR DESCRIPTION
This pull request refactors the VRC25 fee logic in the state processor and state transition modules. The changes simplify the handling of fee capacity and token fee deduction for failed transactions, remove unused fields and logic, and clarify the refund process for VRC25-sponsored and Atlas-block transactions.

Fee logic simplification and cleanup:

* Removed the `balanceFee`, `balanceUpdated`, `totalFeeUsed`, and `parrentState` fields from the `victionProcessorState` struct, along with their initialization and usage, to simplify state tracking during block processing.
* Deleted the logic in `afterProcess` that updated fee capacity and balances for non-Atlas blocks, as this is now handled elsewhere or is no longer needed.
* Refactored the VRC25 fee deduction logic in `afterApplyTransaction` to only charge a minimum token fee for failed VRC25-sponsored transactions, preventing free failed transaction abuse. The previous logic for updating fee capacity and tracking balances was removed.

VRC25 refund logic clarification:

* Improved the `vrc25RefundGas` method to clearly distinguish between sponsored and non-sponsored transactions, ensuring unused gas is properly refunded to both the fee capacity storage slot and the sender's native ETH balance, depending on transaction type.

Dependency cleanup:

* Removed the unused import of `github.com/ethereum/go-ethereum/common` from `core/state_processor_viction.go`.