### PR TITLE
Fix/invalid penalty list on checkpoint block after tip signing

### DIFF
--- a/eth/viction/penalty.go
+++ b/eth/viction/penalty.go
@@ -132,9 +132,9 @@ func PenalizeValidatorsTIPSigning(c *posv.Posv, config *params.ChainConfig, posv
 	}
 
 	// If penalized validators has BlockSign recently, remove them from penalties
-	if len(comebacks) > 0 {
-		mapBlockHash := map[common.Hash]bool{}
-		for i := vicConfig.PenaltyComebackBlockCount - 1; i >= 0; i-- {
+	mapBlockHash := map[common.Hash]bool{}
+	for i := vicConfig.PenaltyComebackBlockCount - 1; i >= 0; i-- {
+		if len(penalties) > 0 {
 			blockNumber := header.Number.Uint64() - i - 1
 			header := chain.GetHeaderByNumber(blockNumber)
 			blockHash := epochBlockHashes[i]
@@ -162,6 +162,8 @@ func PenalizeValidatorsTIPSigning(c *posv.Posv, config *params.ChainConfig, posv
 					}
 				}
 			}
+		} else {
+			break
 		}
 	}
 

--- a/eth/viction/penalty.go
+++ b/eth/viction/penalty.go
@@ -133,9 +133,9 @@ func PenalizeValidatorsTIPSigning(c *posv.Posv, config *params.ChainConfig, posv
 
 	// If penalized validators has BlockSign recently, remove them from penalties
 	mapBlockHash := map[common.Hash]bool{}
-	for i := vicConfig.PenaltyComebackBlockCount - 1; i >= 0; i-- {
+	for i := int(vicConfig.PenaltyComebackBlockCount) - 1; i >= 0; i-- {
 		if len(comebacks) > 0 {
-			blockNumber := header.Number.Uint64() - i - 1
+			blockNumber := header.Number.Uint64() - uint64(i) - 1
 			header := chain.GetHeaderByNumber(blockNumber)
 			blockHash := epochBlockHashes[i]
 			if blockNumber%vicConfig.ValidatorSignInterval == 0 {

--- a/eth/viction/penalty.go
+++ b/eth/viction/penalty.go
@@ -134,7 +134,7 @@ func PenalizeValidatorsTIPSigning(c *posv.Posv, config *params.ChainConfig, posv
 	// If penalized validators has BlockSign recently, remove them from penalties
 	mapBlockHash := map[common.Hash]bool{}
 	for i := vicConfig.PenaltyComebackBlockCount - 1; i >= 0; i-- {
-		if len(penalties) > 0 {
+		if len(comebacks) > 0 {
 			blockNumber := header.Number.Uint64() - i - 1
 			header := chain.GetHeaderByNumber(blockNumber)
 			blockHash := epochBlockHashes[i]


### PR DESCRIPTION
* Issue: 
  - `runtime error: index out of range [18446744073709551615] with length 900`
* Changes: 
  - Updated iteration logic to check comebacks inside the loop
  - Cast `vicConfig.PenaltyComebackBlockCount` to  `int` to prevent infinity loop