### PR TITLE
refactor: adjust dirty-tracking logic in journal revert function to align with legacy behavior

### DIFF
--- a/core/state/journal.go
+++ b/core/state/journal.go
@@ -62,12 +62,23 @@ func (j *journal) revert(statedb *StateDB, snapshot int) {
 		// Undo the changes made by the operation
 		j.entries[i].revert(statedb)
 
+		
+		// Note: we've removed the dirty-tracking cleanup here to match the legacy
+		// victionchain behavior. In standard Geth, we would decrement the dirty
+		// counter and potentially remove the account from the dirty set. By keeping
+		// the account in the dirty set, we ensure that EIP-158's 'deleteEmptyObjects'
+		// logic in Finalise(true) will correctly process and delete accounts that
+		// were touched but reverted to empty (like the 0x01 precompile).
+		// TODO : enable dirty-tracking cleanup once we have a better understanding 
+		// of the implications and can ensure it doesn't interfere with Viction's 
+		// unique account handling.
+
 		// Drop any dirty tracking induced by the change
-		if addr := j.entries[i].dirtied(); addr != nil {
-			if j.dirties[*addr]--; j.dirties[*addr] == 0 {
-				delete(j.dirties, *addr)
-			}
-		}
+		// if addr := j.entries[i].dirtied(); addr != nil {
+		// 	if j.dirties[*addr]--; j.dirties[*addr] == 0 {
+		// 		delete(j.dirties, *addr)
+		// 	}
+		// }
 	}
 	j.entries = j.entries[:snapshot]
 }


### PR DESCRIPTION
This PR fix issue at block #6610865

  **Sumary** : In vic-geth, because 0x01 was removed from the dirty list during revert, the node never calls TryDelete. The empty leaf from Genesis remains in the trie, causing the root mismatch.
  
  
  **Note** : Already marked it with todo to enable it later ( mine stage ) to match Geth behavior .