### PR TITLE
fix: backend viction error handling

### DIFF
--- a/consensus/posv/posv_extend.go
+++ b/consensus/posv/posv_extend.go
@@ -59,7 +59,7 @@ type PosvBackend interface {
 	PosvGetAttestors(vicConfig *params.VictionConfig, header *types.Header, validators []common.Address) ([]int64, error)
 
 	// Get block signers from the state.
-	PosvGetBlockSignData(config *params.ChainConfig, vicConfig *params.VictionConfig, header *types.Header, chain consensus.ChainReader) []types.Transaction
+	PosvGetBlockSignData(config *params.ChainConfig, vicConfig *params.VictionConfig, header *types.Header, chain consensus.ChainReader) ([]types.Transaction, error)
 
 	// Get creator-attestor pairs from the state.
 	PosvGetCreatorAttestorPairs(c *Posv, config *params.ChainConfig, header, checkpointHeader *types.Header) (map[common.Address]common.Address, uint64, error)
@@ -177,12 +177,20 @@ func DecodeAttestorsFromHeader(attestorsBuff []byte) []int64 {
 
 // Get all BlockSign transactions for a given block. If it's not cached yet, get it from the state.
 func (c *Posv) GetSignDataForBlock(config *params.ChainConfig, vicConfig *params.VictionConfig, header *types.Header,
-	chain consensus.ChainReader) []types.Transaction {
+	chain consensus.ChainReader) ([]types.Transaction, error) {
+	if header == nil {
+		return nil, fmt.Errorf("GetSignDataForBlock: header is nil")
+	}
 	blockHash := header.Hash()
 	if signers, ok := c.BlockSigners.Get(blockHash); ok {
-		return signers.([]types.Transaction)
+		if signers, ok := signers.([]types.Transaction); ok && signers != nil {
+			return signers, nil
+		}
 	}
-	signers := c.backend.PosvGetBlockSignData(config, vicConfig, header, chain)
+	signers, err := c.backend.PosvGetBlockSignData(config, vicConfig, header, chain)
+	if err != nil {
+		return nil, err
+	}
 	c.BlockSigners.Add(blockHash, signers)
-	return signers
+	return signers, nil
 }

--- a/eth/backend_viction.go
+++ b/eth/backend_viction.go
@@ -34,11 +34,15 @@ func (s *Ethereum) PosvGetAttestors(vicConfig *params.VictionConfig, header *typ
 // Get block signers from the state.
 func (s *Ethereum) PosvGetBlockSignData(config *params.ChainConfig, vicConfig *params.VictionConfig, header *types.Header,
 	chain consensus.ChainReader,
-) []types.Transaction {
+) ([]types.Transaction, error) {
+	if header == nil {
+		return nil, fmt.Errorf("PosvGetBlockSignData: header is nil")
+	}
+	blockHash := header.Hash()
 	blockNumber := header.Number
-	block := chain.GetBlock(header.Hash(), blockNumber.Uint64())
+	block := chain.GetBlock(blockHash, blockNumber.Uint64())
 	if block == nil {
-		return []types.Transaction{}
+		return nil, fmt.Errorf("PosvGetBlockSignData: block body not found (number=%d hash=%s)", blockNumber, blockHash)
 	}
 	data := []types.Transaction{}
 
@@ -46,10 +50,17 @@ func (s *Ethereum) PosvGetBlockSignData(config *params.ChainConfig, vicConfig *p
 	// successful signing txs count toward rewards and penalties.
 	var receipts types.Receipts
 	if !config.IsTIPSigning(blockNumber) {
-		receipts = s.blockchain.GetReceiptsByHash(header.Hash())
+		receipts = s.blockchain.GetReceiptsByHash(blockHash)
+	}
+	txs := block.Transactions()
+	if receipts != nil && len(receipts) != len(txs) {
+		return nil, fmt.Errorf(
+			"PosvGetBlockSignData: receipts/tx count mismatch (number=%d hash=%s txs=%d receipts=%d)",
+			blockNumber.Uint64(), blockHash, len(txs), len(receipts),
+		)
 	}
 
-	for i, tx := range block.Transactions() {
+	for i, tx := range txs {
 		if !tx.IsSigningTransaction(vicConfig.ValidatorBlockSignContract) {
 			continue
 		}
@@ -67,7 +78,7 @@ func (s *Ethereum) PosvGetBlockSignData(config *params.ChainConfig, vicConfig *p
 		}
 		data = append(data, *tx)
 	}
-	return data
+	return data, nil
 }
 
 // Get creator-attestor pairs from the state.
@@ -175,7 +186,7 @@ func (s *Ethereum) PosvGetPenalties(c *posv.Posv, config *params.ChainConfig, po
 func (s *Ethereum) PosvGetValidators(vicConfig *params.VictionConfig, header *types.Header, chain consensus.ChainReader,
 ) ([]common.Address, error) {
 	if header == nil {
-		return []common.Address{}, nil
+		return []common.Address{}, fmt.Errorf("header is nil")
 	}
 	// Guard against being called before eth.blockchain is assigned (e.g. during
 	// NewBlockChain's internal VerifyHeader when SetBackend was called too early).

--- a/eth/viction/penalty.go
+++ b/eth/viction/penalty.go
@@ -36,7 +36,10 @@ func PenalizeValidatorsDefault(c *posv.Posv, config *params.ChainConfig, posvCon
 			if len(validators) == 0 {
 				break
 			}
-			txs := c.GetSignDataForBlock(config, vicConfig, header, chain)
+			txs, err := c.GetSignDataForBlock(config, vicConfig, header, chain)
+			if err != nil {
+				return []common.Address{}, err
+			}
 			signer := types.MakeSigner(config, big.NewInt(int64(i)))
 			// Check for BlockSign of specific signer
 			for _, tx := range txs {
@@ -128,7 +131,10 @@ func PenalizeValidatorsTIPSigning(c *posv.Posv, config *params.ChainConfig, posv
 			if blockNumber%vicConfig.ValidatorSignInterval == 0 {
 				mapBlockHash[blockHash] = true
 			}
-			txs := c.GetSignDataForBlock(config, vicConfig, header, chain)
+			txs, err := c.GetSignDataForBlock(config, vicConfig, header, chain)
+			if err != nil {
+				return []common.Address{}, err
+			}
 			signer := types.MakeSigner(config, big.NewInt(int64(blockNumber)))
 			// Check for BlockSign of specific signer
 			for _, tx := range txs {

--- a/eth/viction/reward.go
+++ b/eth/viction/reward.go
@@ -62,7 +62,10 @@ func CalcRewardsForValidators(
 		blockHashes[i] = h.Hash()
 
 		// Use GetSignDataForBlock so that pre-TIPSigning blocks are filtered by receipt status
-		txs := c.GetSignDataForBlock(config, vicConfig, h, chain)
+		txs, err := c.GetSignDataForBlock(config, vicConfig, h, chain)
+		if err != nil {
+			return nil, err
+		}
 		signer := types.MakeSigner(config, h.Number)
 		for _, tx := range txs {
 			txData := tx.Data()


### PR DESCRIPTION
This pull request introduces improved error handling for retrieving block sign data and validator information in the PoSV consensus implementation. The changes ensure that functions return errors when invalid input is provided or when expected data is missing, leading to more robust and predictable behavior across consensus, penalty, and reward logic.
Closes/Fixes: #46 

### Error Handling Improvements

* Updated the `PosvGetBlockSignData` method in the `PosvBackend` interface and its implementation to return an error alongside the transaction slice, and added explicit checks for `nil` headers and block retrieval failures. 
* Modified `GetSignDataForBlock` in `posv_extend.go` to propagate errors from the backend and handle `nil` headers, returning errors instead of silently failing.

### Penalty and Reward Logic Updates

* Updated penalty calculation functions (`PenalizeValidatorsDefault` and `PenalizeValidatorsTIPSigning` in `penalty.go`) to handle errors from `GetSignDataForBlock`, ensuring early exit and error propagation when block sign data cannot be retrieved.
* Modified reward calculation in `CalcRewardsForValidators` to check for errors from `GetSignDataForBlock` and return early if an error occurs, preventing reward miscalculation due to missing or invalid block sign data.

### Validator Retrieval Improvements

* Updated `PosvGetValidators` to return an error if the header is `nil`, rather than returning an empty slice, improving input validation and error transparency.…rors and return types correctly