### PR TITLE
fix: penalty mismatch

### DIFF
--- a/eth/backend_viction.go
+++ b/eth/backend_viction.go
@@ -46,10 +46,13 @@ func (s *Ethereum) PosvGetBlockSignData(config *params.ChainConfig, vicConfig *p
 	}
 	data := []types.Transaction{}
 
-	// Before TIPSigning, block-sign txs are EVM-executed and may fail. Only
-	// successful signing txs count toward rewards and penalties.
+	// Before TIPSigning, block-sign txs are EVM-executed and may fail.
+	// Only successful signing txs count toward rewards and penalties.
+	//
+	// On post-Byzantium receipt format, `Receipt.Status` is the correct source
+	// of success/failure. Using `len(PostState)` is unreliable and can misclassify.
 	var receipts types.Receipts
-	if !config.IsTIPSigning(blockNumber) {
+	if config != nil && !config.IsTIPSigning(blockNumber) {
 		receipts = s.blockchain.GetReceiptsByHash(blockHash)
 	}
 	txs := block.Transactions()
@@ -66,13 +69,10 @@ func (s *Ethereum) PosvGetBlockSignData(config *params.ChainConfig, vicConfig *p
 		}
 		if receipts != nil && i < len(receipts) {
 			r := receipts[i]
-			var status uint64
-			if len(r.PostState) > 0 {
-				status = types.ReceiptStatusSuccessful
-			} else {
-				status = r.Status
+			if r == nil {
+				continue
 			}
-			if status == types.ReceiptStatusFailed {
+			if r.Status == types.ReceiptStatusFailed {
 				continue
 			}
 		}


### PR DESCRIPTION
This pull request improves the logic for determining successful block-signing transactions in the `PosvGetBlockSignData` function. The changes ensure more reliable classification of transaction success and handle edge cases more robustly.

Improvements to transaction success classification:

* Updated the comment to clarify that, for post-Byzantium receipt format, `Receipt.Status` is the correct indicator of success/failure, and using `len(PostState)` is unreliable.
* Changed the logic to use `Receipt.Status` directly for determining transaction success, and added a check to skip processing if the receipt is `nil`. This prevents misclassification and handles edge cases where receipts may be missing.

Robustness enhancements:

* Added a `nil` check for `config` before calling `IsTIPSigning`, ensuring the function does not panic if `config` is not provided.…fig and refining receipt status checks