### PR TITLE
refactor: update storage location retrieval methods

### DIFF
--- a/core/state/storage_location.go
+++ b/core/state/storage_location.go
@@ -54,28 +54,9 @@ func StorageLocationOfFixedArrayElement(arraySlot StorageLocation, elementIndex 
 	return StorageLocation(new(big.Int).Add(arraySlot.Big(), offset).Bytes())
 }
 
-func GetValidatorOwnerSlot(candidate common.Address) common.Hash {
-	validatorMappingSlot := vicValidatorStorageMap["validatorsState"]
-	return crypto.Keccak256Hash(candidate.Hash().Bytes(), common.BigToHash(big.NewInt(int64(validatorMappingSlot))).Bytes())
-}
-
-func GetStorageKeyForSlot(slot uint64) common.Hash {
-	slotHash := common.BigToHash(new(big.Int).SetUint64(slot))
-	return slotHash
-}
-
-func GetStorageKeyForMapping(key common.Hash, slot uint64) common.Hash {
-	slotHash := common.BigToHash(new(big.Int).SetUint64(slot))
-	retByte := crypto.Keccak256(key.Bytes(), slotHash.Bytes())
-	ret := new(big.Int)
-	ret.SetBytes(retByte)
-	return common.BigToHash(ret)
-}
-
-// GetLocDynamicArrAtElement is used to get the location of element inside dynamic array
-func GetLocDynamicArrAtElement(slotHash common.Hash, index uint64, elementSize uint64) common.Hash {
-	slotKecBig := crypto.Keccak256Hash(slotHash.Bytes()).Big()
-	// arrBig = slotKecBig + index * elementSize
-	arrBig := slotKecBig.Add(slotKecBig, new(big.Int).SetUint64(index*elementSize))
-	return common.BigToHash(arrBig)
+func StorageLocationOfValidatorOwner(candidate common.Address) common.Hash {
+	slot := vicValidatorStorageMap["validatorsState"] // uint64 slot index
+	mappingSlot := StorageLocationFromSlot(slot)      // 32‑byte slot
+	loc := StorageLocationOfMappingElement(mappingSlot, candidate.Hash().Bytes())
+	return loc.Hash() // common.Hash to use with GetState
 }

--- a/core/state_transition_viction.go
+++ b/core/state_transition_viction.go
@@ -34,8 +34,8 @@ func (st *StateTransition) vrc25BuyGas() error {
 	// 4. Deduct from Contract's Storage Balance
 	// Note: The native ETH deduction happens in state_transition.go via st.state.SubBalance(st.payer)
 	newFeeCap := new(big.Int).Sub(feeCap, vrc25GasFee)
-	feeCapKey := state.GetStorageKeyForMapping(st.msg.To().Hash(), slotTokensState)
-	st.state.SetState(victionConfig.VRC25Contract, feeCapKey, common.BigToHash(newFeeCap))
+	feeCapKey := state.StorageLocationOfMappingElement(state.StorageLocationFromSlot(slotTokensState), st.msg.To().Hash().Bytes())
+	st.state.SetState(victionConfig.VRC25Contract, feeCapKey.Hash(), common.BigToHash(newFeeCap))
 
 	// 5. Set Payer to System Contract
 	// This ensures buyGas() deducts native ETH from the system contract
@@ -59,8 +59,8 @@ func (st *StateTransition) vrc25RefundGas(remaining *big.Int) {
 		feeCap := vrc25.GetFeeCapacity(st.state, vrc25Contract, addr)
 		if feeCap != nil { // always non-nil for non-nil addr; guard defensively
 			newFeeCap := new(big.Int).Add(feeCap, remaining)
-			feeCapKey := state.GetStorageKeyForMapping(addr.Hash(), slotTokensState)
-			st.state.SetState(vrc25Contract, feeCapKey, common.BigToHash(newFeeCap))
+			feeCapKey := state.StorageLocationOfMappingElement(state.StorageLocationFromSlot(slotTokensState), addr.Hash().Bytes())
+			st.state.SetState(vrc25Contract, feeCapKey.Hash(), common.BigToHash(newFeeCap))
 		}
 	}
 
@@ -105,7 +105,7 @@ func (st *StateTransition) applyTransactionFee() {
 	}
 
 	// After TIPTRC21Fee fork: route fee to the registered owner of the validator.
-	slot := state.GetValidatorOwnerSlot(st.evm.Context.Coinbase)
+	slot := state.StorageLocationOfValidatorOwner(st.evm.Context.Coinbase)
 	ownerHash := st.state.GetState(victionCfg.ValidatorContract, slot)
 	owner := common.BytesToAddress(ownerHash.Bytes())
 	if owner != (common.Address{}) {

--- a/core/vrc25/vrc25.go
+++ b/core/vrc25/vrc25.go
@@ -37,9 +37,10 @@ func PayFeeWithVRC25(statedb vm.StateDB, from common.Address, token common.Addre
 		return ErrInvalidParams
 	}
 	// 2. Retrieve the balance of the from address for the VRC25 token
-	slotBalances := SlotVRC25Token["balances"]
-	balanceKey := state.GetStorageKeyForMapping(from.Hash(), slotBalances)
-	balanceHash := statedb.GetState(token, balanceKey)
+	slotBalances := SlotVRC25Token["balances"]                 // uint64 slot index
+	balanceSlot := state.StorageLocationFromSlot(slotBalances) // StorageLocation (32-byte slot)
+	balanceKey := state.StorageLocationOfMappingElement(balanceSlot, from.Hash().Bytes())
+	balanceHash := statedb.GetState(token, balanceKey.Hash())
 
 	if balanceHash != (common.Hash{}) {
 		// 3. Check if balance is positive
@@ -48,16 +49,16 @@ func PayFeeWithVRC25(statedb vm.StateDB, from common.Address, token common.Addre
 			return nil
 		}
 		// 4. Retrieve the issuer address of the token
-		issuerKey := state.GetStorageKeyForSlot(SlotVRC25Token["issuer"])
-		issuerHash := statedb.GetState(token, issuerKey)
+		issuerKey := state.StorageLocationFromSlot(SlotVRC25Token["issuer"])
+		issuerHash := statedb.GetState(token, issuerKey.Hash())
 		if issuerHash == (common.Hash{}) {
 			return nil
 		}
 		issuerAddr := common.BytesToAddress(issuerHash.Bytes())
 
 		// 5. Retrieve the minimum fee required by the token
-		minFeeKey := state.GetStorageKeyForSlot(SlotVRC25Token["minFee"])
-		minFeeHash := statedb.GetState(token, minFeeKey)
+		minFeeKey := state.StorageLocationFromSlot(SlotVRC25Token["minFee"])
+		minFeeHash := statedb.GetState(token, minFeeKey.Hash())
 		minFee := minFeeHash.Big()
 
 		// 6. Determine the actual fee to charge (lesser of balance or minFee)
@@ -68,14 +69,14 @@ func PayFeeWithVRC25(statedb vm.StateDB, from common.Address, token common.Addre
 
 		// 7. Deduct the fee from the user's balance and update state
 		newBalance := new(big.Int).Sub(balance, feeUsed)
-		statedb.SetState(token, balanceKey, common.BigToHash(newBalance))
+		statedb.SetState(token, balanceKey.Hash(), common.BigToHash(newBalance))
 
 		// 8. Add the fee to the issuer's balance and update state
-		issuerBalanceKey := state.GetStorageKeyForMapping(issuerAddr.Hash(), slotBalances)
-		issuerBalanceHash := statedb.GetState(token, issuerBalanceKey)
+		issuerBalanceKey := state.StorageLocationOfMappingElement(balanceSlot, issuerAddr.Hash().Bytes())
+		issuerBalanceHash := statedb.GetState(token, issuerBalanceKey.Hash())
 		issuerBalance := issuerBalanceHash.Big()
 		newIssuerBalance := new(big.Int).Add(issuerBalance, feeUsed)
-		statedb.SetState(token, issuerBalanceKey, common.BigToHash(newIssuerBalance))
+		statedb.SetState(token, issuerBalanceKey.Hash(), common.BigToHash(newIssuerBalance))
 	}
 	return nil
 }
@@ -88,8 +89,8 @@ func UpdateFeeCapacity(statedb vm.StateDB, vrc25Contract common.Address, newBala
 	}
 	slotTokensState := SlotVRC25Contract["tokensState"]
 	for token, value := range newBalance {
-		balanceKey := state.GetStorageKeyForMapping(token.Hash(), slotTokensState)
-		statedb.SetState(vrc25Contract, balanceKey, common.BigToHash(value))
+		balanceKey := state.StorageLocationOfMappingElement(state.StorageLocationFromSlot(slotTokensState), token.Hash().Bytes())
+		statedb.SetState(vrc25Contract, balanceKey.Hash(), common.BigToHash(value))
 	}
 	statedb.SubBalance(vrc25Contract, totalFeeUsed)
 }
@@ -99,8 +100,8 @@ func GetFeeCapacity(statedb vm.StateDB, vrc25Contract common.Address, addr *comm
 	if addr == nil {
 		return nil
 	}
-	feeCapKey := state.GetStorageKeyForMapping(addr.Hash(), SlotVRC25Contract["tokensState"])
-	feeCapHash := statedb.GetState(vrc25Contract, feeCapKey)
+	feeCapKey := state.StorageLocationOfMappingElement(state.StorageLocationFromSlot(SlotVRC25Contract["tokensState"]), addr.Hash().Bytes())
+	feeCapHash := statedb.GetState(vrc25Contract, feeCapKey.Hash())
 	return feeCapHash.Big()
 }
 
@@ -112,11 +113,11 @@ func ValidateVRC25Transaction(statedb vm.StateDB, vrc25Contract common.Address, 
 	}
 
 	slotBalances := SlotVRC25Token["balances"]
-	balanceKey := state.GetStorageKeyForMapping(from.Hash(), slotBalances)
-	balanceHash := statedb.GetState(to, balanceKey)
+	balanceKey := state.StorageLocationOfMappingElement(state.StorageLocationFromSlot(slotBalances), from.Hash().Bytes())
+	balanceHash := statedb.GetState(to, balanceKey.Hash())
 	minFeeSlot := SlotVRC25Token["minFee"]
-	minFeeKey := state.GetStorageKeyForSlot(minFeeSlot)
-	minFeeHash := statedb.GetState(to, minFeeKey)
+	minFeeKey := state.StorageLocationFromSlot(minFeeSlot)
+	minFeeHash := statedb.GetState(to, minFeeKey.Hash())
 
 	if balanceHash == (common.Hash{}) {
 		if minFeeHash != (common.Hash{}) {

--- a/legacy/tomox/tradingstate/relayer_state.go
+++ b/legacy/tomox/tradingstate/relayer_state.go
@@ -60,8 +60,8 @@ func GetBaseTokenAtIndex(relayer common.Address, statedb *state.StateDB, index u
 	locBig := GetLocMappingAtKey(relayer.Hash(), slot)
 	locBig = new(big.Int).Add(locBig, RelayerStructMappingSlot["_fromTokens"])
 	locHash := common.BigToHash(locBig)
-	loc := state.GetLocDynamicArrAtElement(locHash, index, 1)
-	return common.BytesToAddress(statedb.GetState(common.HexToAddress(RelayerRegistrationSMC), loc).Bytes())
+	loc := state.StorageLocationOfDynamicArrayElement(state.StorageLocationFromHash(locHash), index, 1)
+	return common.BytesToAddress(statedb.GetState(common.HexToAddress(RelayerRegistrationSMC), loc.Hash()).Bytes())
 }
 
 func GetQuoteTokenLength(relayer common.Address, statedb *state.StateDB) uint64 {
@@ -77,8 +77,8 @@ func GetQuoteTokenAtIndex(relayer common.Address, statedb *state.StateDB, index 
 	locBig := GetLocMappingAtKey(relayer.Hash(), slot)
 	locBig = new(big.Int).Add(locBig, RelayerStructMappingSlot["_toTokens"])
 	locHash := common.BigToHash(locBig)
-	loc := state.GetLocDynamicArrAtElement(locHash, index, 1)
-	return common.BytesToAddress(statedb.GetState(common.HexToAddress(RelayerRegistrationSMC), loc).Bytes())
+	loc := state.StorageLocationOfDynamicArrayElement(state.StorageLocationFromHash(locHash), index, 1)
+	return common.BytesToAddress(statedb.GetState(common.HexToAddress(RelayerRegistrationSMC), loc.Hash()).Bytes())
 }
 
 func GetRelayerCount(statedb *state.StateDB) uint64 {
@@ -114,12 +114,12 @@ func GetAllTradingPairs(statedb *state.StateDB) (map[common.Hash]bool, error) {
 		fromTokens := []common.Address{}
 		fromTokenSlotHash := common.BytesToHash(fromTokenSlot.Bytes())
 		for i := uint64(0); i < fromTokenLength; i++ {
-			fromToken := common.BytesToAddress(statedb.GetState(common.HexToAddress(RelayerRegistrationSMC), state.GetLocDynamicArrAtElement(fromTokenSlotHash, i, uint64(1))).Bytes())
+			fromToken := common.BytesToAddress(statedb.GetState(common.HexToAddress(RelayerRegistrationSMC), state.StorageLocationOfDynamicArrayElement(state.StorageLocationFromHash(fromTokenSlotHash), i, uint64(1)).Hash()).Bytes())
 			fromTokens = append(fromTokens, fromToken)
 		}
 		toTokenSlotHash := common.BytesToHash(toTokenSlot.Bytes())
 		for i := uint64(0); i < toTokenLength; i++ {
-			toToken := common.BytesToAddress(statedb.GetState(common.HexToAddress(RelayerRegistrationSMC), state.GetLocDynamicArrAtElement(toTokenSlotHash, i, uint64(1))).Bytes())
+			toToken := common.BytesToAddress(statedb.GetState(common.HexToAddress(RelayerRegistrationSMC), state.StorageLocationOfDynamicArrayElement(state.StorageLocationFromHash(toTokenSlotHash), i, uint64(1)).Hash()).Bytes())
 
 			log.Debug("GetAllTradingPairs all pair info", "from", fromTokens[i].Hex(), "toToken", toToken.Hex())
 			allPairs[GetTradingOrderBookHash(fromTokens[i], toToken)] = true


### PR DESCRIPTION
This pull request refactors and unifies the way storage locations are computed and accessed throughout the codebase, especially for mappings and dynamic arrays in smart contract state. The changes replace multiple ad-hoc helper functions with a consistent set of `StorageLocation*` methods, improving code clarity, maintainability, and reducing the risk of subtle bugs related to storage key calculation.

Key improvements and refactorings include:

**Storage Location Calculation Refactoring:**

* Replaced `GetStorageKeyForMapping`, `GetStorageKeyForSlot`, and `GetLocDynamicArrAtElement` with new unified methods: `StorageLocationFromSlot`, `StorageLocationOfMappingElement`, and `StorageLocationOfDynamicArrayElement`. These methods encapsulate the logic for calculating storage locations for mappings and dynamic arrays, leading to more readable and less error-prone code.

* Introduced `StorageLocationOfValidatorOwner` to replace `GetValidatorOwnerSlot`, providing a clearer and more consistent interface for retrieving the storage slot of a validator's owner.

**State Transition and Fee Handling Updates:**

* Updated all usages in `core/state_transition_viction.go` and `core/vrc25/vrc25.go` to use the new storage location methods for handling VRC25 token balances, fee capacities, and validator owner lookups. This ensures that state reads and writes are performed using the new, safer abstractions. 

**Legacy Trading State Updates:**

* Refactored legacy trading state functions to use the new dynamic array storage location helpers, ensuring consistency even in older code paths. 

Overall, these changes modernize and standardize the codebase's approach to Ethereum-compatible storage access, reducing technical debt and making future maintenance easier.

---

**Most Important Changes:**

**Storage Location Refactoring:**
- Unified storage key calculation by introducing `StorageLocationFromSlot`, `StorageLocationOfMappingElement`, and `StorageLocationOfDynamicArrayElement`, and removed legacy helpers like `GetStorageKeyForMapping` and `GetLocDynamicArrAtElement`.
- Added `StorageLocationOfValidatorOwner` to replace `GetValidatorOwnerSlot` for validator owner lookups.

**Fee and State Transition Logic:**
- Refactored all VRC25 fee and balance logic to use the new storage location methods, ensuring consistent and correct state access.
- Updated validator fee routing to use the new storage location abstraction.

**Legacy Trading State Consistency:**
- Updated legacy trading state functions to use the new dynamic array storage helpers, ensuring uniformity across the codebase and clarity