### PR TITLE
Update PosvGetPenalties to accept a list of validators from snapshot

### DIFF
--- a/consensus/posv/posv.go
+++ b/consensus/posv/posv.go
@@ -388,7 +388,7 @@ func (c *Posv) Prepare(chainH consensus.ChainHeaderReader, header *types.Header)
 	if number%c.config.Epoch == 0 {
 		validators := snap.GetSigners()
 		// remove penalized validators in current epoch
-		penalties, err := c.backend.PosvGetPenalties(c, chain.Config(), c.config, chain.Config().Viction, header, chain)
+		penalties, err := c.backend.PosvGetPenalties(c, chain.Config(), c.config, chain.Config().Viction, header, chain, validators)
 		if err != nil {
 			return err
 		}

--- a/consensus/posv/posv_extend.go
+++ b/consensus/posv/posv_extend.go
@@ -72,7 +72,7 @@ type PosvBackend interface {
 	PosvDistributeEpochRewards(header *types.Header, state *state.StateDB, epochReward *EpochReward) error
 
 	// Penalize validators for creating bad block or not creating block at all.
-	PosvGetPenalties(c *Posv, config *params.ChainConfig, posvConfig *params.PosvConfig, vicConfig *params.VictionConfig, header *types.Header, chain consensus.ChainReader) ([]common.Address, error)
+	PosvGetPenalties(c *Posv, config *params.ChainConfig, posvConfig *params.PosvConfig, vicConfig *params.VictionConfig, header *types.Header, chain consensus.ChainReader, validators []common.Address) ([]common.Address, error)
 
 	// Get eligble validators from the state.
 	PosvGetValidators(vicConfig *params.VictionConfig, header *types.Header, chain consensus.ChainReader) ([]common.Address, error)

--- a/consensus/posv/verifier.go
+++ b/consensus/posv/verifier.go
@@ -201,7 +201,7 @@ func (c *Posv) verifyValidators(chain consensus.ChainReader, header *types.Heade
 	retryCount := 0
 	for retryCount < 2 {
 		// compare penalties computed from state with header.Penalties
-		penalties, err := c.backend.PosvGetPenalties(c, chain.Config(), c.config, chain.Config().Viction, header, chain)
+		penalties, err := c.backend.PosvGetPenalties(c, chain.Config(), c.config, chain.Config().Viction, header, chain, validators)
 		if err != nil {
 			return err
 		}

--- a/eth/backend_viction.go
+++ b/eth/backend_viction.go
@@ -178,9 +178,10 @@ func (s *Ethereum) PosvDistributeEpochRewards(header *types.Header, state *state
 func (s *Ethereum) PosvGetPenalties(c *posv.Posv, config *params.ChainConfig, posvConfig *params.PosvConfig, vicConfig *params.VictionConfig,
 	header *types.Header,
 	chain consensus.ChainReader,
+	validators []common.Address,
 ) ([]common.Address, error) {
 	if config.IsTIPSigning(header.Number) {
-		return viction.PenalizeValidatorsTIPSigning(c, config, posvConfig, vicConfig, header, chain)
+		return viction.PenalizeValidatorsTIPSigning(c, config, posvConfig, vicConfig, header, chain, validators)
 	}
 	return viction.PenalizeValidatorsDefault(s.BlockChain(), c, config, posvConfig, vicConfig, header, chain)
 }

--- a/eth/viction/penalty.go
+++ b/eth/viction/penalty.go
@@ -71,6 +71,7 @@ func PenalizeValidatorsDefault(bc *core.BlockChain, c *posv.Posv, config *params
 func PenalizeValidatorsTIPSigning(c *posv.Posv, config *params.ChainConfig, posvConfig *params.PosvConfig, vicConfig *params.VictionConfig,
 	header *types.Header,
 	chain consensus.ChainReader,
+	validators []common.Address,
 ) ([]common.Address, error) {
 	blockNumber := header.Number.Uint64()
 	prevCheckpointBlockNumber := blockNumber - posvConfig.Epoch
@@ -99,8 +100,8 @@ func PenalizeValidatorsTIPSigning(c *posv.Posv, config *params.ChainConfig, posv
 
 	// Penalize validators didn't create block or lower than required
 	prevCheckpointHeader := chain.GetHeaderByNumber(prevCheckpointBlockNumber)
-	validators := posv.ExtractValidatorsFromCheckpointHeader(prevCheckpointHeader)
-	for _, validator := range validators {
+	preValidators := posv.ExtractValidatorsFromCheckpointHeader(prevCheckpointHeader)
+	for _, validator := range preValidators {
 		if _, exist := blockMiningCounts[validator]; !exist {
 			penalties = append(penalties, validator)
 		}


### PR DESCRIPTION
This PR refactors penalty calculation in POSV by explicitly passing the validator set from the snapshot instead of retrieving it internally.

Motivation:
* Ensure penalties are computed against a well-defined validator set and prevent inconsistencies such as:
`invalid penalty list on checkpoint block` 