### PR TITLE
Fix wrong state for reading voters cap & signing txs counted

### DIFF
--- a/eth/backend_viction.go
+++ b/eth/backend_viction.go
@@ -37,12 +37,35 @@ func (s *Ethereum) PosvGetBlockSignData(config *params.ChainConfig, vicConfig *p
 ) []types.Transaction {
 	blockNumber := header.Number
 	block := chain.GetBlock(header.Hash(), blockNumber.Uint64())
+	if block == nil {
+		return []types.Transaction{}
+	}
 	data := []types.Transaction{}
-	transactions := block.Transactions()
-	for _, tx := range transactions {
-		if tx.IsSigningTransaction(vicConfig.ValidatorBlockSignContract) {
-			data = append(data, *tx)
+
+	// Before TIPSigning, block-sign txs are EVM-executed and may fail. Only
+	// successful signing txs count toward rewards and penalties.
+	var receipts types.Receipts
+	if !config.IsTIPSigning(blockNumber) {
+		receipts = s.blockchain.GetReceiptsByHash(header.Hash())
+	}
+
+	for i, tx := range block.Transactions() {
+		if !tx.IsSigningTransaction(vicConfig.ValidatorBlockSignContract) {
+			continue
 		}
+		if receipts != nil && i < len(receipts) {
+			r := receipts[i]
+			var status uint64
+			if len(r.PostState) > 0 {
+				status = types.ReceiptStatusSuccessful
+			} else {
+				status = r.Status
+			}
+			if status == types.ReceiptStatusFailed {
+				continue
+			}
+		}
+		data = append(data, *tx)
 	}
 	return data
 }

--- a/eth/backend_viction.go
+++ b/eth/backend_viction.go
@@ -108,7 +108,20 @@ func (s *Ethereum) PosvGetEpochReward(c *posv.Posv, config *params.ChainConfig, 
 	}
 	epochRewards.ValidatorRewards = validatorRewards
 
-	stakeholderRewards, err := viction.CalcRewardsForStakeholders(c, config, posvConfig, vicConfig, header, validatorRewards, statedb, logger)
+	// Use pre-transaction state for voter caps
+	parentHeader := chain.GetHeader(header.ParentHash, blockNumber-1)
+	var rewardState *state.StateDB
+	if parentHeader != nil {
+		rewardState, err = s.BlockChain().StateAt(parentHeader.Root)
+		if err != nil {
+			logger.Warn("PosvGetEpochReward: failed to get parent state, falling back to current state", "block", blockNumber, "err", err)
+			rewardState = statedb
+		}
+	} else {
+		rewardState = statedb
+	}
+
+	stakeholderRewards, err := viction.CalcRewardsForStakeholders(c, config, posvConfig, vicConfig, header, validatorRewards, rewardState, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/eth/viction/reward.go
+++ b/eth/viction/reward.go
@@ -61,21 +61,15 @@ func CalcRewardsForValidators(
 		}
 		blockHashes[i] = h.Hash()
 
-		block := chain.GetBlock(h.Hash(), i)
-		if block == nil {
-			continue
-		}
-		blockSignAddr := vicConfig.ValidatorBlockSignContract
-		for _, tx := range block.Transactions() {
-			if !tx.IsSigningTransaction(blockSignAddr) {
-				continue
-			}
+		// Use GetSignDataForBlock so that pre-TIPSigning blocks are filtered by receipt status
+		txs := c.GetSignDataForBlock(config, vicConfig, h, chain)
+		signer := types.MakeSigner(config, h.Number)
+		for _, tx := range txs {
 			txData := tx.Data()
 			if len(txData) < common.HashLength {
 				continue
 			}
 			signedBlockHash := common.BytesToHash(txData[len(txData)-common.HashLength:])
-			signer := types.MakeSigner(config, h.Number)
 			msg, err := tx.AsMessage(signer)
 			if err != nil {
 				logger.Debug("CalcRewardsForValidators: failed to get sender", "txHash", tx.Hash().Hex(), "err", err)


### PR DESCRIPTION
This pull request introduces important changes to the block signing and reward calculation logic in the Viction consensus backend. The updates ensure that only successful signing transactions are considered for validator rewards, and that stakeholder rewards are calculated using the correct pre-transaction state for voter caps. These improvements enhance the accuracy and reliability of reward distribution in the protocol.

Block signing and reward logic improvements:

* Updated `PosvGetBlockSignData` in `eth/backend_viction.go` to filter out failed signing transactions before TIPSigning, using transaction receipts to ensure only successful signing transactions are counted for rewards and penalties.
* Modified `CalcRewardsForValidators` in `eth/viction/reward.go` to use `GetSignDataForBlock`, which applies the new filtering logic for signing transactions, ensuring consistency and correctness in reward calculation.

Stakeholder reward calculation accuracy:

* Changed `PosvGetEpochReward` in `eth/backend_viction.go` to use the pre-transaction state from the parent block for voter caps, improving the accuracy of stakeholder reward calculations and handling fallback to current state if parent state retrieval fails.