### PR TITLE
Add explicit error for missing validator signatures and update seal verification logic

### DIFF
--- a/consensus/errors.go
+++ b/consensus/errors.go
@@ -35,7 +35,5 @@ var (
 	// plus one.
 	ErrInvalidNumber = errors.New("invalid block number")
 
-	ErrFailValidatorSignature = errors.New("invalid validator signature")
-
 	ErrNoValidatorSignature = errors.New("no validator in header")
 )

--- a/consensus/errors.go
+++ b/consensus/errors.go
@@ -36,4 +36,6 @@ var (
 	ErrInvalidNumber = errors.New("invalid block number")
 
 	ErrFailValidatorSignature = errors.New("invalid validator signature")
+
+	ErrNoValidatorSignature = errors.New("no validator in header")
 )

--- a/consensus/posv/verifier.go
+++ b/consensus/posv/verifier.go
@@ -351,7 +351,7 @@ func (c *Posv) verifySeal(chainH consensus.ChainHeaderReader, header *types.Head
 	}
 
 	// Enforce double validation
-	if number > c.config.Epoch {
+	if number > c.config.Epoch && seal {
 		attestor, err := c.Attestor(header)
 		if err != nil {
 			return err

--- a/consensus/posv/verifier.go
+++ b/consensus/posv/verifier.go
@@ -54,8 +54,8 @@ func (c *Posv) verifyHeader(chain consensus.ChainHeaderReader, header *types.Hea
 	nowUnix := now.Unix()
 
 	if seal {
-		if header.Number.Uint64() > c.config.Epoch && len(header.Attestor) != ExtraSeal {
-			return consensus.ErrFailValidatorSignature
+		if header.Number.Uint64() > c.config.Epoch && len(header.Attestor) == 0 {
+			return consensus.ErrNoValidatorSignature
 		}
 		// Don't waste time checking blocks from the future
 		if header.Time > uint64(nowUnix) {
@@ -350,8 +350,8 @@ func (c *Posv) verifySeal(chainH consensus.ChainHeaderReader, header *types.Head
 		}
 	}
 
-	// Enforce double validation
-	if number > c.config.Epoch && seal {
+	// Enforce double validation (POSV-encoded headers only)
+	if number > c.config.Epoch && seal && header.Posv {
 		attestor, err := c.Attestor(header)
 		if err != nil {
 			return err

--- a/consensus/posv/verifier.go
+++ b/consensus/posv/verifier.go
@@ -350,8 +350,8 @@ func (c *Posv) verifySeal(chainH consensus.ChainHeaderReader, header *types.Head
 		}
 	}
 
-	// Enforce double validation (POSV-encoded headers only)
-	if number > c.config.Epoch && seal && header.Posv {
+	// Enforce double validation
+	if number > c.config.Epoch {
 		attestor, err := c.Attestor(header)
 		if err != nil {
 			return err


### PR DESCRIPTION
This pull request introduces an explicit error for missing validator signatures in block headers, improving error handling and clarity in the consensus verification process.

Error handling improvements:

* Added a new error `ErrNoValidatorSignature` to `consensus/errors.go` to represent cases where no validator signature is present in a block header.
* Updated the header verification logic in `consensus/posv/verifier.go` to return the new `ErrNoValidatorSignature` error when a block header after the epoch has no validator signatures, instead of returning a generic invalid signature error.
* Updated logic in `verifyHeader` when `seal` == true to ensure proper handling of missing validator signatures.