### PR TITLE
legacy lending

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1884,6 +1884,13 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, er
 				}(time.Now(), followup, throwaway, &followupInterrupt)
 			}
 		}
+		// Viction pre-process hook: epoch-gated lending liquidations must run BEFORE
+		// bc.processor.Process() so that statedb mutations are visible to transactions.
+		if err := bc.beforeProcessViction(block, statedb); err != nil {
+			bc.reportBlock(block, nil, err)
+			atomic.StoreUint32(&followupInterrupt, 1)
+			return it.index, err
+		}
 		// Process block using the parent state as reference point
 		substart := time.Now()
 		receipts, logs, usedGas, err := bc.processor.Process(block, statedb, bc.vmConfig)

--- a/core/blockchain_viction.go
+++ b/core/blockchain_viction.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/posv"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/sortlgc"
 )
@@ -22,6 +24,63 @@ func (bc *BlockChain) SetTradingEngine(engine TradingEngine) {
 	}
 	sp.SetTradingEngine(engine)
 	log.Info("TomoX trading engine installed on state processor")
+}
+
+// SetLendingEngine injects the legacy TomoZ lending engine into the block processor.
+func (bc *BlockChain) SetLendingEngine(engine LendingEngine) {
+	sp, ok := bc.processor.(*StateProcessor)
+	if !ok {
+		log.Error("SetLendingEngine: processor is not a *StateProcessor, lending engine not installed")
+		return
+	}
+	sp.SetLendingEngine(engine)
+	log.Info("TomoZ lending engine installed on state processor")
+}
+
+// beforeProcessViction runs Viction-specific pre-processing before bc.processor.Process().
+// Currently handles TomoZ epoch-gated liquidation.
+// ORDERING: Must be called BEFORE bc.processor.Process() - liquidation mutations to statedb
+// must be visible to block transaction execution.
+func (bc *BlockChain) beforeProcessViction(block *types.Block, statedb *state.StateDB) error {
+	if bc.chainConfig.Posv == nil {
+		return nil
+	}
+	sp, ok := bc.processor.(*StateProcessor)
+	if !ok || sp.lendingEngine == nil || sp.tradingEngine == nil {
+		return nil
+	}
+	if !bc.chainConfig.IsTIPTomoXLending(block.Number()) || bc.chainConfig.IsAtlas(block.Number()) {
+		return nil
+	}
+	if block.NumberU64()%bc.chainConfig.Posv.Epoch != uint64(bc.chainConfig.Viction.LendingLiquidateTradeBlock) {
+		return nil
+	}
+
+	parent := bc.GetBlock(block.ParentHash(), block.NumberU64()-1)
+	if parent == nil {
+		return nil
+	}
+	parentAuthor, err := bc.Engine().Author(parent.Header())
+	if err != nil {
+		return fmt.Errorf("TomoZ: liquidation: failed to resolve parent author: %w", err)
+	}
+	tradingState, err := sp.tradingEngine.GetTradingState(parent, parentAuthor)
+	if err != nil {
+		return fmt.Errorf("TomoZ: liquidation: failed to open TradingStateDB: %w", err)
+	}
+	lendingState, err := sp.lendingEngine.GetLendingState(parent, parentAuthor)
+	if err != nil {
+		return fmt.Errorf("TomoZ: liquidation: failed to open LendingStateDB: %w", err)
+	}
+
+	_, _, _, _, _, err = sp.lendingEngine.ProcessLiquidationData(
+		block.Header(), bc, statedb, tradingState, lendingState,
+	)
+	if err != nil {
+		return fmt.Errorf("TomoZ: ProcessLiquidationData failed at block %d: %w", block.NumberU64(), err)
+	}
+	log.Debug("TomoZ: epoch liquidation processed", "block", block.NumberU64())
+	return nil
 }
 
 func (bc *BlockChain) UpdateM1() error {

--- a/core/blockchain_viction.go
+++ b/core/blockchain_viction.go
@@ -1,5 +1,4 @@
 // Copyright 2026 The Vic-geth Authors
-// This file provides vic-extensions to the geth BlockChain.
 package core
 
 import (
@@ -14,8 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/sortlgc"
 )
 
-// SetTradingEngine injects the legacy TomoX trading engine into the block processor.
-// This enables historical block replay for pre-Atlas TomoX transactions.
+// SetTradingEngine injects the TomoX trading engine into the block processor.
 func (bc *BlockChain) SetTradingEngine(engine TradingEngine) {
 	sp, ok := bc.processor.(*StateProcessor)
 	if !ok {
@@ -26,7 +24,7 @@ func (bc *BlockChain) SetTradingEngine(engine TradingEngine) {
 	log.Info("TomoX trading engine installed on state processor")
 }
 
-// SetLendingEngine injects the legacy TomoZ lending engine into the block processor.
+// SetLendingEngine injects the TomoZ lending engine into the block processor.
 func (bc *BlockChain) SetLendingEngine(engine LendingEngine) {
 	sp, ok := bc.processor.(*StateProcessor)
 	if !ok {
@@ -37,10 +35,8 @@ func (bc *BlockChain) SetLendingEngine(engine LendingEngine) {
 	log.Info("TomoZ lending engine installed on state processor")
 }
 
-// beforeProcessViction runs Viction-specific pre-processing before bc.processor.Process().
-// Currently handles TomoZ epoch-gated liquidation.
-// ORDERING: Must be called BEFORE bc.processor.Process() - liquidation mutations to statedb
-// must be visible to block transaction execution.
+// beforeProcessViction runs TomoZ liquidation data at epoch boundaries before
+// the main transaction loop. Only active for pre-Atlas lending-enabled blocks.
 func (bc *BlockChain) beforeProcessViction(block *types.Block, statedb *state.StateDB) error {
 	if bc.chainConfig.Posv == nil {
 		return nil
@@ -90,8 +86,8 @@ func (bc *BlockChain) UpdateM1() error {
 	}
 	log.Info("It's time to update new set of masternodes for the next epoch...")
 
-	contracrAddress := bc.chainConfig.Viction.ValidatorContract
-	if contracrAddress == (common.Address{}) {
+	contractAddress := bc.chainConfig.Viction.ValidatorContract
+	if contractAddress == (common.Address{}) {
 		return fmt.Errorf("validator contract address is not set in chain config")
 	}
 
@@ -103,11 +99,11 @@ func (bc *BlockChain) UpdateM1() error {
 	if err != nil {
 		return fmt.Errorf("failed to get state at current root (block %v): %v", bc.CurrentHeader().Number, err)
 	}
-	candidates = stateDB.VicGetCandidates(contracrAddress)
+	candidates = stateDB.VicGetCandidates(contractAddress)
 
 	var ms []posv.Masternode
 	for _, candidate := range candidates {
-		_, cap := stateDB.VicGetValidatorInfo(contracrAddress, candidate)
+		_, cap := stateDB.VicGetValidatorInfo(contractAddress, candidate)
 
 		//TODO: smart contract shouldn't return "0x0000000000000000000000000000000000000000"
 		if candidate.String() != "0x0000000000000000000000000000000000000000" {

--- a/core/lending_engine.go
+++ b/core/lending_engine.go
@@ -1,0 +1,68 @@
+// Copyright 2026 The Vic-geth Authors
+// lending_engine.go defines the LendingEngine interface for the legacy TomoZ lending protocol.
+package core
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/prque"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/legacy/tomox/tradingstate"
+	"github.com/ethereum/go-ethereum/legacy/tomoxlending/lendingstate"
+)
+
+// LendingEngine is the interface that the legacy TomoZ lending engine must satisfy.
+// Defined here to avoid import cycles (core → legacy/tomoxlending → ... → core).
+// The concrete implementation is legacy/tomoxlending.Lending.
+//
+// Note on GetLendingStateRoot naming: the interface method GetLendingStateRoot(block, author)
+// is distinct from the package-level helper GetLendingStateRoot(block, addr, author) in
+// state_processor_viction.go. They have different signatures and serve different purposes.
+type LendingEngine interface {
+	GetLendingStateRoot(block *types.Block, author common.Address) (common.Hash, error)
+	GetLendingState(block *types.Block, author common.Address) (*lendingstate.LendingStateDB, error)
+	HasLendingState(block *types.Block, author common.Address) bool
+	GetStateCache() lendingstate.Database
+	GetTriegc() *prque.Prque
+	CommitOrder(
+		header *types.Header,
+		coinbase common.Address,
+		chain tradingstate.ChainContext,
+		statedb *state.StateDB,
+		lendingStateDB *lendingstate.LendingStateDB,
+		tradingStateDB *tradingstate.TradingStateDB,
+		lendingOrderBook common.Hash,
+		order *lendingstate.LendingItem,
+	) ([]*lendingstate.LendingTrade, []*lendingstate.LendingItem, error)
+	GetCollateralPrices(
+		header *types.Header,
+		chain tradingstate.ChainContext,
+		statedb *state.StateDB,
+		tradingStateDB *tradingstate.TradingStateDB,
+		collateralToken common.Address,
+		lendingToken common.Address,
+	) (*big.Int, *big.Int, error)
+	GetMediumTradePriceBeforeEpoch(
+		chain tradingstate.ChainContext,
+		statedb *state.StateDB,
+		tradingStateDB *tradingstate.TradingStateDB,
+		baseToken common.Address,
+		quoteToken common.Address,
+	) (*big.Int, error)
+	ProcessLiquidationData(
+		header *types.Header,
+		chain tradingstate.ChainContext,
+		statedb *state.StateDB,
+		tradingState *tradingstate.TradingStateDB,
+		lendingState *lendingstate.LendingStateDB,
+	) (
+		updatedTrades map[common.Hash]*lendingstate.LendingTrade,
+		liquidatedTrades []*lendingstate.LendingTrade,
+		autoRepayTrades []*lendingstate.LendingTrade,
+		autoTopUpTrades []*lendingstate.LendingTrade,
+		autoRecallTrades []*lendingstate.LendingTrade,
+		err error,
+	)
+}

--- a/core/lending_engine.go
+++ b/core/lending_engine.go
@@ -1,5 +1,4 @@
 // Copyright 2026 The Vic-geth Authors
-// lending_engine.go defines the LendingEngine interface for the legacy TomoZ lending protocol.
 package core
 
 import (
@@ -13,13 +12,8 @@ import (
 	"github.com/ethereum/go-ethereum/legacy/tomoxlending/lendingstate"
 )
 
-// LendingEngine is the interface that the legacy TomoZ lending engine must satisfy.
-// Defined here to avoid import cycles (core → legacy/tomoxlending → ... → core).
-// The concrete implementation is legacy/tomoxlending.Lending.
-//
-// Note on GetLendingStateRoot naming: the interface method GetLendingStateRoot(block, author)
-// is distinct from the package-level helper GetLendingStateRoot(block, addr, author) in
-// state_processor_viction.go. They have different signatures and serve different purposes.
+// LendingEngine is the interface the TomoZ lending engine must satisfy.
+// Defined here to avoid an import cycle between core and legacy/tomoxlending.
 type LendingEngine interface {
 	GetLendingStateRoot(block *types.Block, author common.Address) (common.Hash, error)
 	GetLendingState(block *types.Block, author common.Address) (*lendingstate.LendingStateDB, error)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -40,6 +40,11 @@ type StateProcessor struct {
 	// tradingEngine holds the legacy TomoX blackbox for replaying historical
 	// orders during sync. Set via SetTradingEngine(). Nil when TomoX is not needed.
 	tradingEngine TradingEngine
+
+	// lendingEngine holds the legacy TomoZ lending engine for replaying historical
+	// lending orders and liquidations during sync. Set via SetLendingEngine(). Nil when
+	// TomoZ lending is not needed.
+	lendingEngine LendingEngine
 }
 
 // NewStateProcessor initialises a new StateProcessor.

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -17,8 +17,6 @@
 package core
 
 import (
-	"fmt"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/consensus/misc"
@@ -97,13 +95,13 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 		// Apply Viction-specific system transactions (BlockSigner, TomoX).
 		handled, receipt, _, err, _ := p.applyVictionTransaction(statedb, tx, header, usedGas)
 		if err != nil {
-			return nil, nil, 0, fmt.Errorf("could not apply tx %d [%v]: %w", i, tx.Hash().Hex(), err)
+			return nil, nil, 0, err
 		}
 
 		if !handled {
 			receipt, err = applyTransaction(msg, p.config, p.bc, nil, gp, statedb, header, tx, usedGas, vmenv)
 			if err != nil {
-				return nil, nil, 0, fmt.Errorf("could not apply tx %d [%v]: %w", i, tx.Hash().Hex(), err)
+				return nil, nil, 0, err
 			}
 		}
 

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -17,6 +17,8 @@
 package core
 
 import (
+	"fmt"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/consensus/misc"
@@ -95,13 +97,13 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 		// Apply Viction-specific system transactions (BlockSigner, TomoX).
 		handled, receipt, _, err, _ := p.applyVictionTransaction(statedb, tx, header, usedGas)
 		if err != nil {
-			return nil, nil, 0, err
+			return nil, nil, 0, fmt.Errorf("could not apply tx %d [%v]: %w", i, tx.Hash().Hex(), err)
 		}
 
 		if !handled {
 			receipt, err = applyTransaction(msg, p.config, p.bc, nil, gp, statedb, header, tx, usedGas, vmenv)
 			if err != nil {
-				return nil, nil, 0, err
+				return nil, nil, 0, fmt.Errorf("could not apply tx %d [%v]: %w", i, tx.Hash().Hex(), err)
 			}
 		}
 

--- a/core/state_processor_viction.go
+++ b/core/state_processor_viction.go
@@ -1,5 +1,4 @@
 // Copyright 2026 The Vic-geth Authors
-// This file provides vic-extensions to the geth.
 package core
 
 import (
@@ -19,12 +18,11 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
-// TradingEngine is the interface that the legacy TomoX blackbox must satisfy.
-// It's defined here to avoid an import cycle (core → legacy/tomox → ... → core).
-// The concrete implementation is legacy/tomox.TomoX.
+// TradingEngine is the interface the TomoX engine must satisfy.
+// Defined here to avoid an import cycle between core and legacy/tomox.
 type TradingEngine interface {
-	// CommitOrder replays a single order through the matching engine.
-	// Mutates both statedb (token balances) and tradingStateDB (order book).
+	// CommitOrder replays a single order through the matching engine,
+	// mutating statedb and tradingStateDB.
 	CommitOrder(
 		header *types.Header,
 		coinbase common.Address,
@@ -35,37 +33,34 @@ type TradingEngine interface {
 		order *tradingstate.OrderItem,
 	) ([]map[string]string, []*tradingstate.OrderItem, error)
 
-	// GetTradingState opens the TradingStateDB trie from the given block's
-	// trading root. Used to initialize the parallel trie per block during sync.
+	// GetTradingState opens the TradingStateDB trie rooted at the given block.
 	GetTradingState(block *types.Block, author common.Address) (*tradingstate.TradingStateDB, error)
 
-	// UpdateMediumPriceBeforeEpoch computes and stores average trading prices
-	// at epoch boundaries. Must be called before order matching at epoch blocks.
+	// UpdateMediumPriceBeforeEpoch computes epoch-averaged prices; must be called
+	// before order matching at epoch boundaries.
 	UpdateMediumPriceBeforeEpoch(epoch uint64, tradingStateDB *tradingstate.TradingStateDB, statedb *state.StateDB) error
 }
 
+// victionProcessorState holds per-block Viction state that is reset each block.
 type victionProcessorState struct {
 	currentBlockNumber *big.Int
 
-	// TomoX legacy trading state (parallel Merkle trie for order books).
-	// Initialized per block in beforeProcess from the parent block's trading root.
-	// Only non-nil for pre-Atlas blocks where TomoX was active.
+	// tradingStateDB is the TomoX order-book trie. Non-nil only for pre-Atlas blocks.
 	tradingStateDB *tradingstate.TradingStateDB
 
-	// lendingStateDB is the parallel Merkle trie for lending order books.
-	// Initialized per block in beforeProcess from the parent block's lending root.
-	// Only non-nil for pre-Atlas blocks where TomoZ lending was active.
+	// lendingStateDB is the TomoZ lending order-book trie. Non-nil only for pre-Atlas blocks.
 	lendingStateDB *lendingstate.LendingStateDB
-	// Pre-Atlas VRC25 fee tracking.
-	feeBalance map[common.Address]*big.Int // running snapshot: token -> remaining cap
-	feeUpdated map[common.Address]*big.Int // tokens that had fees charged: token -> final cap
-	totalFee   *big.Int                    // sum of all fees charged across the block
+
+	// Pre-Atlas VRC25 fee tracking: running balances per token, updated each tx,
+	// flushed to state in afterProcess.
+	feeBalance map[common.Address]*big.Int // token -> remaining capacity
+	feeUpdated map[common.Address]*big.Int // tokens with fees charged -> final capacity
+	totalFee   *big.Int                    // total fees charged this block
 }
 
 func (p *StateProcessor) beforeProcess(block *types.Block, statedb *state.StateDB) error {
 	header := block.Header()
 
-	// Initialize victionState for this block.
 	p.victionState = &victionProcessorState{
 		currentBlockNumber: new(big.Int).Set(header.Number),
 		feeUpdated:         map[common.Address]*big.Int{},
@@ -73,24 +68,26 @@ func (p *StateProcessor) beforeProcess(block *types.Block, statedb *state.StateD
 	}
 
 	if p.config.TIPSigningBlock != nil && p.config.TIPSigningBlock.Cmp(header.Number) == 0 {
-		statedb.DeleteAddress(p.config.Viction.ValidatorBlockSignContract)
+		if p.config.Viction != nil {
+			statedb.DeleteAddress(p.config.Viction.ValidatorBlockSignContract)
+		}
 	}
-	if p.config.IsAtlas(header.Number) {
-		misc.ApplyVIPVRC25Upgrade(statedb, p.config.Viction, p.config.AtlasBlock, header.Number)
-	}
-	if p.config.SaigonBlock != nil && p.config.SaigonBlock.Cmp(block.Number()) <= 0 {
-		misc.ApplySaigonHardFork(statedb, p.config.Viction, p.config.SaigonBlock, block.Number())
+	if p.config.Viction != nil {
+		if p.config.IsAtlas(header.Number) {
+			misc.ApplyVIPVRC25Upgrade(statedb, p.config.Viction, p.config.AtlasBlock, header.Number)
+		}
+		if p.config.IsSaigon(block.Number()) {
+			misc.ApplySaigonHardFork(statedb, p.config.Viction, p.config.SaigonBlock, block.Number())
+		}
 	}
 
-	// Pre-Atlas: snapshot all registered VRC25 token fee capacities so per-tx
-	// eligibility checks use the running map rather than live state reads.
+	// Pre-Atlas: snapshot all VRC25 token fee capacities for per-tx eligibility checks.
 	if !p.config.IsAtlas(header.Number) &&
 		p.config.Viction != nil && p.config.Viction.VRC25Contract != (common.Address{}) {
 		p.victionState.feeBalance = vrc25.GetAllFeeCapacities(statedb, p.config.Viction.VRC25Contract)
 	}
 
-	// --- TomoX TradingStateDB initialization ---
-	// Before Atlas, initialize the trading state trie from the parent block.
+	// Pre-Atlas: open the TomoX trading trie from the parent block.
 	if !p.config.IsAtlas(header.Number) && p.tradingEngine != nil && p.config.Posv != nil &&
 		p.config.IsTIPTomoX(header.Number) && header.Number.Uint64() > p.config.Posv.Epoch {
 
@@ -99,8 +96,6 @@ func (p *StateProcessor) beforeProcess(block *types.Block, statedb *state.StateD
 			parentAuthor, _ := p.engine.Author(parent.Header())
 			tradingState, err := p.tradingEngine.GetTradingState(parent, parentAuthor)
 			if err != nil {
-				// Hard error: a nil tradingStateDB causes afterProcess to skip root
-				// verification entirely (nil guard), silently accepting an invalid block.
 				return fmt.Errorf("TomoX: failed to open TradingStateDB at block %d: %w", header.Number, err)
 			}
 			p.victionState.tradingStateDB = tradingState
@@ -116,7 +111,7 @@ func (p *StateProcessor) beforeProcess(block *types.Block, statedb *state.StateD
 		}
 	}
 
-	// Requires tradingStateDB to already be initialized: lending order matching needs both states.
+	// Pre-Atlas: open the TomoZ lending trie; requires tradingStateDB to be ready.
 	if !p.config.IsAtlas(header.Number) && p.lendingEngine != nil && p.config.Posv != nil &&
 		p.config.IsTIPTomoXLending(header.Number) && header.Number.Uint64() > p.config.Posv.Epoch &&
 		p.victionState.tradingStateDB != nil {
@@ -132,7 +127,6 @@ func (p *StateProcessor) beforeProcess(block *types.Block, statedb *state.StateD
 		}
 	}
 
-	// Initialize signers
 	InitSignerInTransactions(p.config, header, block.Transactions())
 
 	return nil
@@ -146,9 +140,7 @@ func (p *StateProcessor) afterProcess(block *types.Block, statedb *state.StateDB
 		vrc25.UpdateFeeCapacity(statedb, p.config.Viction.VRC25Contract, p.victionState.feeUpdated, p.victionState.totalFee)
 	}
 
-	// --- TomoX trading root verification ---
-	// Consensus-critical: a mismatch means order matching produced different state
-	// than what the block author committed in the 0x92 tx.
+	// Verify the TomoX trading state root committed in the 0x92 tx.
 	if p.victionState != nil && p.victionState.tradingStateDB != nil && p.tradingEngine != nil {
 		gotRoot := p.victionState.tradingStateDB.IntermediateRoot()
 		blockAuthor, err := p.engine.Author(block.Header())
@@ -163,14 +155,13 @@ func (p *StateProcessor) afterProcess(block *types.Block, statedb *state.StateDB
 		log.Debug("TomoX: trading state root verified", "block", block.NumberU64(), "root", gotRoot.Hex())
 	}
 
-	// Mirrors victionchain: gate on tradingStateDB (not lendingEngine).
+	// Verify the TomoZ lending state root committed in the same 0x92 tx.
 	if p.victionState != nil && p.victionState.lendingStateDB != nil && p.victionState.tradingStateDB != nil {
 		gotRoot := p.victionState.lendingStateDB.IntermediateRoot()
 		blockAuthor, err := p.engine.Author(block.Header())
 		if err != nil {
 			return fmt.Errorf("TomoZ: failed to resolve block author at block %d: %w", block.NumberU64(), err)
 		}
-		// Both trading and lending roots live in the same 0x92 tx — filter on TradingStateContract.
 		expectRoot := GetLendingStateRoot(block, p.config.Viction.TradingStateContract, blockAuthor, p.config)
 		if gotRoot != expectRoot {
 			return fmt.Errorf("TomoZ: lending state root mismatch at block %d: got %s, expected %s",
@@ -183,17 +174,17 @@ func (p *StateProcessor) afterProcess(block *types.Block, statedb *state.StateDB
 }
 
 func (p *StateProcessor) beforeApplyTransaction(block *types.Block, tx *types.Transaction, msg types.Message, statedb *state.StateDB) error {
+	if p.config.Viction == nil {
+		return nil
+	}
 	header := block.Header()
 
-	// Bypass blacklist for legacy blocks (before hardfork)
-	maxBlockNumber := new(big.Int).SetInt64(9147459)
-	if header.Number.Cmp(maxBlockNumber) <= 0 {
+	if header.Number.BitLen() <= 64 && header.Number.Uint64() <= 9147459 {
 		if val := p.config.Viction.GetVictionBypassBalance(header.Number.Uint64(), msg.From()); val != nil {
 			statedb.SetBalance(msg.From(), val)
 		}
 	}
 
-	// Check blacklist after hardfork
 	if p.config.IsTIPBlacklist(block.Number()) {
 		if p.config.Viction.IsBlacklisted(msg.From()) {
 			return ErrBlacklistedAddress
@@ -203,56 +194,49 @@ func (p *StateProcessor) beforeApplyTransaction(block *types.Block, tx *types.Tr
 		}
 	}
 
-	// TODO: TomoX/TomoZ validation intentionally skipped for now
-	// When needed, add:
-	// - ValidateTomoZApplyTransaction() for TRC21 token registration
-	// - ValidateTomoXApplyTransaction() for TomoX pair registration
-
 	return nil
 }
 
 func (p *StateProcessor) applyVictionTransaction(statedb *state.StateDB, tx *types.Transaction, header *types.Header, usedGas *uint64) (bool, *types.Receipt, uint64, error, *big.Int) {
-	if tx.To() == nil {
+	if tx.To() == nil || p.config.Viction == nil {
 		return false, nil, 0, nil, nil
 	}
 	to := *tx.To()
 	vicConfig := p.config.Viction
 
-	// 1. BlockSigner (0x89) — Validator signature transactions
+	// 0x89 — block-signer transaction
 	if to == vicConfig.ValidatorBlockSignContract && p.config.IsTIPSigning(header.Number) {
 		return p.applySignTransaction(statedb, tx, header, usedGas)
 	}
 
-	// 2. TomoX system contracts — only active before Atlas hardfork
+	// TomoX and TomoZ system contracts are disabled at Atlas.
 	if !p.config.IsAtlas(header.Number) {
-		// 0x91 — TomoX matching batch (order execution)
+		// 0x91 — TomoX order-matching batch
 		if to == vicConfig.TomoXContract && p.config.IsTIPTomoX(header.Number) {
 			return p.applyTomoXTx(statedb, tx, header, usedGas)
 		}
 
-		// 0x92 — Trading state root commit
+		// 0x92 — trading state root commit; verified in afterProcess
 		if to == vicConfig.TradingStateContract && p.config.IsTIPTomoX(header.Number) {
-			// TODO: verify trading state root against computed TradingStateDB
 			return p.applyEmptyTransaction(statedb, tx, header, usedGas)
 		}
 
-		// 0x93 — Lending matching batch
+		// 0x93 — TomoZ lending order-matching batch
 		if to == vicConfig.LendingContract && p.config.IsTIPTomoXLending(header.Number) {
 			return p.applyLendingTx(statedb, tx, header, usedGas)
 		}
 
-		// 0x94 — Lending finalized trade (liquidation)
+		// 0x94 — lending finalized trade
 		if to == vicConfig.LendingFinalizedContract && p.config.IsTIPTomoXLending(header.Number) {
 			return p.applyEmptyTransaction(statedb, tx, header, usedGas)
 		}
 	}
 
-	// Not a viction-specific transaction — use standard EVM
 	return false, nil, 0, nil, nil
 }
 
-// applyEmptyTransaction creates a zero-gas receipt for system transactions
-// that bypass EVM execution (e.g., TomoX order matches, trading state root commits).
+// applyEmptyTransaction produces a zero-gas receipt without running the EVM.
+// Used for system transactions whose effects are handled outside the EVM (0x91–0x94).
 func (p *StateProcessor) applyEmptyTransaction(statedb *state.StateDB, tx *types.Transaction, header *types.Header, usedGas *uint64) (bool, *types.Receipt, uint64, error, *big.Int) {
 	var root []byte
 	if p.config.IsByzantium(header.Number) {
@@ -281,12 +265,10 @@ func (p *StateProcessor) applySignTransaction(statedb *state.StateDB, tx *types.
 	} else {
 		root = statedb.IntermediateRoot(p.config.IsEIP158(header.Number)).Bytes()
 	}
-	// Validate Sender
 	from, err := types.Sender(types.MakeSigner(p.config, header.Number), tx)
 	if err != nil {
 		return true, nil, 0, err, nil
 	}
-	// Nonce Validation
 	nonce := statedb.GetNonce(from)
 	if nonce < tx.Nonce() {
 		return true, nil, 0, ErrNonceTooHigh, nil
@@ -323,7 +305,7 @@ func (p *StateProcessor) afterApplyTransaction(tx *types.Transaction, msg types.
 	token := *tx.To()
 	vicCfg := p.config.Viction
 
-	// Pre-Atlas VRC25 fee accumulation.
+	// Pre-Atlas: accumulate VRC25 fee deductions into feeUpdated; flushed in afterProcess.
 	if p.victionState.feeBalance != nil {
 		runningCap, ok := p.victionState.feeBalance[token]
 		if ok && runningCap != nil {
@@ -331,15 +313,12 @@ func (p *StateProcessor) afterApplyTransaction(tx *types.Transaction, msg types.
 			if p.config.TIPTRC21FeeBlock != nil && blockNum.Cmp(p.config.TIPTRC21FeeBlock) > 0 && vicCfg != nil && vicCfg.VRC25GasPrice != nil {
 				fee = new(big.Int).Mul(fee, (*big.Int)(vicCfg.VRC25GasPrice))
 			}
-			// tokenFeeUsed: running cap must be strictly greater than fee.
 			if runningCap.Cmp(fee) > 0 {
-				// Deduct from the running balance; record in updated map.
 				newCap := new(big.Int).Sub(runningCap, fee)
 				p.victionState.feeBalance[token] = newCap
 				p.victionState.feeUpdated[token] = newCap
 				p.victionState.totalFee.Add(p.victionState.totalFee, fee)
 
-				// Failed-tx minimum token fee
 				if receipt.Status == types.ReceiptStatusFailed {
 					vrc25.PayFeeWithVRC25(statedb, msg.From(), token)
 				}
@@ -350,8 +329,12 @@ func (p *StateProcessor) afterApplyTransaction(tx *types.Transaction, msg types.
 	return nil
 }
 
-// --- Helpers ---
+// InitSignerInTransactions pre-caches sender addresses for all transactions in
+// parallel, amortizing ECDSA recovery before the sequential transaction loop.
 func InitSignerInTransactions(config *params.ChainConfig, header *types.Header, txs types.Transactions) {
+	if txs.Len() == 0 {
+		return
+	}
 	nWorker := runtime.NumCPU()
 	signer := types.MakeSigner(config, header.Number)
 	chunkSize := txs.Len() / nWorker
@@ -377,21 +360,17 @@ func InitSignerInTransactions(config *params.ChainConfig, header *types.Header, 
 	wg.Wait()
 }
 
-// SetTradingEngine injects the legacy TomoX trading engine into the state processor.
-// Called by the blockchain layer during initialization when TomoX is needed for sync.
-// Stored on the processor (not per-block state) since it persists across blocks.
+// SetTradingEngine injects the TomoX trading engine into the state processor.
 func (p *StateProcessor) SetTradingEngine(engine TradingEngine) {
 	p.tradingEngine = engine
 }
 
-// SetLendingEngine injects the legacy TomoZ lending engine into the state processor.
+// SetLendingEngine injects the TomoZ lending engine into the state processor.
 func (p *StateProcessor) SetLendingEngine(engine LendingEngine) {
 	p.lendingEngine = engine
 }
 
-// applyTomoXTx decodes and replays TomoX order matches from a 0x91 transaction.
-// During sync, it decodes the TxMatchBatch, replays each order via CommitOrder
-// (mutating both the state and the trading orderbook), and returns an empty receipt.
+// applyTomoXTx decodes and replays a TomoX order-matching batch (0x91 transaction).
 func (p *StateProcessor) applyTomoXTx(statedb *state.StateDB, tx *types.Transaction, header *types.Header, usedGas *uint64) (bool, *types.Receipt, uint64, error, *big.Int) {
 	var root []byte
 	if p.config.IsByzantium(header.Number) {
@@ -403,9 +382,6 @@ func (p *StateProcessor) applyTomoXTx(statedb *state.StateDB, tx *types.Transact
 	if len(tx.Data()) > 0 && p.victionState != nil && p.victionState.tradingStateDB != nil && p.tradingEngine != nil {
 		txMatchBatch, err := tradingstate.DecodeTxMatchesBatch(tx.Data())
 		if err != nil {
-			// Site 1: batch decode failure is a hard block rejection.
-			// A node that cannot decode the TxMatchBatch cannot replay the block's
-			// trading state deterministically, so the block must be rejected.
 			return true, nil, 0, fmt.Errorf("TomoX: failed to decode TxMatchBatch tx=%s: %w", tx.Hash().Hex(), err), nil
 		}
 
@@ -414,28 +390,22 @@ func (p *StateProcessor) applyTomoXTx(statedb *state.StateDB, tx *types.Transact
 		tradingStateDB := p.victionState.tradingStateDB
 
 		for i, txDataMatch := range txMatchBatch.Data {
-			// Decode the order from the match data
 			order, err := txDataMatch.DecodeOrder()
 			if err != nil {
-				// Site 2: victionchain behavior: soft-skip on per-order decode failure
-				// (see victionchain/core/block_validator.go:122-125)
 				log.Warn("TomoX: failed to decode order, skipping", "index", i, "err", err)
 				continue
 			}
 
 			orderBook := tradingstate.GetTradingOrderBookHash(order.BaseToken, order.QuoteToken)
 
-			trades, rejects, err := tradingEngine.CommitOrder(header, coinbase, p.bc, statedb, tradingStateDB, orderBook, order)
+			_, rejects, err := tradingEngine.CommitOrder(header, coinbase, p.bc, statedb, tradingStateDB, orderBook, order)
 			if err != nil {
-				// Site 3: victionchain behavior: CommitOrder/ApplyOrder failure is a hard error
-				// (see victionchain/core/block_validator.go:130-132)
 				return true, nil, 0, fmt.Errorf("TomoX: CommitOrder failed index=%d order=%s: %w", i, order.Hash.Hex(), err), nil
 			}
 
 			if len(rejects) > 0 {
 				log.Debug("TomoX: orders rejected", "count", len(rejects))
 			}
-			_ = trades // trades are logged but not needed for state correctness
 		}
 	}
 
@@ -452,8 +422,7 @@ func (p *StateProcessor) applyTomoXTx(statedb *state.StateDB, tx *types.Transact
 	return true, receipt, 0, nil, nil
 }
 
-// applyLendingTx decodes and replays TomoZ lending order matches from a 0x93 transaction.
-// TxLendingBatch.Data is []*LendingItem — elements are already decoded, no DecodeOrder() wrapper.
+// applyLendingTx decodes and replays a TomoZ lending order-matching batch (0x93 transaction).
 func (p *StateProcessor) applyLendingTx(statedb *state.StateDB, tx *types.Transaction, header *types.Header, usedGas *uint64) (bool, *types.Receipt, uint64, error, *big.Int) {
 	var root []byte
 	if p.config.IsByzantium(header.Number) {
@@ -482,7 +451,7 @@ func (p *StateProcessor) applyLendingTx(statedb *state.StateDB, tx *types.Transa
 				continue
 			}
 			lendingOrderBook := lendingstate.GetLendingOrderBookHash(order.LendingToken, order.Term)
-			trades, rejects, err := p.lendingEngine.CommitOrder(
+			_, rejects, err := p.lendingEngine.CommitOrder(
 				header, coinbase, p.bc, statedb,
 				lendingStateDB, tradingStateDB, lendingOrderBook, order,
 			)
@@ -492,7 +461,6 @@ func (p *StateProcessor) applyLendingTx(statedb *state.StateDB, tx *types.Transa
 			if len(rejects) > 0 {
 				log.Debug("TomoZ: lending orders rejected", "count", len(rejects))
 			}
-			_ = trades
 		}
 	}
 
@@ -507,10 +475,8 @@ func (p *StateProcessor) applyLendingTx(statedb *state.StateDB, tx *types.Transa
 	return true, receipt, 0, nil, nil
 }
 
-// GetLendingStateRoot extracts the lending state root from the 0x92 transaction.
-// The 0x92 tx data format: [32 bytes trading root | ≥32 bytes lending root]
-// Uses tx.Data()[32:] — common.BytesToHash crops the last 32 bytes when input > 32 bytes.
-// Filters on TradingStateContract (0x92) — same tx as trading root, second slot.
+// GetLendingStateRoot extracts the TomoZ lending state root from the 0x92 tx.
+// The tx payload is [32 bytes trading root | 32 bytes lending root]; this returns bytes [32:64].
 func GetLendingStateRoot(block *types.Block, tradingStateAddr common.Address, author common.Address, config *params.ChainConfig) common.Hash {
 	signer := types.MakeSigner(config, block.Number())
 	for _, tx := range block.Transactions() {
@@ -528,12 +494,8 @@ func GetLendingStateRoot(block *types.Block, tradingStateAddr common.Address, au
 	return lendingstate.EmptyRoot
 }
 
-// GetTradingStateRoot extracts the trading state root from the 0x92 transaction
-// authored by the block's coinbase. Returns EmptyRoot if no such transaction exists.
-// The 0x92 tx data format: [32 bytes trading root | 32 bytes lending root]
-//
-// Author validation: only the block author may commit the trading state root —
-// this is a consensus invariant.
+// GetTradingStateRoot extracts the TomoX trading state root from the 0x92 tx.
+// The tx payload is [32 bytes trading root | 32 bytes lending root]; this returns bytes [0:32].
 func GetTradingStateRoot(block *types.Block, tradingStateAddr common.Address, author common.Address, config *params.ChainConfig) common.Hash {
 	signer := types.MakeSigner(config, block.Number())
 	for _, tx := range block.Transactions() {

--- a/core/state_processor_viction.go
+++ b/core/state_processor_viction.go
@@ -115,7 +115,7 @@ func (p *StateProcessor) afterProcess(block *types.Block, statedb *state.StateDB
 		if err != nil {
 			return fmt.Errorf("TomoX: failed to resolve block author at block %d: %w", block.NumberU64(), err)
 		}
-		expectRoot := GetTradingStateRoot(block, p.config.Viction.TradingStateContract, blockAuthor)
+		expectRoot := GetTradingStateRoot(block, p.config.Viction.TradingStateContract, blockAuthor, p.config)
 		if gotRoot != expectRoot {
 			return fmt.Errorf("TomoX: trading state root mismatch at block %d: got %s, expected %s",
 				block.NumberU64(), gotRoot.Hex(), expectRoot.Hex())
@@ -377,12 +377,8 @@ func (p *StateProcessor) applyTomoXTx(statedb *state.StateDB, tx *types.Transact
 //
 // Author validation: only the block author may commit the trading state root —
 // this is a consensus invariant.
-//
-// Signer: 0x92 system transactions are created by the victionchain miner using
-// HomesteadSigner (see legacy/tomox/tomox.go:GetTradingStateRoot:85).
-// We must use the same signer to correctly recover the transaction sender.
-func GetTradingStateRoot(block *types.Block, tradingStateAddr common.Address, author common.Address) common.Hash {
-	signer := types.HomesteadSigner{}
+func GetTradingStateRoot(block *types.Block, tradingStateAddr common.Address, author common.Address, config *params.ChainConfig) common.Hash {
+	signer := types.MakeSigner(config, block.Number())
 	for _, tx := range block.Transactions() {
 		if tx.To() == nil || *tx.To() != tradingStateAddr {
 			continue

--- a/core/state_processor_viction.go
+++ b/core/state_processor_viction.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vrc25"
 	"github.com/ethereum/go-ethereum/legacy/tomox/tradingstate"
+	"github.com/ethereum/go-ethereum/legacy/tomoxlending/lendingstate"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 )
@@ -50,6 +51,11 @@ type victionProcessorState struct {
 	// Initialized per block in beforeProcess from the parent block's trading root.
 	// Only non-nil for pre-Atlas blocks where TomoX was active.
 	tradingStateDB *tradingstate.TradingStateDB
+
+	// lendingStateDB is the parallel Merkle trie for lending order books.
+	// Initialized per block in beforeProcess from the parent block's lending root.
+	// Only non-nil for pre-Atlas blocks where TomoZ lending was active.
+	lendingStateDB *lendingstate.LendingStateDB
 }
 
 func (p *StateProcessor) beforeProcess(block *types.Block, statedb *state.StateDB) error {
@@ -86,16 +92,30 @@ func (p *StateProcessor) beforeProcess(block *types.Block, statedb *state.StateD
 			}
 			p.victionState.tradingStateDB = tradingState
 
-			// At epoch boundaries, update medium prices before any order matching.
-			// Intentional soft failure: epoch price is best-effort, not consensus-critical.
 			if header.Number.Uint64()%p.config.Posv.Epoch == 0 {
 				if err := p.tradingEngine.UpdateMediumPriceBeforeEpoch(
 					header.Number.Uint64()/p.config.Posv.Epoch,
 					tradingState, statedb,
 				); err != nil {
-					log.Error("TomoX: UpdateMediumPriceBeforeEpoch failed", "block", header.Number, "err", err)
+					return fmt.Errorf("TomoX: UpdateMediumPriceBeforeEpoch failed at block %d: %w", header.Number, err)
 				}
 			}
+		}
+	}
+
+	// Requires tradingStateDB to already be initialized: lending order matching needs both states.
+	if !p.config.IsAtlas(header.Number) && p.lendingEngine != nil && p.config.Posv != nil &&
+		p.config.IsTIPTomoXLending(header.Number) && header.Number.Uint64() > p.config.Posv.Epoch &&
+		p.victionState.tradingStateDB != nil {
+
+		parent := p.bc.GetBlock(header.ParentHash, header.Number.Uint64()-1)
+		if parent != nil {
+			parentAuthor, _ := p.engine.Author(parent.Header())
+			lendingState, err := p.lendingEngine.GetLendingState(parent, parentAuthor)
+			if err != nil {
+				return fmt.Errorf("TomoZ: failed to open LendingStateDB at block %d: %w", header.Number, err)
+			}
+			p.victionState.lendingStateDB = lendingState
 		}
 	}
 
@@ -121,6 +141,22 @@ func (p *StateProcessor) afterProcess(block *types.Block, statedb *state.StateDB
 				block.NumberU64(), gotRoot.Hex(), expectRoot.Hex())
 		}
 		log.Debug("TomoX: trading state root verified", "block", block.NumberU64(), "root", gotRoot.Hex())
+	}
+
+	// Mirrors victionchain: gate on tradingStateDB (not lendingEngine).
+	if p.victionState != nil && p.victionState.lendingStateDB != nil && p.victionState.tradingStateDB != nil {
+		gotRoot := p.victionState.lendingStateDB.IntermediateRoot()
+		blockAuthor, err := p.engine.Author(block.Header())
+		if err != nil {
+			return fmt.Errorf("TomoZ: failed to resolve block author at block %d: %w", block.NumberU64(), err)
+		}
+		// Both trading and lending roots live in the same 0x92 tx — filter on TradingStateContract.
+		expectRoot := GetLendingStateRoot(block, p.config.Viction.TradingStateContract, blockAuthor, p.config)
+		if gotRoot != expectRoot {
+			return fmt.Errorf("TomoZ: lending state root mismatch at block %d: got %s, expected %s",
+				block.NumberU64(), gotRoot.Hex(), expectRoot.Hex())
+		}
+		log.Debug("TomoZ: lending state root verified", "block", block.NumberU64(), "root", gotRoot.Hex())
 	}
 
 	return nil
@@ -182,7 +218,7 @@ func (p *StateProcessor) applyVictionTransaction(statedb *state.StateDB, tx *typ
 
 		// 0x93 — Lending matching batch
 		if to == vicConfig.LendingContract && p.config.IsTIPTomoXLending(header.Number) {
-			return p.applyEmptyTransaction(statedb, tx, header, usedGas)
+			return p.applyLendingTx(statedb, tx, header, usedGas)
 		}
 
 		// 0x94 — Lending finalized trade (liquidation)
@@ -308,6 +344,11 @@ func (p *StateProcessor) SetTradingEngine(engine TradingEngine) {
 	p.tradingEngine = engine
 }
 
+// SetLendingEngine injects the legacy TomoZ lending engine into the state processor.
+func (p *StateProcessor) SetLendingEngine(engine LendingEngine) {
+	p.lendingEngine = engine
+}
+
 // applyTomoXTx decodes and replays TomoX order matches from a 0x91 transaction.
 // During sync, it decodes the TxMatchBatch, replays each order via CommitOrder
 // (mutating both the state and the trading orderbook), and returns an empty receipt.
@@ -369,6 +410,82 @@ func (p *StateProcessor) applyTomoXTx(statedb *state.StateDB, tx *types.Transact
 	receipt.Bloom = types.CreateBloom(types.Receipts{receipt})
 
 	return true, receipt, 0, nil, nil
+}
+
+// applyLendingTx decodes and replays TomoZ lending order matches from a 0x93 transaction.
+// TxLendingBatch.Data is []*LendingItem — elements are already decoded, no DecodeOrder() wrapper.
+func (p *StateProcessor) applyLendingTx(statedb *state.StateDB, tx *types.Transaction, header *types.Header, usedGas *uint64) (bool, *types.Receipt, uint64, error, *big.Int) {
+	var root []byte
+	if p.config.IsByzantium(header.Number) {
+		statedb.Finalise(true)
+	} else {
+		root = statedb.IntermediateRoot(p.config.IsEIP158(header.Number)).Bytes()
+	}
+
+	if len(tx.Data()) > 0 &&
+		p.victionState != nil &&
+		p.victionState.lendingStateDB != nil &&
+		p.victionState.tradingStateDB != nil &&
+		p.lendingEngine != nil {
+
+		txMatchBatch, err := lendingstate.DecodeTxLendingBatch(tx.Data())
+		if err != nil {
+			return true, nil, 0, fmt.Errorf("TomoZ: failed to decode TxLendingBatch tx=%s: %w", tx.Hash().Hex(), err), nil
+		}
+
+		coinbase := header.Coinbase
+		lendingStateDB := p.victionState.lendingStateDB
+		tradingStateDB := p.victionState.tradingStateDB
+
+		for i, order := range txMatchBatch.Data {
+			if order == nil {
+				continue
+			}
+			lendingOrderBook := lendingstate.GetLendingOrderBookHash(order.LendingToken, order.Term)
+			trades, rejects, err := p.lendingEngine.CommitOrder(
+				header, coinbase, p.bc, statedb,
+				lendingStateDB, tradingStateDB, lendingOrderBook, order,
+			)
+			if err != nil {
+				return true, nil, 0, fmt.Errorf("TomoZ: CommitOrder failed index=%d: %w", i, err), nil
+			}
+			if len(rejects) > 0 {
+				log.Debug("TomoZ: lending orders rejected", "count", len(rejects))
+			}
+			_ = trades
+		}
+	}
+
+	receipt := types.NewReceipt(root, false, *usedGas)
+	receipt.TxHash = tx.Hash()
+	receipt.GasUsed = 0
+	txLog := &types.Log{}
+	txLog.Address = *tx.To()
+	txLog.BlockNumber = header.Number.Uint64()
+	statedb.AddLog(txLog)
+	receipt.Bloom = types.CreateBloom(types.Receipts{receipt})
+	return true, receipt, 0, nil, nil
+}
+
+// GetLendingStateRoot extracts the lending state root from the 0x92 transaction.
+// The 0x92 tx data format: [32 bytes trading root | ≥32 bytes lending root]
+// Uses tx.Data()[32:] — common.BytesToHash crops the last 32 bytes when input > 32 bytes.
+// Filters on TradingStateContract (0x92) — same tx as trading root, second slot.
+func GetLendingStateRoot(block *types.Block, tradingStateAddr common.Address, author common.Address, config *params.ChainConfig) common.Hash {
+	signer := types.MakeSigner(config, block.Number())
+	for _, tx := range block.Transactions() {
+		if tx.To() == nil || *tx.To() != tradingStateAddr {
+			continue
+		}
+		from, err := types.Sender(signer, tx)
+		if err != nil || from != author {
+			continue
+		}
+		if len(tx.Data()) >= 64 {
+			return common.BytesToHash(tx.Data()[32:])
+		}
+	}
+	return lendingstate.EmptyRoot
 }
 
 // GetTradingStateRoot extracts the trading state root from the 0x92 transaction

--- a/eth/backend_viction.go
+++ b/eth/backend_viction.go
@@ -11,8 +11,8 @@ import (
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/viction"
-	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/legacy/tomox"
+	"github.com/ethereum/go-ethereum/legacy/tomoxlending"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/params"
@@ -239,12 +239,8 @@ func (s *Ethereum) PosvGetValidators(vicConfig *params.VictionConfig, header *ty
 
 }
 
-func (s *Ethereum) PosvSetTomoxTradingEngine(tradingDb ethdb.Database) {
-	tomoxEngine := tomox.NewWithDB(tradingDb)
-	s.blockchain.SetTradingEngine(tomoxEngine)
-}
-
-// setupPosvBackend wires the POSV engine backend and optional TomoX trading engine.
+// setupPosvBackend wires the POSV engine backend and the legacy TomoX/TomoZ engines
+// for historical block replay (pre-Atlas sync).
 func (eth *Ethereum) setupPosvBackend(chainConfig *params.ChainConfig, stack *node.Node) error {
 	if chainConfig.Posv == nil {
 		return nil
@@ -265,14 +261,25 @@ func (eth *Ethereum) setupPosvBackend(chainConfig *params.ChainConfig, stack *no
 	}
 
 	// Initialize legacy TomoX trading engine for historical block replay.
-	// Required on Viction (Posv) networks to sync pre-Atlas blocks containing
-	// TomoX order matching transactions (0x91). Not needed on non-Posv chains.
+	// Required to sync pre-Atlas blocks containing TomoX order matching transactions (0x91).
 	tradingDb, err := stack.OpenDatabase("tomox", 256, 256, "eth/db/tomox/")
 	if err != nil {
 		log.Error("Failed to open TomoX trading database", "err", err)
-	} else {
-		eth.PosvSetTomoxTradingEngine(tradingDb)
+		return nil
 	}
+	tomoxEngine := tomox.NewWithDB(tradingDb, eth.blockchain.Config())
+	eth.blockchain.SetTradingEngine(tomoxEngine)
+
+	// Initialize legacy TomoZ lending engine for historical block replay.
+	// Required to sync pre-Atlas blocks containing TomoZ lending order transactions (0x93).
+	// Must share the same tomoxEngine instance so lending price lookups hit the same trading state.
+	lendingDb, err := stack.OpenDatabase("tomoxlending", 256, 256, "eth/db/tomoxlending/")
+	if err != nil {
+		log.Error("Failed to open TomoZ lending database", "err", err)
+		return nil
+	}
+	lendingEngine := tomoxlending.New(lendingDb, tomoxEngine, eth.blockchain.Config())
+	eth.blockchain.SetLendingEngine(lendingEngine)
 
 	return nil
 }

--- a/legacy/tomox/tomox.go
+++ b/legacy/tomox/tomox.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/legacy/tomox/tradingstate"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
 
 	"sync"
 
@@ -47,6 +48,10 @@ type TomoX struct {
 	Triegc     *prque.Prque          // Priority queue mapping block numbers to tries to gc
 	StateCache tradingstate.Database // State database to reuse between imports (contains state cache)    *tomox_state.TradingStateDB
 
+	// config is needed to derive the correct transaction signer (EIP155 vs Homestead)
+	// when extracting the trading state root from the 0x92 system transaction.
+	config *params.ChainConfig
+
 	orderNonce map[common.Address]*big.Int
 
 	settings          sync.Map // holds configuration settings that can be dynamically changed
@@ -54,10 +59,11 @@ type TomoX struct {
 	orderCache        *lru.Cache
 }
 
-func NewWithDB(db ethdb.Database) *TomoX {
+func NewWithDB(db ethdb.Database, config *params.ChainConfig) *TomoX {
 	tokenDecimalCache, _ := lru.New(defaultCacheLimit)
 	orderCache, _ := lru.New(tradingstate.OrderCacheLimit)
 	tomoX := &TomoX{
+		config:            config,
 		orderNonce:        make(map[common.Address]*big.Int),
 		Triegc:            prque.New(nil),
 		tokenDecimalCache: tokenDecimalCache,
@@ -80,16 +86,17 @@ func (tomox *TomoX) GetTradingState(block *types.Block, author common.Address) (
 }
 
 func (tomox *TomoX) GetTradingStateRoot(block *types.Block, author common.Address) (common.Hash, error) {
+	signer := types.MakeSigner(tomox.config, block.Number())
 	for _, tx := range block.Transactions() {
-		signer := types.HomesteadSigner{}
-		from, err := types.Sender(signer, tx)
-		if err != nil {
+		if tx.To() == nil || tx.To().Hex() != tradingstate.TradingStateAddr {
 			continue
 		}
-		if tx.To() != nil && tx.To().Hex() == tradingstate.TradingStateAddr && from.String() == author.String() {
-			if len(tx.Data()) >= 32 {
-				return common.BytesToHash(tx.Data()[:32]), nil
-			}
+		from, err := types.Sender(signer, tx)
+		if err != nil || from != author {
+			continue
+		}
+		if len(tx.Data()) >= 32 {
+			return common.BytesToHash(tx.Data()[:32]), nil
 		}
 	}
 	return tradingstate.EmptyRoot, nil

--- a/legacy/tomoxlending/lendingstate/common.go
+++ b/legacy/tomoxlending/lendingstate/common.go
@@ -1,0 +1,274 @@
+package lendingstate
+
+import (
+	"encoding/json"
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+var (
+	EmptyAddress = "0x0000000000000000000000000000000000000000"
+	EmptyRoot    = common.HexToHash("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
+)
+
+var EmptyHash = common.Hash{}
+var Zero = big.NewInt(0)
+var One = big.NewInt(1)
+
+// RelayerLendingFee is the minimum lending fee threshold (0.01 TOMO = 1e16 wei).
+var RelayerLendingFee = big.NewInt(10000000000000000)
+
+// RelayerLendingCancelFee is the fee charged when cancelling a lending order (0.001 TOMO = 1e15 wei).
+var RelayerLendingCancelFee = big.NewInt(1000000000000000)
+
+// LendingLockAddress is the system address that holds locked collateral for lending trades.
+const LendingLockAddress = "0x0000000000000000000000000000000000000011"
+
+// RateTopUp and BaseTopUp define the top-up rate: newLiquidationPrice = currentPrice * RateTopUp / BaseTopUp = 90%.
+var RateTopUp = big.NewInt(90)
+var BaseTopUp = big.NewInt(100)
+
+// BaseRecall is the precision base for the recall rate calculation.
+var BaseRecall = big.NewInt(100)
+
+// OneYear is the number of seconds in one year (365 days).
+const OneYear = uint64(31536000)
+
+// BaseLendingInterest is the precision base for lending interest rates (1e8).
+var BaseLendingInterest = big.NewInt(100000000)
+var EmptyLendingOrder = LendingItem{
+	Quantity: Zero,
+}
+
+var EmptyLendingTrade = LendingTrade{
+	Amount: big.NewInt(0),
+}
+
+type itemList struct {
+	Volume *big.Int
+	Root   common.Hash
+}
+
+type lendingObject struct {
+	Nonce               uint64
+	TradeNonce          uint64
+	InvestingRoot       common.Hash
+	BorrowingRoot       common.Hash
+	LiquidationTimeRoot common.Hash
+	LendingItemRoot     common.Hash
+	LendingTradeRoot    common.Hash
+}
+
+// liquidation reasons
+const (
+	LiquidatedByTime  = uint64(0)
+	LiquidatedByPrice = uint64(1)
+)
+
+type LiquidationData struct {
+	RecallAmount      *big.Int
+	LiquidationAmount *big.Int
+	CollateralPrice   *big.Int
+	Reason            uint64
+}
+
+var (
+	TokenMappingSlot = map[string]uint64{
+		"balances": 0,
+	}
+	RelayerMappingSlot = map[string]uint64{
+		"CONTRACT_OWNER":       0,
+		"MaximumRelayers":      1,
+		"MaximumTokenList":     2,
+		"RELAYER_LIST":         3,
+		"RELAYER_COINBASES":    4,
+		"RESIGN_REQUESTS":      5,
+		"RELAYER_ON_SALE_LIST": 6,
+		"RelayerCount":         7,
+		"MinimumDeposit":       8,
+	}
+	RelayerStructMappingSlot = map[string]*big.Int{
+		"_deposit":    big.NewInt(0),
+		"_fee":        big.NewInt(1),
+		"_fromTokens": big.NewInt(2),
+		"_toTokens":   big.NewInt(3),
+		"_index":      big.NewInt(4),
+		"_owner":      big.NewInt(5),
+	}
+)
+
+type TxLendingBatch struct {
+	Data      []*LendingItem
+	Timestamp int64
+	TxHash    common.Hash
+}
+
+type MatchingResult struct {
+	Trades  []*LendingTrade
+	Rejects []*LendingItem
+}
+
+type FinalizedResult struct {
+	Liquidated []common.Hash
+	AutoRepay  []common.Hash
+	AutoTopUp  []common.Hash
+	AutoRecall []common.Hash
+	TxHash     common.Hash
+	Timestamp  int64
+}
+
+// use orderHash instead of tradeId
+// because both takerOrders don't have tradeId
+func GetLendingItemHistoryKey(lendingToken, collateralToken common.Address, lendingItemHash common.Hash) common.Hash {
+	return crypto.Keccak256Hash(lendingToken.Bytes(), collateralToken.Bytes(), lendingItemHash.Bytes())
+}
+
+type LendingItemHistoryItem struct {
+	TxHash       common.Hash
+	FilledAmount *big.Int
+	Status       string
+	UpdatedAt    time.Time
+}
+
+type LendingTradeHistoryItem struct {
+	TxHash                 common.Hash
+	CollateralLockedAmount *big.Int
+	LiquidationPrice       *big.Int
+	Status                 string
+	UpdatedAt              time.Time
+}
+
+type LendingPair struct {
+	LendingToken    common.Address
+	CollateralToken common.Address
+}
+
+// ToJSON : log json string
+func ToJSON(object interface{}, args ...string) string {
+	var str []byte
+	if len(args) == 2 {
+		str, _ = json.MarshalIndent(object, args[0], args[1])
+	} else {
+		str, _ = json.Marshal(object)
+	}
+	return string(str)
+}
+
+func Mul(x, y *big.Int) *big.Int {
+	return big.NewInt(0).Mul(x, y)
+}
+
+func Div(x, y *big.Int) *big.Int {
+	return big.NewInt(0).Div(x, y)
+}
+
+func Add(x, y *big.Int) *big.Int {
+	return big.NewInt(0).Add(x, y)
+}
+
+func Sub(x, y *big.Int) *big.Int {
+	return big.NewInt(0).Sub(x, y)
+}
+
+func Neg(x *big.Int) *big.Int {
+	return big.NewInt(0).Neg(x)
+}
+
+func ToBigInt(s string) *big.Int {
+	res := big.NewInt(0)
+	res.SetString(s, 10)
+	return res
+}
+
+func CloneBigInt(bigInt *big.Int) *big.Int {
+	res := new(big.Int).SetBytes(bigInt.Bytes())
+	return res
+}
+
+func Exp(x, y *big.Int) *big.Int {
+	return big.NewInt(0).Exp(x, y, nil)
+}
+
+func Max(a, b *big.Int) *big.Int {
+	if a.Cmp(b) == 1 {
+		return a
+	} else {
+		return b
+	}
+}
+
+func GetLendingOrderBookHash(lendingToken common.Address, term uint64) common.Hash {
+	return crypto.Keccak256Hash(append(params.Uint64ToHash(term).Bytes(), lendingToken.Bytes()...))
+}
+
+func EncodeTxLendingBatch(batch TxLendingBatch) ([]byte, error) {
+	data, err := json.Marshal(batch)
+	if err != nil || data == nil {
+		return []byte{}, err
+	}
+	return data, nil
+}
+
+func DecodeTxLendingBatch(data []byte) (TxLendingBatch, error) {
+	txMatchResult := TxLendingBatch{}
+	if err := json.Unmarshal(data, &txMatchResult); err != nil {
+		return TxLendingBatch{}, err
+	}
+	return txMatchResult, nil
+}
+
+func EtherToWei(amount *big.Int) *big.Int {
+	return new(big.Int).Mul(amount, new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil))
+}
+
+func WeiToEther(amount *big.Int) *big.Int {
+	return new(big.Int).Div(amount, new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil))
+}
+
+func EncodeFinalizedResult(liquidatedTrades, autoRepayTrades, autoTopUpTrades, autoRecallTrades []*LendingTrade) ([]byte, error) {
+	liquidatedHashes := []common.Hash{}
+	autoRepayHashes := []common.Hash{}
+	autoTopUpHashes := []common.Hash{}
+	autoRecallHashes := []common.Hash{}
+
+	for _, trade := range liquidatedTrades {
+		liquidatedHashes = append(liquidatedHashes, trade.Hash)
+	}
+	for _, trade := range autoRepayTrades {
+		autoRepayHashes = append(autoRepayHashes, trade.Hash)
+	}
+	for _, trade := range autoTopUpTrades {
+		autoTopUpHashes = append(autoTopUpHashes, trade.Hash)
+	}
+	for _, trade := range autoRecallTrades {
+		autoRecallHashes = append(autoRecallHashes, trade.Hash)
+	}
+	result := FinalizedResult{
+		Liquidated: liquidatedHashes,
+		AutoRepay:  autoRepayHashes,
+		AutoTopUp:  autoTopUpHashes,
+		AutoRecall: autoRecallHashes,
+		Timestamp:  time.Now().UnixNano(),
+	}
+	data, err := json.Marshal(result)
+	if err != nil || data == nil {
+		return []byte{}, err
+	}
+	return data, nil
+}
+
+func DecodeFinalizedResult(data []byte) (result FinalizedResult, err error) {
+	result = FinalizedResult{}
+	if err := json.Unmarshal(data, &result); err != nil {
+		return FinalizedResult{}, err
+	}
+	return result, nil
+}
+
+func GetLendingCacheKey(item *LendingItem) common.Hash {
+	return crypto.Keccak256Hash(item.UserAddress.Bytes(), item.Nonce.Bytes())
+}

--- a/legacy/tomoxlending/lendingstate/database.go
+++ b/legacy/tomoxlending/lendingstate/database.go
@@ -1,0 +1,140 @@
+// Copyright 2017 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package lendingstate
+
+import (
+	"fmt"
+	"sync"
+
+	lru "github.com/hashicorp/golang-lru"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/trie"
+)
+
+// Trie cache generation limit after which to evic trie nodes from memory.
+var MaxTrieCacheGen = uint16(120)
+
+const (
+	// Number of past tries to keep. This value is chosen such that
+	// reasonable chain reorg depths will hit an existing trie.
+	maxPastTries = 12
+
+	// Number of codehash->size associations to keep.
+	codeSizeCacheSize = 100000
+)
+
+// Database wraps access to tries and contract code.
+type Database interface {
+	// OpenTrie opens the main account trie.
+	OpenTrie(root common.Hash) (Trie, error)
+
+	// OpenStorageTrie opens the storage trie of an account.
+	OpenStorageTrie(addrHash, root common.Hash) (Trie, error)
+
+	// CopyTrie returns an independent copy of the given trie.
+	CopyTrie(Trie) Trie
+
+	// ContractCode retrieves a particular contract's code.
+	ContractCode(addrHash, codeHash common.Hash) ([]byte, error)
+
+	// ContractCodeSize retrieves a particular contracts code's size.
+	ContractCodeSize(addrHash, codeHash common.Hash) (int, error)
+
+	// TrieDB retrieves the low level trie database used for data storage.
+	TrieDB() *trie.Database
+}
+
+// Trie is a Ethereum Merkle Trie.
+type Trie interface {
+	TryGet(key []byte) ([]byte, error)
+	TryGetBestLeftKeyAndValue() ([]byte, []byte, error)
+	TryGetAllLeftKeyAndValue(limit []byte) ([][]byte, [][]byte, error)
+	TryGetBestRightKeyAndValue() ([]byte, []byte, error)
+	TryUpdate(key, value []byte) error
+	TryDelete(key []byte) error
+	Commit(onleaf trie.LeafCallback) (common.Hash, int, error)
+	Hash() common.Hash
+	NodeIterator(startKey []byte) trie.NodeIterator
+	GetKey([]byte) []byte // TODO(fjl): remove this when TomoXTrie is removed
+	Prove(key []byte, fromLevel uint, proofDb ethdb.KeyValueWriter) error
+}
+
+// NewDatabase creates a backing store for state. The returned database is safe for
+// concurrent use and retains cached trie nodes in memory. The pool is an optional
+// intermediate trie-node memory pool between the low level storage layer and the
+// high level trie abstraction.
+func NewDatabase(db ethdb.Database) Database {
+	csc, _ := lru.New(codeSizeCacheSize)
+	return &cachingDB{
+		db:            trie.NewDatabase(db),
+		codeSizeCache: csc,
+	}
+}
+
+type cachingDB struct {
+	db            *trie.Database
+	mu            sync.Mutex
+	pastTries     []*TomoXTrie
+	codeSizeCache *lru.Cache
+}
+
+// OpenTrie opens the main account trie.
+func (db *cachingDB) OpenTrie(root common.Hash) (Trie, error) {
+	return NewTomoXTrie(root, db.db)
+}
+
+func (db *cachingDB) pushTrie(t *TomoXTrie) {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	if len(db.pastTries) >= maxPastTries {
+		copy(db.pastTries, db.pastTries[1:])
+		db.pastTries[len(db.pastTries)-1] = t
+	} else {
+		db.pastTries = append(db.pastTries, t)
+	}
+}
+
+// OpenStorageTrie opens the storage trie of an account.
+func (db *cachingDB) OpenStorageTrie(addrHash, root common.Hash) (Trie, error) {
+	return NewTomoXTrie(root, db.db)
+}
+
+// CopyTrie returns an independent copy of the given trie.
+func (db *cachingDB) CopyTrie(t Trie) Trie {
+	switch t := t.(type) {
+	case *TomoXTrie:
+		return t.Copy()
+	default:
+		panic(fmt.Errorf("unknown trie type %T", t))
+	}
+}
+
+// ContractCode retrieves a particular contract's code.
+func (db *cachingDB) ContractCode(addrHash, codeHash common.Hash) ([]byte, error) {
+	return nil, nil
+}
+
+// ContractCodeSize retrieves a particular contracts code's size.
+func (db *cachingDB) ContractCodeSize(addrHash, codeHash common.Hash) (int, error) {
+	return 0, nil
+}
+
+// TrieDB retrieves any intermediate trie-node caching layer.
+func (db *cachingDB) TrieDB() *trie.Database {
+	return db.db
+}

--- a/legacy/tomoxlending/lendingstate/dump.go
+++ b/legacy/tomoxlending/lendingstate/dump.go
@@ -1,0 +1,418 @@
+// Copyright 2014 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package lendingstate
+
+import (
+	"fmt"
+	"math/big"
+	"sort"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/ethereum/go-ethereum/trie"
+)
+
+type DumpOrderList struct {
+	Volume *big.Int
+	Orders map[*big.Int]*big.Int
+}
+
+type DumpOrderBookInfo struct {
+	Nonce                 uint64
+	TradeNonce            uint64
+	BestInvesting         *big.Int
+	BestBorrowing         *big.Int
+	LowestLiquidationTime *big.Int
+}
+
+func (self *LendingStateDB) DumpInvestingTrie(orderBook common.Hash) (map[*big.Int]DumpOrderList, error) {
+	exhangeObject := self.getLendingExchange(orderBook)
+	if exhangeObject == nil {
+		return nil, fmt.Errorf("Order book not found orderBook : %v ", orderBook.Hex())
+	}
+	mapResult := map[*big.Int]DumpOrderList{}
+	it := trie.NewIterator(exhangeObject.getInvestingTrie(self.db).NodeIterator(nil))
+	for it.Next() {
+		interestHash := common.BytesToHash(it.Key)
+		if params.EmptyHash(interestHash) {
+			continue
+		}
+		interest := new(big.Int).SetBytes(interestHash.Bytes())
+		if _, exist := exhangeObject.investingStates[interestHash]; exist {
+			continue
+		} else {
+			var data itemList
+			if err := rlp.DecodeBytes(it.Value, &data); err != nil {
+				return nil, fmt.Errorf("Fail when decode order iist orderBook : %v ,interest :%v ", orderBook.Hex(), interest)
+			}
+			stateOrderList := newItemListState(orderBook, interestHash, data, nil)
+			mapResult[interest] = stateOrderList.DumpItemList(self.db)
+		}
+	}
+	for interestHash, itemList := range exhangeObject.investingStates {
+		if itemList.Volume().Sign() > 0 {
+			mapResult[new(big.Int).SetBytes(interestHash.Bytes())] = itemList.DumpItemList(self.db)
+		}
+	}
+	listInterest := []*big.Int{}
+	for interest := range mapResult {
+		listInterest = append(listInterest, interest)
+	}
+	sort.Slice(listInterest, func(i, j int) bool {
+		return listInterest[i].Cmp(listInterest[j]) < 0
+	})
+	result := map[*big.Int]DumpOrderList{}
+	for _, interest := range listInterest {
+		result[interest] = mapResult[interest]
+	}
+	return result, nil
+}
+
+func (self *LendingStateDB) DumpBorrowingTrie(orderBook common.Hash) (map[*big.Int]DumpOrderList, error) {
+	exhangeObject := self.getLendingExchange(orderBook)
+	if exhangeObject == nil {
+		return nil, fmt.Errorf("Order book not found orderBook : %v ", orderBook.Hex())
+	}
+	mapResult := map[*big.Int]DumpOrderList{}
+	it := trie.NewIterator(exhangeObject.getBorrowingTrie(self.db).NodeIterator(nil))
+	for it.Next() {
+		interestHash := common.BytesToHash(it.Key)
+		if params.EmptyHash(interestHash) {
+			continue
+		}
+		interest := new(big.Int).SetBytes(interestHash.Bytes())
+		if _, exist := exhangeObject.borrowingStates[interestHash]; exist {
+			continue
+		} else {
+			var data itemList
+			if err := rlp.DecodeBytes(it.Value, &data); err != nil {
+				return nil, fmt.Errorf("Fail when decode order iist orderBook : %v ,interest :%v ", orderBook.Hex(), interest)
+			}
+			stateOrderList := newItemListState(orderBook, interestHash, data, nil)
+			mapResult[interest] = stateOrderList.DumpItemList(self.db)
+		}
+	}
+	for interestHash, itemList := range exhangeObject.borrowingStates {
+		if itemList.Volume().Sign() > 0 {
+			mapResult[new(big.Int).SetBytes(interestHash.Bytes())] = itemList.DumpItemList(self.db)
+		}
+	}
+	listInterest := []*big.Int{}
+	for interest := range mapResult {
+		listInterest = append(listInterest, interest)
+	}
+	sort.Slice(listInterest, func(i, j int) bool {
+		return listInterest[i].Cmp(listInterest[j]) < 0
+	})
+	result := map[*big.Int]DumpOrderList{}
+	for _, interest := range listInterest {
+		result[interest] = mapResult[interest]
+	}
+	return result, nil
+}
+
+func (self *LendingStateDB) GetInvestings(orderBook common.Hash) (map[*big.Int]*big.Int, error) {
+	exhangeObject := self.getLendingExchange(orderBook)
+	if exhangeObject == nil {
+		return nil, fmt.Errorf("Order book not found orderBook : %v ", orderBook.Hex())
+	}
+	mapResult := map[*big.Int]*big.Int{}
+	it := trie.NewIterator(exhangeObject.getInvestingTrie(self.db).NodeIterator(nil))
+	for it.Next() {
+		interestHash := common.BytesToHash(it.Key)
+		if params.EmptyHash(interestHash) {
+			continue
+		}
+		interest := new(big.Int).SetBytes(interestHash.Bytes())
+		if _, exist := exhangeObject.investingStates[interestHash]; exist {
+			continue
+		} else {
+			var data itemList
+			if err := rlp.DecodeBytes(it.Value, &data); err != nil {
+				return nil, fmt.Errorf("Fail when decode order iist orderBook : %v ,interest :%v ", orderBook.Hex(), interest)
+			}
+			stateOrderList := newItemListState(orderBook, interestHash, data, nil)
+			mapResult[interest] = stateOrderList.data.Volume
+		}
+	}
+	for interestHash, itemList := range exhangeObject.investingStates {
+		if itemList.Volume().Sign() > 0 {
+			mapResult[new(big.Int).SetBytes(interestHash.Bytes())] = itemList.data.Volume
+		}
+	}
+	listInterest := []*big.Int{}
+	for interest := range mapResult {
+		listInterest = append(listInterest, interest)
+	}
+	sort.Slice(listInterest, func(i, j int) bool {
+		return listInterest[i].Cmp(listInterest[j]) < 0
+	})
+	result := map[*big.Int]*big.Int{}
+	for _, interest := range listInterest {
+		result[interest] = mapResult[interest]
+	}
+	return result, nil
+}
+
+func (self *LendingStateDB) GetBorrowings(orderBook common.Hash) (map[*big.Int]*big.Int, error) {
+	exhangeObject := self.getLendingExchange(orderBook)
+	if exhangeObject == nil {
+		return nil, fmt.Errorf("Order book not found orderBook : %v ", orderBook.Hex())
+	}
+	mapResult := map[*big.Int]*big.Int{}
+	it := trie.NewIterator(exhangeObject.getBorrowingTrie(self.db).NodeIterator(nil))
+	for it.Next() {
+		interestHash := common.BytesToHash(it.Key)
+		if params.EmptyHash(interestHash) {
+			continue
+		}
+		interest := new(big.Int).SetBytes(interestHash.Bytes())
+		if _, exist := exhangeObject.borrowingStates[interestHash]; exist {
+			continue
+		} else {
+			var data itemList
+			if err := rlp.DecodeBytes(it.Value, &data); err != nil {
+				return nil, fmt.Errorf("Fail when decode order iist orderBook : %v ,interest :%v ", orderBook.Hex(), interest)
+			}
+			stateOrderList := newItemListState(orderBook, interestHash, data, nil)
+			mapResult[interest] = stateOrderList.data.Volume
+		}
+	}
+	for interestHash, itemList := range exhangeObject.borrowingStates {
+		if itemList.Volume().Sign() > 0 {
+			mapResult[new(big.Int).SetBytes(interestHash.Bytes())] = itemList.data.Volume
+		}
+	}
+	listInterest := []*big.Int{}
+	for interest := range mapResult {
+		listInterest = append(listInterest, interest)
+	}
+	sort.Slice(listInterest, func(i, j int) bool {
+		return listInterest[i].Cmp(listInterest[j]) < 0
+	})
+	result := map[*big.Int]*big.Int{}
+	for _, interest := range listInterest {
+		result[interest] = mapResult[interest]
+	}
+	return result, nil
+}
+
+func (self *itemListState) DumpItemList(db Database) DumpOrderList {
+	mapResult := DumpOrderList{Volume: self.Volume(), Orders: map[*big.Int]*big.Int{}}
+	orderListIt := trie.NewIterator(self.getTrie(db).NodeIterator(nil))
+	for orderListIt.Next() {
+		keyHash := common.BytesToHash(orderListIt.Key)
+		if params.EmptyHash(keyHash) {
+			continue
+		}
+		if _, exist := self.cachedStorage[keyHash]; exist {
+			continue
+		} else {
+			_, content, _, _ := rlp.Split(orderListIt.Value)
+			mapResult.Orders[new(big.Int).SetBytes(keyHash.Bytes())] = new(big.Int).SetBytes(content)
+		}
+	}
+	for key, value := range self.cachedStorage {
+		if !params.EmptyHash(value) {
+			mapResult.Orders[new(big.Int).SetBytes(key.Bytes())] = new(big.Int).SetBytes(value.Bytes())
+		}
+	}
+	listIds := []*big.Int{}
+	for id := range mapResult.Orders {
+		listIds = append(listIds, id)
+	}
+	sort.Slice(listIds, func(i, j int) bool {
+		return listIds[i].Cmp(listIds[j]) < 0
+	})
+	result := DumpOrderList{Volume: self.Volume(), Orders: map[*big.Int]*big.Int{}}
+	for _, id := range listIds {
+		result.Orders[id] = mapResult.Orders[id]
+	}
+	return result
+}
+
+func (self *LendingStateDB) DumpOrderBookInfo(orderBook common.Hash) (*DumpOrderBookInfo, error) {
+	exhangeObject := self.getLendingExchange(orderBook)
+	if exhangeObject == nil {
+		return nil, fmt.Errorf("Order book not found orderBook : %v ", orderBook.Hex())
+	}
+	result := &DumpOrderBookInfo{}
+	result.Nonce = exhangeObject.data.Nonce
+	result.TradeNonce = exhangeObject.data.TradeNonce
+	result.BestInvesting = new(big.Int).SetBytes(exhangeObject.getBestInvestingInterest(self.db).Bytes())
+	result.BestBorrowing = new(big.Int).SetBytes(exhangeObject.getBestBorrowingInterest(self.db).Bytes())
+	lowestLiquidationTime, _ := exhangeObject.getLowestLiquidationTime(self.db)
+	result.LowestLiquidationTime = new(big.Int).SetBytes(lowestLiquidationTime.Bytes())
+	return result, nil
+}
+
+func (self *liquidationTimeState) DumpItemList(db Database) DumpOrderList {
+	mapResult := DumpOrderList{Volume: self.Volume(), Orders: map[*big.Int]*big.Int{}}
+	orderListIt := trie.NewIterator(self.getTrie(db).NodeIterator(nil))
+	for orderListIt.Next() {
+		keyHash := common.BytesToHash(orderListIt.Key)
+		if params.EmptyHash(keyHash) {
+			continue
+		}
+		if _, exist := self.cachedStorage[keyHash]; exist {
+			continue
+		} else {
+			_, content, _, _ := rlp.Split(orderListIt.Value)
+			mapResult.Orders[new(big.Int).SetBytes(keyHash.Bytes())] = new(big.Int).SetBytes(content)
+		}
+	}
+	for key, value := range self.cachedStorage {
+		if !params.EmptyHash(value) {
+			mapResult.Orders[new(big.Int).SetBytes(key.Bytes())] = new(big.Int).SetBytes(value.Bytes())
+		}
+	}
+	listIds := []*big.Int{}
+	for id := range mapResult.Orders {
+		listIds = append(listIds, id)
+	}
+	sort.Slice(listIds, func(i, j int) bool {
+		return listIds[i].Cmp(listIds[j]) < 0
+	})
+	result := DumpOrderList{Volume: self.Volume(), Orders: map[*big.Int]*big.Int{}}
+	for _, id := range listIds {
+		result.Orders[id] = mapResult.Orders[id]
+	}
+	return mapResult
+}
+func (self *LendingStateDB) DumpLiquidationTimeTrie(orderBook common.Hash) (map[*big.Int]DumpOrderList, error) {
+	exhangeObject := self.getLendingExchange(orderBook)
+	if exhangeObject == nil {
+		return nil, fmt.Errorf("Order book not found orderBook : %v ", orderBook.Hex())
+	}
+	mapResult := map[*big.Int]DumpOrderList{}
+	it := trie.NewIterator(exhangeObject.getLiquidationTimeTrie(self.db).NodeIterator(nil))
+	for it.Next() {
+		unixTimeHash := common.BytesToHash(it.Key)
+		if params.EmptyHash(unixTimeHash) {
+			continue
+		}
+		unixTime := new(big.Int).SetBytes(unixTimeHash.Bytes())
+		if _, exist := exhangeObject.liquidationTimeStates[unixTimeHash]; exist {
+			continue
+		} else {
+			var data itemList
+			if err := rlp.DecodeBytes(it.Value, &data); err != nil {
+				return nil, fmt.Errorf("Fail when decode order iist orderBook : %v ,unixTime :%v ", orderBook.Hex(), unixTime)
+			}
+			stateOrderList := newLiquidationTimeState(orderBook, unixTimeHash, data, nil)
+			mapResult[unixTime] = stateOrderList.DumpItemList(self.db)
+		}
+	}
+	for unixTimeHash, itemList := range exhangeObject.liquidationTimeStates {
+		if itemList.Volume().Sign() > 0 {
+			mapResult[new(big.Int).SetBytes(unixTimeHash.Bytes())] = itemList.DumpItemList(self.db)
+		}
+	}
+	listUnixTime := []*big.Int{}
+	for unixTime := range mapResult {
+		listUnixTime = append(listUnixTime, unixTime)
+	}
+	sort.Slice(listUnixTime, func(i, j int) bool {
+		return listUnixTime[i].Cmp(listUnixTime[j]) < 0
+	})
+	result := map[*big.Int]DumpOrderList{}
+	for _, unixTime := range listUnixTime {
+		result[unixTime] = mapResult[unixTime]
+	}
+	return result, nil
+}
+
+func (self *LendingStateDB) DumpLendingOrderTrie(orderBook common.Hash) (map[*big.Int]LendingItem, error) {
+	exhangeObject := self.getLendingExchange(orderBook)
+	if exhangeObject == nil {
+		return nil, fmt.Errorf("Order book not found orderBook : %v ", orderBook.Hex())
+	}
+	mapResult := map[*big.Int]LendingItem{}
+	it := trie.NewIterator(exhangeObject.getLendingItemTrie(self.db).NodeIterator(nil))
+	for it.Next() {
+		orderIdHash := common.BytesToHash(it.Key)
+		if params.EmptyHash(orderIdHash) {
+			continue
+		}
+		orderId := new(big.Int).SetBytes(orderIdHash.Bytes())
+		if _, exist := exhangeObject.lendingItemStates[orderIdHash]; exist {
+			continue
+		} else {
+			var data LendingItem
+			if err := rlp.DecodeBytes(it.Value, &data); err != nil {
+				return nil, fmt.Errorf("Fail when decode order iist orderBook : %v ,orderId :%v ", orderBook.Hex(), orderId)
+			}
+			mapResult[orderId] = data
+		}
+	}
+	for orderIdHash, lendingOrder := range exhangeObject.lendingItemStates {
+		mapResult[new(big.Int).SetBytes(orderIdHash.Bytes())] = lendingOrder.data
+	}
+	listOrderId := []*big.Int{}
+	for orderId := range mapResult {
+		listOrderId = append(listOrderId, orderId)
+	}
+	sort.Slice(listOrderId, func(i, j int) bool {
+		return listOrderId[i].Cmp(listOrderId[j]) < 0
+	})
+	result := map[*big.Int]LendingItem{}
+	for _, orderId := range listOrderId {
+		result[orderId] = mapResult[orderId]
+	}
+	return result, nil
+}
+
+func (self *LendingStateDB) DumpLendingTradeTrie(orderBook common.Hash) (map[*big.Int]LendingTrade, error) {
+	exhangeObject := self.getLendingExchange(orderBook)
+	if exhangeObject == nil {
+		return nil, fmt.Errorf("Order book not found orderBook : %v ", orderBook.Hex())
+	}
+	mapResult := map[*big.Int]LendingTrade{}
+	it := trie.NewIterator(exhangeObject.getLendingTradeTrie(self.db).NodeIterator(nil))
+	for it.Next() {
+		tradeIdHash := common.BytesToHash(it.Key)
+		if params.EmptyHash(tradeIdHash) {
+			continue
+		}
+		tradeId := new(big.Int).SetBytes(tradeIdHash.Bytes())
+		if _, exist := exhangeObject.lendingTradeStates[tradeIdHash]; exist {
+			continue
+		} else {
+			var data LendingTrade
+			if err := rlp.DecodeBytes(it.Value, &data); err != nil {
+				return nil, fmt.Errorf("Fail when decode order iist orderBook : %v ,tradeId :%v ", orderBook.Hex(), tradeId)
+			}
+			mapResult[tradeId] = data
+		}
+	}
+	for tradeIdHash, lendingTrade := range exhangeObject.lendingTradeStates {
+		mapResult[new(big.Int).SetBytes(tradeIdHash.Bytes())] = lendingTrade.data
+	}
+	listTradeId := []*big.Int{}
+	for tradeId := range mapResult {
+		listTradeId = append(listTradeId, tradeId)
+	}
+	sort.Slice(listTradeId, func(i, j int) bool {
+		return listTradeId[i].Cmp(listTradeId[j]) < 0
+	})
+	result := map[*big.Int]LendingTrade{}
+	for _, tradeId := range listTradeId {
+		result[tradeId] = mapResult[tradeId]
+	}
+	return result, nil
+}

--- a/legacy/tomoxlending/lendingstate/journal.go
+++ b/legacy/tomoxlending/lendingstate/journal.go
@@ -1,0 +1,138 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package lendingstate
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"math/big"
+)
+
+type journalEntry interface {
+	undo(db *LendingStateDB)
+}
+
+type journal []journalEntry
+
+type (
+	// Changes to the account trie.
+	insertOrder struct {
+		orderBook common.Hash
+		orderId   common.Hash
+		order     *LendingItem
+	}
+	insertTrading struct {
+		orderBook common.Hash
+		tradeId   uint64
+		prvTrade  *LendingTrade
+	}
+	cancelOrder struct {
+		orderBook common.Hash
+		orderId   common.Hash
+		order     LendingItem
+	}
+	cancelTrading struct {
+		orderBook common.Hash
+		tradeId   uint64
+		order     LendingTrade
+	}
+	subAmountOrder struct {
+		orderBook common.Hash
+		orderId   common.Hash
+		order     LendingItem
+		amount    *big.Int
+	}
+	nonceChange struct {
+		hash common.Hash
+		prev uint64
+	}
+	tradeNonceChange struct {
+		hash common.Hash
+		prev uint64
+	}
+	liquidationPriceChange struct {
+		orderBook common.Hash
+		tradeId   common.Hash
+		prev      *big.Int
+	}
+	collateralLockedAmount struct {
+		orderBook common.Hash
+		tradeId   common.Hash
+		prev      *big.Int
+	}
+)
+
+func (ch insertOrder) undo(s *LendingStateDB) {
+	s.CancelLendingOrder(ch.orderBook, ch.order)
+}
+func (ch cancelOrder) undo(s *LendingStateDB) {
+	s.InsertLendingItem(ch.orderBook, ch.orderId, ch.order)
+}
+func (ch subAmountOrder) undo(s *LendingStateDB) {
+	interestHash := common.BigToHash(ch.order.Interest)
+	stateOrderBook := s.getLendingExchange(ch.orderBook)
+	var stateOrderList *itemListState
+	switch ch.order.Side {
+	case Investing:
+		stateOrderList = stateOrderBook.getInvestingOrderList(s.db, interestHash)
+	case Borrowing:
+		stateOrderList = stateOrderBook.getBorrowingOrderList(s.db, interestHash)
+	default:
+		return
+	}
+	stateOrderItem := stateOrderBook.getLendingItem(s.db, ch.orderId)
+	newAmount := new(big.Int).Add(stateOrderItem.Quantity(), ch.amount)
+	stateOrderItem.setVolume(newAmount)
+	stateOrderList.insertLendingItem(s.db, ch.orderId, common.BigToHash(newAmount))
+	stateOrderList.AddVolume(ch.amount)
+}
+func (ch nonceChange) undo(s *LendingStateDB) {
+	s.SetNonce(ch.hash, ch.prev)
+}
+
+func (ch tradeNonceChange) undo(s *LendingStateDB) {
+	s.SetTradeNonce(ch.hash, ch.prev)
+}
+func (ch cancelTrading) undo(s *LendingStateDB) {
+	s.InsertTradingItem(ch.orderBook, ch.tradeId, ch.order)
+}
+func (ch insertTrading) undo(s *LendingStateDB) {
+	s.InsertTradingItem(ch.orderBook, ch.tradeId, *ch.prvTrade)
+}
+
+func (ch liquidationPriceChange) undo(s *LendingStateDB) {
+	stateOrderBook := s.getLendingExchange(ch.orderBook)
+	if stateOrderBook == nil {
+		return
+	}
+	stateLendingTrade := stateOrderBook.getLendingTrade(s.db, ch.tradeId)
+	if stateLendingTrade == nil {
+		return
+	}
+	stateLendingTrade.SetLiquidationPrice(ch.prev)
+}
+
+func (ch collateralLockedAmount) undo(s *LendingStateDB) {
+	stateOrderBook := s.getLendingExchange(ch.orderBook)
+	if stateOrderBook == nil {
+		return
+	}
+	stateLendingTrade := stateOrderBook.getLendingTrade(s.db, ch.tradeId)
+	if stateLendingTrade == nil {
+		return
+	}
+	stateLendingTrade.SetCollateralLockedAmount(ch.prev)
+}

--- a/legacy/tomoxlending/lendingstate/lendingcontract.go
+++ b/legacy/tomoxlending/lendingstate/lendingcontract.go
@@ -1,0 +1,315 @@
+package lendingstate
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+	tradingstate "github.com/ethereum/go-ethereum/legacy/tomox/tradingstate"
+)
+
+const (
+	// LendingRegistrationSMC is the address of the on-chain lending registration contract.
+	LendingRegistrationSMC = "0x7d761afd7ff65a79e4173897594a194e3c506e57"
+)
+
+var (
+	LendingRelayerListSlot    = uint64(0)
+	CollateralMapSlot         = uint64(1)
+	DefaultCollateralSlot     = uint64(2)
+	SupportedBaseSlot         = uint64(3)
+	SupportedTermSlot         = uint64(4)
+	ILOCollateralSlot         = uint64(5)
+	LendingRelayerStructSlots = map[string]*big.Int{
+		"fee":         big.NewInt(0),
+		"bases":       big.NewInt(1),
+		"terms":       big.NewInt(2),
+		"collaterals": big.NewInt(3),
+	}
+	CollateralStructSlots = map[string]*big.Int{
+		"depositRate":     big.NewInt(0),
+		"liquidationRate": big.NewInt(1),
+		"recallRate":      big.NewInt(2),
+		"price":           big.NewInt(3),
+	}
+	PriceStructSlots = map[string]*big.Int{
+		"price":       big.NewInt(0),
+		"blockNumber": big.NewInt(1),
+	}
+)
+
+// locSimpleVariable returns the storage location of a simple (non-mapping, non-array) variable at the given slot.
+func locSimpleVariable(slot uint64) common.Hash {
+	return common.BigToHash(new(big.Int).SetUint64(slot))
+}
+
+// locDynamicArrAtElement returns the storage location of an element in a dynamic array.
+func locDynamicArrAtElement(slotHash common.Hash, index uint64, elementSize uint64) common.Hash {
+	slotKecBig := crypto.Keccak256Hash(slotHash.Bytes()).Big()
+	arrBig := slotKecBig.Add(slotKecBig, new(big.Int).SetUint64(index*elementSize))
+	return common.BigToHash(arrBig)
+}
+
+// locOfStructElement returns the storage location of a struct field.
+func locOfStructElement(locOfStruct *big.Int, elementSlotInStruct *big.Int) common.Hash {
+	return common.BigToHash(new(big.Int).Add(locOfStruct, elementSlotInStruct))
+}
+
+// @function IsValidRelayer : return whether the given address is the coinbase of a valid relayer or not
+// @param statedb : current state
+// @param coinbase: coinbase address of relayer
+// @return: true if it's a valid coinbase address of lending protocol, otherwise return false
+func IsValidRelayer(statedb *state.StateDB, coinbase common.Address) bool {
+	locRelayerState := GetLocMappingAtKey(coinbase.Hash(), LendingRelayerListSlot)
+
+	// a valid relayer must have baseToken
+	locBaseToken := locOfStructElement(locRelayerState, LendingRelayerStructSlots["bases"])
+	if v := statedb.GetState(common.HexToAddress(LendingRegistrationSMC), common.BytesToHash(locBaseToken.Bytes())); v != (common.Hash{}) {
+		if tradingstate.IsResignedRelayer(coinbase, statedb) {
+			return false
+		}
+		slot := tradingstate.RelayerMappingSlot["RELAYER_LIST"]
+		locRelayerStateTrading := GetLocMappingAtKey(coinbase.Hash(), slot)
+
+		locBigDeposit := new(big.Int).SetUint64(uint64(0)).Add(locRelayerStateTrading, tradingstate.RelayerStructMappingSlot["_deposit"])
+		locHashDeposit := common.BigToHash(locBigDeposit)
+		balance := statedb.GetState(common.HexToAddress(tradingstate.RelayerRegistrationSMC), locHashDeposit).Big()
+		expectedFund := new(big.Int).Mul(tradingstate.BasePrice, tradingstate.RelayerLockedFund)
+		if balance.Cmp(expectedFund) <= 0 {
+			log.Debug("Relayer is not in relayer list", "relayer", coinbase.String(), "balance", balance, "expected", expectedFund)
+			return false
+		}
+		return true
+	}
+	return false
+}
+
+// @function GetFee
+// @param statedb : current state
+// @param coinbase: coinbase address of relayer
+// @return: feeRate of lending
+func GetFee(statedb *state.StateDB, coinbase common.Address) *big.Int {
+	locRelayerState := GetLocMappingAtKey(coinbase.Hash(), LendingRelayerListSlot)
+	locHash := common.BytesToHash(new(big.Int).Add(locRelayerState, LendingRelayerStructSlots["fee"]).Bytes())
+	return statedb.GetState(common.HexToAddress(LendingRegistrationSMC), locHash).Big()
+}
+
+// @function GetBaseList
+// @param statedb : current state
+// @param coinbase: coinbase address of relayer
+// @return: list of base tokens
+func GetBaseList(statedb *state.StateDB, coinbase common.Address) []common.Address {
+	baseList := []common.Address{}
+	locRelayerState := GetLocMappingAtKey(coinbase.Hash(), LendingRelayerListSlot)
+	locBaseHash := locOfStructElement(locRelayerState, LendingRelayerStructSlots["bases"])
+	length := statedb.GetState(common.HexToAddress(LendingRegistrationSMC), locBaseHash).Big().Uint64()
+	for i := uint64(0); i < length; i++ {
+		loc := locDynamicArrAtElement(locBaseHash, i, 1)
+		addr := common.BytesToAddress(statedb.GetState(common.HexToAddress(LendingRegistrationSMC), loc).Bytes())
+		if addr != (common.Address{}) {
+			baseList = append(baseList, addr)
+		}
+	}
+	return baseList
+}
+
+// @function GetTerms
+// @param statedb : current state
+// @param coinbase: coinbase address of relayer
+// @return: list of supported terms of the given relayer
+func GetTerms(statedb *state.StateDB, coinbase common.Address) []uint64 {
+	terms := []uint64{}
+	locRelayerState := GetLocMappingAtKey(coinbase.Hash(), LendingRelayerListSlot)
+	locTermHash := locOfStructElement(locRelayerState, LendingRelayerStructSlots["terms"])
+	length := statedb.GetState(common.HexToAddress(LendingRegistrationSMC), locTermHash).Big().Uint64()
+	for i := uint64(0); i < length; i++ {
+		loc := locDynamicArrAtElement(locTermHash, i, 1)
+		t := statedb.GetState(common.HexToAddress(LendingRegistrationSMC), loc).Big().Uint64()
+		if t != uint64(0) {
+			terms = append(terms, t)
+		}
+	}
+	return terms
+}
+
+// @function IsValidPair
+// @param statedb : current state
+// @param coinbase: coinbase address of relayer
+// @param baseToken: address of baseToken
+// @param terms: term
+// @return: TRUE if the given baseToken, term organize a valid pair
+func IsValidPair(statedb *state.StateDB, coinbase common.Address, baseToken common.Address, term uint64) (valid bool, pairIndex uint64) {
+	baseTokenList := GetBaseList(statedb, coinbase)
+	terms := GetTerms(statedb, coinbase)
+	baseIndexes := []uint64{}
+	for i := uint64(0); i < uint64(len(baseTokenList)); i++ {
+		if baseTokenList[i] == baseToken {
+			baseIndexes = append(baseIndexes, i)
+		}
+	}
+	for _, index := range baseIndexes {
+		if terms[index] == term {
+			pairIndex = index
+			return true, pairIndex
+		}
+	}
+	return false, pairIndex
+}
+
+// @function GetCollaterals
+// @param statedb : current state
+// @param coinbase: coinbase address of relayer
+// @param baseToken: address of baseToken
+// @param terms: term
+// @return:
+//   - collaterals []common.Address  : list of addresses of collateral
+//   - isSpecialCollateral           : TRUE if collateral is a token which is NOT available for trading in TomoX, otherwise FALSE
+func GetCollaterals(statedb *state.StateDB, coinbase common.Address, baseToken common.Address, term uint64) (collaterals []common.Address, isSpecialCollateral bool) {
+	validPair, _ := IsValidPair(statedb, coinbase, baseToken, term)
+	if !validPair {
+		return []common.Address{}, false
+	}
+
+	// if collaterals is not defined for the relayer, return default collaterals
+	locDefaultCollateralHash := locSimpleVariable(DefaultCollateralSlot)
+	length := statedb.GetState(common.HexToAddress(LendingRegistrationSMC), locDefaultCollateralHash).Big().Uint64()
+	for i := uint64(0); i < length; i++ {
+		loc := locDynamicArrAtElement(locDefaultCollateralHash, i, 1)
+		addr := common.BytesToAddress(statedb.GetState(common.HexToAddress(LendingRegistrationSMC), loc).Bytes())
+		if addr != (common.Address{}) {
+			collaterals = append(collaterals, addr)
+		}
+	}
+	return collaterals, false
+}
+
+// @function GetCollateralDetail
+// @param statedb : current state
+// @param token: address of collateral token
+// @return: depositRate, liquidationRate, price of collateral
+func GetCollateralDetail(statedb *state.StateDB, token common.Address) (depositRate, liquidationRate, recallRate *big.Int) {
+	collateralState := GetLocMappingAtKey(token.Hash(), CollateralMapSlot)
+	locDepositRate := locOfStructElement(collateralState, CollateralStructSlots["depositRate"])
+	locLiquidationRate := locOfStructElement(collateralState, CollateralStructSlots["liquidationRate"])
+	locRecallRate := locOfStructElement(collateralState, CollateralStructSlots["recallRate"])
+	depositRate = statedb.GetState(common.HexToAddress(LendingRegistrationSMC), locDepositRate).Big()
+	liquidationRate = statedb.GetState(common.HexToAddress(LendingRegistrationSMC), locLiquidationRate).Big()
+	recallRate = statedb.GetState(common.HexToAddress(LendingRegistrationSMC), locRecallRate).Big()
+	return depositRate, liquidationRate, recallRate
+}
+
+func GetCollateralPrice(statedb *state.StateDB, collateralToken common.Address, lendingToken common.Address) (price, blockNumber *big.Int) {
+	collateralState := GetLocMappingAtKey(collateralToken.Hash(), CollateralMapSlot)
+	locMapPrices := collateralState.Add(collateralState, CollateralStructSlots["price"])
+	locLendingTokenPriceByte := crypto.Keccak256(lendingToken.Hash().Bytes(), common.BigToHash(locMapPrices).Bytes())
+
+	locCollateralPrice := common.BigToHash(new(big.Int).Add(new(big.Int).SetBytes(locLendingTokenPriceByte), PriceStructSlots["price"]))
+	locBlockNumber := common.BigToHash(new(big.Int).Add(new(big.Int).SetBytes(locLendingTokenPriceByte), PriceStructSlots["blockNumber"]))
+
+	price = statedb.GetState(common.HexToAddress(LendingRegistrationSMC), locCollateralPrice).Big()
+	blockNumber = statedb.GetState(common.HexToAddress(LendingRegistrationSMC), locBlockNumber).Big()
+	return price, blockNumber
+}
+
+// @function GetSupportedTerms
+// @param statedb : current state
+// @return: list of terms which tomoxlending supports
+func GetSupportedTerms(statedb *state.StateDB) []uint64 {
+	terms := []uint64{}
+	locSupportedTerm := locSimpleVariable(SupportedTermSlot)
+	length := statedb.GetState(common.HexToAddress(LendingRegistrationSMC), locSupportedTerm).Big().Uint64()
+	for i := uint64(0); i < length; i++ {
+		loc := locDynamicArrAtElement(locSupportedTerm, i, 1)
+		t := statedb.GetState(common.HexToAddress(LendingRegistrationSMC), loc).Big().Uint64()
+		if t != 0 {
+			terms = append(terms, t)
+		}
+	}
+	return terms
+}
+
+// @function GetSupportedBaseToken
+// @param statedb : current state
+// @return: list of tokens which are available for lending
+func GetSupportedBaseToken(statedb *state.StateDB) []common.Address {
+	baseTokens := []common.Address{}
+	locSupportedBaseToken := locSimpleVariable(SupportedBaseSlot)
+	length := statedb.GetState(common.HexToAddress(LendingRegistrationSMC), locSupportedBaseToken).Big().Uint64()
+	for i := uint64(0); i < length; i++ {
+		loc := locDynamicArrAtElement(locSupportedBaseToken, i, 1)
+		addr := common.BytesToAddress(statedb.GetState(common.HexToAddress(LendingRegistrationSMC), loc).Bytes())
+		if addr != (common.Address{}) {
+			baseTokens = append(baseTokens, addr)
+		}
+	}
+	return baseTokens
+}
+
+// @function GetAllCollateral
+// @param statedb : current state
+// @return: list of address of collateral token
+func GetAllCollateral(statedb *state.StateDB) []common.Address {
+	collaterals := []common.Address{}
+
+	locDefaultCollateralHash := locSimpleVariable(DefaultCollateralSlot)
+	length := statedb.GetState(common.HexToAddress(LendingRegistrationSMC), locDefaultCollateralHash).Big().Uint64()
+	for i := uint64(0); i < length; i++ {
+		loc := locDynamicArrAtElement(locDefaultCollateralHash, i, 1)
+		addr := common.BytesToAddress(statedb.GetState(common.HexToAddress(LendingRegistrationSMC), loc).Bytes())
+		if addr != (common.Address{}) {
+			collaterals = append(collaterals, addr)
+		}
+	}
+	return collaterals
+}
+
+// @function GetAllLendingBooks
+// @param statedb : current state
+// @return: a map to specify whether lendingBook (combination of baseToken and term) is valid or not
+func GetAllLendingBooks(statedb *state.StateDB) (mapLendingBook map[common.Hash]bool, err error) {
+	mapLendingBook = make(map[common.Hash]bool)
+	baseTokens := GetSupportedBaseToken(statedb)
+	terms := GetSupportedTerms(statedb)
+	if len(baseTokens) == 0 {
+		return nil, fmt.Errorf("GetAllLendingBooks: empty baseToken list")
+	}
+	if len(terms) == 0 {
+		return nil, fmt.Errorf("GetAllLendingPairs: empty term list")
+	}
+	for _, baseToken := range baseTokens {
+		for _, term := range terms {
+			if (baseToken != common.Address{}) && (term > 0) {
+				mapLendingBook[GetLendingOrderBookHash(baseToken, term)] = true
+			}
+		}
+	}
+	return mapLendingBook, nil
+}
+
+// @function GetAllLendingPairs
+// @param statedb : current state
+// @return: list of lendingPair (combination of baseToken and collateralToken)
+func GetAllLendingPairs(statedb *state.StateDB) (allPairs []LendingPair, err error) {
+	baseTokens := GetSupportedBaseToken(statedb)
+	collaterals := GetAllCollateral(statedb)
+	if len(baseTokens) == 0 {
+		return allPairs, fmt.Errorf("GetAllLendingPairs: empty baseToken list")
+	}
+	if len(collaterals) == 0 {
+		return allPairs, fmt.Errorf("GetAllLendingPairs: empty collateral list")
+	}
+	for _, baseToken := range baseTokens {
+		for _, collateral := range collaterals {
+			if (baseToken != common.Address{}) && (collateral != common.Address{}) {
+				allPairs = append(allPairs, LendingPair{
+					LendingToken:    baseToken,
+					CollateralToken: collateral,
+				})
+			}
+		}
+	}
+	return allPairs, nil
+}

--- a/legacy/tomoxlending/lendingstate/lendingitem.go
+++ b/legacy/tomoxlending/lendingstate/lendingitem.go
@@ -1,0 +1,326 @@
+package lendingstate
+
+import (
+	"fmt"
+	"math/big"
+	"strconv"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/crypto"
+	tradingstate "github.com/ethereum/go-ethereum/legacy/tomox/tradingstate"
+	"github.com/ethereum/go-ethereum/params"
+	"golang.org/x/crypto/sha3"
+)
+
+const (
+	Investing                  = "INVEST"
+	Borrowing                  = "BORROW"
+	TopUp                      = "TOPUP"
+	Repay                      = "REPAY"
+	Recall                     = "RECALL"
+	LendingStatusNew           = "NEW"
+	LendingStatusOpen          = "OPEN"
+	LendingStatusReject        = "REJECTED"
+	LendingStatusFilled        = "FILLED"
+	LendingStatusPartialFilled = "PARTIAL_FILLED"
+	LendingStatusCancelled     = "CANCELLED"
+	Market                     = "MO"
+	Limit                      = "LO"
+)
+
+var ValidInputLendingStatus = map[string]bool{
+	LendingStatusNew:       true,
+	LendingStatusCancelled: true,
+}
+
+var ValidInputLendingType = map[string]bool{
+	Market: true,
+	Limit:  true,
+	Repay:  true,
+	TopUp:  true,
+	Recall: true,
+}
+
+// Signature struct
+type Signature struct {
+	V byte        `json:"v"`
+	R common.Hash `json:"r"`
+	S common.Hash `json:"s"`
+}
+
+type LendingItem struct {
+	Quantity        *big.Int       `json:"quantity"`
+	Interest        *big.Int       `json:"interest"`
+	Side            string         `json:"side"` // INVESTING/BORROWING
+	Type            string         `json:"type"` // LIMIT/MARKET
+	LendingToken    common.Address `json:"lendingToken"`
+	CollateralToken common.Address `json:"collateralToken"`
+	AutoTopUp       bool           `json:"autoTopUp"`
+	FilledAmount    *big.Int       `json:"filledAmount"`
+	Status          string         `json:"status"`
+	Relayer         common.Address `json:"relayer"`
+	Term            uint64         `json:"term"`
+	UserAddress     common.Address `json:"userAddress"`
+	Signature       *Signature     `json:"signature"`
+	Hash            common.Hash    `json:"hash"`
+	TxHash          common.Hash    `json:"txHash"`
+	Nonce           *big.Int       `json:"nonce"`
+	CreatedAt       time.Time      `json:"createdAt"`
+	UpdatedAt       time.Time      `json:"updatedAt"`
+	LendingId       uint64         `json:"lendingId"`
+	LendingTradeId  uint64         `json:"tradeId"`
+	ExtraData       string         `json:"extraData"`
+}
+
+func (l *LendingItem) VerifyLendingItem(state *state.StateDB) error {
+	if err := l.VerifyLendingStatus(); err != nil {
+		return err
+	}
+	if valid, _ := IsValidPair(state, l.Relayer, l.LendingToken, l.Term); valid == false {
+		return fmt.Errorf("invalid pair . LendToken %s . Term: %v", l.LendingToken.Hex(), l.Term)
+	}
+	if l.Status == LendingStatusNew {
+		if err := l.VerifyLendingType(); err != nil {
+			return err
+		}
+		if l.Type != Repay {
+			if err := l.VerifyLendingQuantity(); err != nil {
+				return err
+			}
+		}
+		if l.Type == Limit || l.Type == Market {
+			if err := l.VerifyLendingSide(); err != nil {
+				return err
+			}
+			if l.Side == Borrowing {
+				if err := l.VerifyCollateral(state); err != nil {
+					return err
+				}
+			}
+		}
+		if l.Type == Limit {
+			if err := l.VerifyLendingInterest(); err != nil {
+				return err
+			}
+		}
+	}
+	if !IsValidRelayer(state, l.Relayer) {
+		return fmt.Errorf("VerifyLendingItem: invalid relayer. address: %s", l.Relayer.Hex())
+	}
+	return nil
+}
+
+func (l *LendingItem) VerifyLendingSide() error {
+	if l.Side != Borrowing && l.Side != Investing {
+		return fmt.Errorf("VerifyLendingSide: invalid side . Side: %s", l.Side)
+	}
+	return nil
+}
+
+func (l *LendingItem) VerifyCollateral(state *state.StateDB) error {
+	if l.CollateralToken.String() == EmptyAddress || l.CollateralToken.String() == l.LendingToken.String() {
+		return fmt.Errorf("invalid collateral %s", l.CollateralToken.Hex())
+	}
+	validCollateral := false
+	collateralList, _ := GetCollaterals(state, l.Relayer, l.LendingToken, l.Term)
+	for _, collateral := range collateralList {
+		if l.CollateralToken.String() == collateral.String() {
+			validCollateral = true
+			break
+		}
+	}
+	if !validCollateral {
+		return fmt.Errorf("invalid collateral %s", l.CollateralToken.Hex())
+	}
+	return nil
+}
+
+func (l *LendingItem) VerifyLendingInterest() error {
+	if l.Interest == nil || l.Interest.Sign() <= 0 {
+		return fmt.Errorf("VerifyLendingInterest: invalid interest. Interest: %v", l.Interest)
+	}
+	return nil
+}
+
+func (l *LendingItem) VerifyLendingQuantity() error {
+	if l.Quantity == nil || l.Quantity.Sign() <= 0 {
+		return fmt.Errorf("VerifyLendingQuantity: invalid quantity. Quantity: %v", l.Quantity)
+	}
+	return nil
+}
+
+func (l *LendingItem) VerifyLendingType() error {
+	if valid, ok := ValidInputLendingType[l.Type]; !ok && !valid {
+		return fmt.Errorf("VerifyLendingType: invalid lending type. Type: %s", l.Type)
+	}
+	return nil
+}
+
+func (l *LendingItem) VerifyLendingStatus() error {
+	if valid, ok := ValidInputLendingStatus[l.Status]; !ok && !valid {
+		return fmt.Errorf("VerifyLendingStatus: invalid lending status. Status: %s", l.Status)
+	}
+	return nil
+}
+
+func (l *LendingItem) ComputeHash() common.Hash {
+	sha := sha3.NewLegacyKeccak256().(crypto.KeccakState)
+	if l.Status == LendingStatusNew {
+		sha.Write(l.Relayer.Bytes())
+		sha.Write(l.UserAddress.Bytes())
+		sha.Write(l.LendingToken.Bytes())
+		sha.Write(l.CollateralToken.Bytes())
+		sha.Write([]byte(strconv.FormatInt(int64(l.Term), 10)))
+		sha.Write(common.BigToHash(l.Quantity).Bytes())
+		if l.Type == Limit {
+			if l.Interest != nil {
+				sha.Write(common.BigToHash(l.Interest).Bytes())
+			}
+		}
+		sha.Write(common.BigToHash(l.EncodedSide()).Bytes())
+		sha.Write([]byte(l.Status))
+		sha.Write([]byte(l.Type))
+		sha.Write(common.BigToHash(l.Nonce).Bytes())
+	} else if l.Status == LendingStatusCancelled {
+		sha.Write(l.Hash.Bytes())
+		sha.Write(common.BigToHash(l.Nonce).Bytes())
+		sha.Write(l.UserAddress.Bytes())
+		sha.Write(common.BigToHash(big.NewInt(int64(l.LendingId))).Bytes())
+		sha.Write([]byte(l.Status))
+		sha.Write(l.Relayer.Bytes())
+		sha.Write(l.LendingToken.Bytes())
+		sha.Write(l.CollateralToken.Bytes())
+	} else {
+		return common.Hash{}
+	}
+
+	var result [32]byte
+	sha.Read(result[:])
+	return common.BytesToHash(result[:])
+}
+
+func (l *LendingItem) EncodedSide() *big.Int {
+	if l.Side == Borrowing {
+		return big.NewInt(0)
+	}
+	return big.NewInt(1)
+}
+
+func VerifyBalance(isTomoXLendingFork bool, statedb *state.StateDB, lendingStateDb *LendingStateDB,
+	orderType, side, status string, userAddress, relayer, lendingToken, collateralToken common.Address,
+	quantity, lendingTokenDecimal, collateralTokenDecimal, lendTokenTOMOPrice, collateralPrice *big.Int,
+	term uint64, lendingId uint64, lendingTradeId uint64) error {
+	borrowingFeeRate := GetFee(statedb, relayer)
+	switch orderType {
+	case TopUp:
+		lendingBook := GetLendingOrderBookHash(lendingToken, term)
+		lendingTrade := lendingStateDb.GetLendingTrade(lendingBook, params.Uint64ToHash(lendingTradeId))
+		if lendingTrade == EmptyLendingTrade {
+			return fmt.Errorf("VerifyBalance: process deposit for emptyLendingTrade is not allowed. lendingTradeId: %v", lendingTradeId)
+		}
+		tokenBalance := GetTokenBalance(lendingTrade.Borrower, lendingTrade.CollateralToken, statedb)
+		if tokenBalance.Cmp(quantity) < 0 {
+			return fmt.Errorf("VerifyBalance: not enough balance to process deposit for lendingTrade."+
+				"lendingTradeId: %v. Token: %s. ExpectedBalance: %s. ActualBalance: %s",
+				lendingTradeId, lendingTrade.CollateralToken.Hex(), quantity.String(), tokenBalance.String())
+		}
+	case Repay:
+		lendingBook := GetLendingOrderBookHash(lendingToken, term)
+		lendingTrade := lendingStateDb.GetLendingTrade(lendingBook, params.Uint64ToHash(lendingTradeId))
+		if lendingTrade == EmptyLendingTrade {
+			return fmt.Errorf("VerifyBalance: process payment for emptyLendingTrade is not allowed. lendingTradeId: %v", lendingTradeId)
+		}
+		tokenBalance := GetTokenBalance(lendingTrade.Borrower, lendingTrade.LendingToken, statedb)
+		paymentBalance := CalculateTotalRepayValue(uint64(time.Now().Unix()), lendingTrade.LiquidationTime, lendingTrade.Term, lendingTrade.Interest, lendingTrade.Amount)
+
+		if tokenBalance.Cmp(paymentBalance) < 0 {
+			return fmt.Errorf("VerifyBalance: not enough balance to process payment for lendingTrade."+
+				"lendingTradeId: %v. Token: %s. ExpectedBalance: %s. ActualBalance: %s",
+				lendingTradeId, lendingTrade.LendingToken.Hex(), paymentBalance.String(), tokenBalance.String())
+
+		}
+	case Market, Limit:
+		switch side {
+		case Investing:
+			switch status {
+			case LendingStatusNew:
+				// make sure that investor have enough lendingToken
+				if balance := GetTokenBalance(userAddress, lendingToken, statedb); balance.Cmp(quantity) < 0 {
+					return fmt.Errorf("VerifyBalance: investor doesn't have enough lendingToken. User: %s. Token: %s. Expected: %v. Have: %v", userAddress.Hex(), lendingToken.Hex(), quantity, balance)
+				}
+				// check quantity: reject if it's too small
+				if lendTokenTOMOPrice != nil && lendTokenTOMOPrice.Sign() > 0 {
+					defaultFee := new(big.Int).Mul(quantity, new(big.Int).SetUint64(DefaultFeeRate))
+					defaultFee = new(big.Int).Div(defaultFee, tradingstate.TomoXBaseFee)
+					defaultFeeInTOMO := common.Big0
+					if lendingToken.String() != tradingstate.TomoNativeAddress {
+						defaultFeeInTOMO = new(big.Int).Mul(defaultFee, lendTokenTOMOPrice)
+						defaultFeeInTOMO = new(big.Int).Div(defaultFeeInTOMO, lendingTokenDecimal)
+					} else {
+						defaultFeeInTOMO = defaultFee
+					}
+					if defaultFeeInTOMO.Cmp(RelayerLendingFee) <= 0 {
+						return ErrQuantityTradeTooSmall
+					}
+
+				}
+
+			case LendingStatusCancelled:
+				// in case of cancel, investor need to pay cancel fee in lendingToken
+				// make sure actualBalance >= cancel fee
+				lendingBook := GetLendingOrderBookHash(lendingToken, term)
+				item := lendingStateDb.GetLendingOrder(lendingBook, common.BigToHash(new(big.Int).SetUint64(lendingId)))
+				cancelFee := big.NewInt(0)
+				cancelFee = new(big.Int).Mul(item.Quantity, borrowingFeeRate)
+				cancelFee = new(big.Int).Div(cancelFee, tradingstate.TomoXBaseCancelFee)
+
+				actualBalance := GetTokenBalance(userAddress, lendingToken, statedb)
+				if actualBalance.Cmp(cancelFee) < 0 {
+					return fmt.Errorf("VerifyBalance: investor doesn't have enough lendingToken to pay cancel fee. LendingToken: %s . ExpectedBalance: %s . ActualBalance: %s",
+						lendingToken.Hex(), cancelFee.String(), actualBalance.String())
+				}
+			default:
+				return fmt.Errorf("VerifyBalance: invalid status of investing lendingitem. Status: %s", status)
+			}
+			return nil
+		case Borrowing:
+			switch status {
+			case LendingStatusNew:
+				depositRate, _, _ := GetCollateralDetail(statedb, collateralToken)
+				settleBalanceResult, err := GetSettleBalance(isTomoXLendingFork, Borrowing, lendTokenTOMOPrice, collateralPrice, depositRate, borrowingFeeRate, lendingToken, collateralToken, lendingTokenDecimal, collateralTokenDecimal, quantity)
+				if err != nil {
+					return err
+				}
+				expectedBalance := settleBalanceResult.CollateralLockedAmount
+				actualBalance := GetTokenBalance(userAddress, collateralToken, statedb)
+				if actualBalance.Cmp(expectedBalance) < 0 {
+					return fmt.Errorf("VerifyBalance: borrower doesn't have enough collateral token.  User: %s. CollateralToken: %s . ExpectedBalance: %s . ActualBalance: %s",
+						userAddress.Hex(), collateralToken.Hex(), expectedBalance.String(), actualBalance.String())
+				}
+			case LendingStatusCancelled:
+				lendingBook := GetLendingOrderBookHash(lendingToken, term)
+				item := lendingStateDb.GetLendingOrder(lendingBook, common.BigToHash(new(big.Int).SetUint64(lendingId)))
+				cancelFee := big.NewInt(0)
+				// Fee ==  quantityToLend/base lend token decimal *price*borrowFee/LendingCancelFee
+				cancelFee = new(big.Int).Div(item.Quantity, collateralPrice)
+				cancelFee = new(big.Int).Mul(cancelFee, borrowingFeeRate)
+				cancelFee = new(big.Int).Div(cancelFee, tradingstate.TomoXBaseCancelFee)
+				actualBalance := GetTokenBalance(userAddress, collateralToken, statedb)
+				if actualBalance.Cmp(cancelFee) < 0 {
+					return fmt.Errorf("VerifyBalance: borrower doesn't have enough collateralToken to pay cancel fee. User: %s. CollateralToken: %s . ExpectedBalance: %s . ActualBalance: %s",
+						userAddress.Hex(), lendingToken.Hex(), cancelFee.String(), actualBalance.String())
+				}
+			default:
+				return fmt.Errorf("VerifyBalance: invalid status of borrowing lendingitem. Status: %s", status)
+			}
+			return nil
+		default:
+			return fmt.Errorf("VerifyBalance: unknown lending side")
+		}
+	default:
+		return fmt.Errorf("VerifyBalance: unknown lending type")
+	}
+	return nil
+}

--- a/legacy/tomoxlending/lendingstate/managed_state.go
+++ b/legacy/tomoxlending/lendingstate/managed_state.go
@@ -1,0 +1,140 @@
+// Copyright 2015 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package lendingstate
+
+import (
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type exchanges struct {
+	stateObject *lendingExchangeState
+	nstart      uint64
+	nonces      []bool
+}
+
+type LendingManagedState struct {
+	*LendingStateDB
+	mu         sync.RWMutex
+	lenddinges map[common.Hash]*exchanges
+}
+
+// LendingManagedState returns a new managed state with the statedb as it's backing layer
+func ManageState(statedb *LendingStateDB) *LendingManagedState {
+	return &LendingManagedState{
+		LendingStateDB: statedb.Copy(),
+		lenddinges:     make(map[common.Hash]*exchanges),
+	}
+}
+
+// SetState sets the backing layer of the managed state
+func (ms *LendingManagedState) SetState(statedb *LendingStateDB) {
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+	ms.LendingStateDB = statedb
+}
+
+// RemoveNonce removed the nonce from the managed state and all future pending nonces
+func (ms *LendingManagedState) RemoveNonce(addr common.Hash, n uint64) {
+	if ms.hasAccount(addr) {
+		ms.mu.Lock()
+		defer ms.mu.Unlock()
+
+		account := ms.getAccount(addr)
+		if n-account.nstart <= uint64(len(account.nonces)) {
+			reslice := make([]bool, n-account.nstart)
+			copy(reslice, account.nonces[:n-account.nstart])
+			account.nonces = reslice
+		}
+	}
+}
+
+// NewNonce returns the new canonical nonce for the managed tradeId
+func (ms *LendingManagedState) NewNonce(addr common.Hash) uint64 {
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+
+	account := ms.getAccount(addr)
+	for i, nonce := range account.nonces {
+		if !nonce {
+			return account.nstart + uint64(i)
+		}
+	}
+	account.nonces = append(account.nonces, true)
+
+	return uint64(len(account.nonces)-1) + account.nstart
+}
+
+// GetNonce returns the canonical nonce for the managed or unmanaged tradeId.
+//
+// Because GetNonce mutates the DB, we must take a write lock.
+func (ms *LendingManagedState) GetNonce(addr common.Hash) uint64 {
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+	if ms.hasAccount(addr) {
+		account := ms.getAccount(addr)
+		return uint64(len(account.nonces)) + account.nstart
+	} else {
+		return ms.LendingStateDB.GetNonce(addr)
+	}
+}
+
+// SetNonce sets the new canonical nonce for the managed state
+func (ms *LendingManagedState) SetNonce(addr common.Hash, nonce uint64) {
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+
+	so := ms.GetOrNewLendingExchangeObject(addr)
+	so.setNonce(nonce)
+
+	ms.lenddinges[addr] = newAccount(so)
+}
+
+// HasAccount returns whether the given address is managed or not
+func (ms *LendingManagedState) HasAccount(addr common.Hash) bool {
+	ms.mu.RLock()
+	defer ms.mu.RUnlock()
+	return ms.hasAccount(addr)
+}
+
+func (ms *LendingManagedState) hasAccount(addr common.Hash) bool {
+	_, ok := ms.lenddinges[addr]
+	return ok
+}
+
+// populate the managed state
+func (ms *LendingManagedState) getAccount(addr common.Hash) *exchanges {
+	if account, ok := ms.lenddinges[addr]; !ok {
+		so := ms.GetOrNewLendingExchangeObject(addr)
+		ms.lenddinges[addr] = newAccount(so)
+	} else {
+		// Always make sure the state tradeId nonce isn't actually higher
+		// than the tracked one.
+		so := ms.LendingStateDB.getLendingExchange(addr)
+		if so != nil && uint64(len(account.nonces))+account.nstart < so.Nonce() {
+			ms.lenddinges[addr] = newAccount(so)
+		}
+
+	}
+
+	return ms.lenddinges[addr]
+}
+
+func newAccount(so *lendingExchangeState) *exchanges {
+	return &exchanges{so, so.Nonce(), nil}
+}

--- a/legacy/tomoxlending/lendingstate/relayer.go
+++ b/legacy/tomoxlending/lendingstate/relayer.go
@@ -1,0 +1,305 @@
+package lendingstate
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/pkg/errors"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/crypto"
+	tradingstate "github.com/ethereum/go-ethereum/legacy/tomox/tradingstate"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+func GetLocMappingAtKey(key common.Hash, slot uint64) *big.Int {
+	slotHash := common.BigToHash(new(big.Int).SetUint64(slot))
+	retByte := crypto.Keccak256(key.Bytes(), slotHash.Bytes())
+	ret := new(big.Int)
+	ret.SetBytes(retByte)
+	return ret
+}
+
+func GetExRelayerFee(relayer common.Address, statedb *state.StateDB) *big.Int {
+	slot := RelayerMappingSlot["RELAYER_LIST"]
+	locBig := GetLocMappingAtKey(relayer.Hash(), slot)
+	locBig = new(big.Int).Add(locBig, RelayerStructMappingSlot["_fee"])
+	locHash := common.BigToHash(locBig)
+	return statedb.GetState(common.HexToAddress(tradingstate.RelayerRegistrationSMC), locHash).Big()
+}
+
+func GetRelayerOwner(relayer common.Address, statedb *state.StateDB) common.Address {
+	slot := RelayerMappingSlot["RELAYER_LIST"]
+	locBig := GetLocMappingAtKey(relayer.Hash(), slot)
+	log.Debug("GetRelayerOwner", "relayer", relayer.Hex(), "slot", slot, "locBig", locBig)
+	locBig = new(big.Int).Add(locBig, RelayerStructMappingSlot["_owner"])
+	locHash := common.BigToHash(locBig)
+	return common.BytesToAddress(statedb.GetState(common.HexToAddress(tradingstate.RelayerRegistrationSMC), locHash).Bytes())
+}
+
+// return true if relayer request to resign and have not withdraw locked fund
+func IsResignedRelayer(relayer common.Address, statedb *state.StateDB) bool {
+	slot := RelayerMappingSlot["RESIGN_REQUESTS"]
+	locBig := GetLocMappingAtKey(relayer.Hash(), slot)
+	locHash := common.BigToHash(locBig)
+	if statedb.GetState(common.HexToAddress(tradingstate.RelayerRegistrationSMC), locHash) != (common.Hash{}) {
+		return true
+	}
+	return false
+}
+
+func GetBaseTokenLength(relayer common.Address, statedb *state.StateDB) uint64 {
+	slot := RelayerMappingSlot["RELAYER_LIST"]
+	locBig := GetLocMappingAtKey(relayer.Hash(), slot)
+	locBig = new(big.Int).Add(locBig, RelayerStructMappingSlot["_fromTokens"])
+	locHash := common.BigToHash(locBig)
+	return statedb.GetState(common.HexToAddress(tradingstate.RelayerRegistrationSMC), locHash).Big().Uint64()
+}
+
+func GetBaseTokenAtIndex(relayer common.Address, statedb *state.StateDB, index uint64) common.Address {
+	slot := RelayerMappingSlot["RELAYER_LIST"]
+	locBig := GetLocMappingAtKey(relayer.Hash(), slot)
+	locBig = new(big.Int).Add(locBig, RelayerStructMappingSlot["_fromTokens"])
+	locHash := common.BigToHash(locBig)
+	loc := locDynamicArrAtElement(locHash, index, 1)
+	return common.BytesToAddress(statedb.GetState(common.HexToAddress(tradingstate.RelayerRegistrationSMC), loc).Bytes())
+}
+
+func GetQuoteTokenLength(relayer common.Address, statedb *state.StateDB) uint64 {
+	slot := RelayerMappingSlot["RELAYER_LIST"]
+	locBig := GetLocMappingAtKey(relayer.Hash(), slot)
+	locBig = new(big.Int).Add(locBig, RelayerStructMappingSlot["_toTokens"])
+	locHash := common.BigToHash(locBig)
+	return statedb.GetState(common.HexToAddress(tradingstate.RelayerRegistrationSMC), locHash).Big().Uint64()
+}
+
+func GetQuoteTokenAtIndex(relayer common.Address, statedb *state.StateDB, index uint64) common.Address {
+	slot := RelayerMappingSlot["RELAYER_LIST"]
+	locBig := GetLocMappingAtKey(relayer.Hash(), slot)
+	locBig = new(big.Int).Add(locBig, RelayerStructMappingSlot["_toTokens"])
+	locHash := common.BigToHash(locBig)
+	loc := locDynamicArrAtElement(locHash, index, 1)
+	return common.BytesToAddress(statedb.GetState(common.HexToAddress(tradingstate.RelayerRegistrationSMC), loc).Bytes())
+}
+
+func SubRelayerFee(relayer common.Address, fee *big.Int, statedb *state.StateDB) error {
+	slot := RelayerMappingSlot["RELAYER_LIST"]
+	locBig := GetLocMappingAtKey(relayer.Hash(), slot)
+
+	locBigDeposit := new(big.Int).SetUint64(uint64(0)).Add(locBig, RelayerStructMappingSlot["_deposit"])
+	locHashDeposit := common.BigToHash(locBigDeposit)
+	balance := statedb.GetState(common.HexToAddress(tradingstate.RelayerRegistrationSMC), locHashDeposit).Big()
+	log.Debug("ApplyTomoXMatchedTransaction settle balance: SubRelayerFee BEFORE", "relayer", relayer.String(), "balance", balance)
+	if balance.Cmp(fee) < 0 {
+		return errors.Errorf("relayer %s isn't enough tomo fee", relayer.String())
+	} else {
+		balance = new(big.Int).Sub(balance, fee)
+		statedb.SetState(common.HexToAddress(tradingstate.RelayerRegistrationSMC), locHashDeposit, common.BigToHash(balance))
+		statedb.SubBalance(common.HexToAddress(tradingstate.RelayerRegistrationSMC), fee)
+		log.Debug("ApplyTomoXMatchedTransaction settle balance: SubRelayerFee AFTER", "relayer", relayer.String(), "balance", balance)
+		return nil
+	}
+}
+
+func CheckRelayerFee(relayer common.Address, fee *big.Int, statedb *state.StateDB) error {
+	slot := RelayerMappingSlot["RELAYER_LIST"]
+	locBig := GetLocMappingAtKey(relayer.Hash(), slot)
+
+	locBigDeposit := new(big.Int).SetUint64(uint64(0)).Add(locBig, RelayerStructMappingSlot["_deposit"])
+	locHashDeposit := common.BigToHash(locBigDeposit)
+	balance := statedb.GetState(common.HexToAddress(tradingstate.RelayerRegistrationSMC), locHashDeposit).Big()
+	if new(big.Int).Sub(balance, fee).Cmp(new(big.Int).Mul(tradingstate.BasePrice, tradingstate.RelayerLockedFund)) < 0 {
+		return errors.Errorf("relayer %s isn't enough tomo fee : balance %d , fee : %d ", relayer.Hex(), balance.Uint64(), fee.Uint64())
+	}
+	return nil
+}
+func AddTokenBalance(addr common.Address, value *big.Int, token common.Address, statedb *state.StateDB) error {
+	// TOMO native
+	if token.String() == tradingstate.TomoNativeAddress {
+		balance := statedb.GetBalance(addr)
+		log.Debug("ApplyTomoXMatchedTransaction settle balance: ADD TOKEN TOMO NATIVE BEFORE", "token", token.String(), "address", addr.String(), "balance", balance, "orderValue", value)
+		statedb.AddBalance(addr, value)
+		balance = statedb.GetBalance(addr)
+		log.Debug("ApplyTomoXMatchedTransaction settle balance: ADD TOMO NATIVE BALANCE AFTER", "token", token.String(), "address", addr.String(), "balance", balance, "orderValue", value)
+
+		return nil
+	}
+
+	// TRC tokens
+	if statedb.Exist(token) {
+		slot := TokenMappingSlot["balances"]
+		locHash := common.BigToHash(GetLocMappingAtKey(addr.Hash(), slot))
+		balance := statedb.GetState(token, locHash).Big()
+		log.Debug("ApplyTomoXMatchedTransaction settle balance: ADD TOKEN BALANCE BEFORE", "token", token.String(), "address", addr.String(), "balance", balance, "orderValue", value)
+		balance = new(big.Int).Add(balance, value)
+		statedb.SetState(token, locHash, common.BigToHash(balance))
+		log.Debug("ApplyTomoXMatchedTransaction settle balance: ADD TOKEN BALANCE AFTER", "token", token.String(), "address", addr.String(), "balance", balance, "orderValue", value)
+		return nil
+	} else {
+		return errors.Errorf("token %s isn't exist", token.String())
+	}
+}
+
+func SubTokenBalance(addr common.Address, value *big.Int, token common.Address, statedb *state.StateDB) error {
+	// TOMO native
+	if token.String() == tradingstate.TomoNativeAddress {
+		balance := statedb.GetBalance(addr)
+		log.Debug("ApplyTomoXMatchedTransaction settle balance: SUB TOMO NATIVE BALANCE BEFORE", "token", token.String(), "address", addr.String(), "balance", balance, "orderValue", value)
+		if balance.Cmp(value) < 0 {
+			return errors.Errorf("value %s in token %s not enough , have : %s , want : %s  ", addr.String(), token.String(), balance, value)
+		}
+		statedb.SubBalance(addr, value)
+		balance = statedb.GetBalance(addr)
+		log.Debug("ApplyTomoXMatchedTransaction settle balance: SUB TOMO NATIVE BALANCE AFTER", "token", token.String(), "address", addr.String(), "balance", balance, "orderValue", value)
+
+		return nil
+	}
+
+	// TRC tokens
+	if statedb.Exist(token) {
+		slot := TokenMappingSlot["balances"]
+		locHash := common.BigToHash(GetLocMappingAtKey(addr.Hash(), slot))
+		balance := statedb.GetState(token, locHash).Big()
+		log.Debug("ApplyTomoXMatchedTransaction settle balance: SUB TOKEN BALANCE BEFORE", "token", token.String(), "address", addr.String(), "balance", balance, "orderValue", value)
+		if balance.Cmp(value) < 0 {
+			return errors.Errorf("value %s in token %s not enough , have : %s , want : %s  ", addr.String(), token.String(), balance, value)
+		}
+		balance = new(big.Int).Sub(balance, value)
+		statedb.SetState(token, locHash, common.BigToHash(balance))
+		log.Debug("ApplyTomoXMatchedTransaction settle balance: SUB TOKEN BALANCE AFTER", "token", token.String(), "address", addr.String(), "balance", balance, "orderValue", value)
+		return nil
+	} else {
+		return errors.Errorf("token %s isn't exist", token.String())
+	}
+}
+
+func CheckSubTokenBalance(addr common.Address, value *big.Int, token common.Address, statedb *state.StateDB, mapBalances map[common.Address]map[common.Address]*big.Int) (*big.Int, error) {
+	// TOMO native
+	if token.String() == tradingstate.TomoNativeAddress {
+		var balance *big.Int
+		if value := mapBalances[token][addr]; value != nil {
+			balance = value
+		} else {
+			balance = statedb.GetBalance(addr)
+		}
+		if balance.Cmp(value) < 0 {
+			return nil, errors.Errorf("value %s in token %s not enough , have : %s , want : %s  ", addr.String(), token.String(), balance, value)
+		}
+		newBalance := new(big.Int).Sub(balance, value)
+		log.Debug("CheckSubTokenBalance settle balance: SUB TOMO NATIVE BALANCE ", "token", token.String(), "address", addr.String(), "balance", balance, "value", value, "newBalance", newBalance)
+		return newBalance, nil
+	}
+	// TRC tokens
+	if statedb.Exist(token) {
+		var balance *big.Int
+		if value := mapBalances[token][addr]; value != nil {
+			balance = value
+		} else {
+			slot := TokenMappingSlot["balances"]
+			locHash := common.BigToHash(GetLocMappingAtKey(addr.Hash(), slot))
+			balance = statedb.GetState(token, locHash).Big()
+		}
+		if balance.Cmp(value) < 0 {
+			return nil, errors.Errorf("value %s in token %s not enough , have : %s , want : %s  ", addr.String(), token.String(), balance, value)
+		}
+		newBalance := new(big.Int).Sub(balance, value)
+		log.Debug("CheckSubTokenBalance settle balance: SUB TOKEN BALANCE ", "token", token.String(), "address", addr.String(), "balance", balance, "value", value, "newBalance", newBalance)
+		return newBalance, nil
+	} else {
+		return nil, errors.Errorf("token %s isn't exist", token.String())
+	}
+}
+
+func CheckAddTokenBalance(addr common.Address, value *big.Int, token common.Address, statedb *state.StateDB, mapBalances map[common.Address]map[common.Address]*big.Int) (*big.Int, error) {
+	// TOMO native
+	if token.String() == tradingstate.TomoNativeAddress {
+		var balance *big.Int
+		if value := mapBalances[token][addr]; value != nil {
+			balance = value
+		} else {
+			balance = statedb.GetBalance(addr)
+		}
+		newBalance := new(big.Int).Add(balance, value)
+		log.Debug("CheckAddTokenBalance settle balance: ADD TOMO NATIVE BALANCE ", "token", token.String(), "address", addr.String(), "balance", balance, "value", value, "newBalance", newBalance)
+		return newBalance, nil
+	}
+	// TRC tokens
+	if statedb.Exist(token) {
+		var balance *big.Int
+		if value := mapBalances[token][addr]; value != nil {
+			balance = value
+		} else {
+			slot := TokenMappingSlot["balances"]
+			locHash := common.BigToHash(GetLocMappingAtKey(addr.Hash(), slot))
+			balance = statedb.GetState(token, locHash).Big()
+		}
+		newBalance := new(big.Int).Add(balance, value)
+		log.Debug("CheckAddTokenBalance settle balance: ADD TOKEN BALANCE ", "token", token.String(), "address", addr.String(), "balance", balance, "value", value, "newBalance", newBalance)
+		if common.BigToHash(newBalance).Big().Cmp(newBalance) != 0 {
+			return nil, fmt.Errorf("Overflow when try add token balance , max is 2^256 , balance : %v , value:%v ", balance, value)
+		} else {
+			return newBalance, nil
+		}
+	} else {
+		return nil, errors.Errorf("token %s isn't exist", token.String())
+	}
+}
+
+func CheckSubRelayerFee(relayer common.Address, fee *big.Int, statedb *state.StateDB, mapBalances map[common.Address]*big.Int) (*big.Int, error) {
+	balance := mapBalances[relayer]
+	if balance == nil {
+		slot := RelayerMappingSlot["RELAYER_LIST"]
+		locBig := GetLocMappingAtKey(relayer.Hash(), slot)
+		locBigDeposit := new(big.Int).SetUint64(uint64(0)).Add(locBig, RelayerStructMappingSlot["_deposit"])
+		locHashDeposit := common.BigToHash(locBigDeposit)
+		balance = statedb.GetState(common.HexToAddress(tradingstate.RelayerRegistrationSMC), locHashDeposit).Big()
+	}
+	log.Debug("CheckSubRelayerFee settle balance: SubRelayerFee ", "relayer", relayer.String(), "balance", balance, "fee", fee)
+	if balance.Cmp(fee) < 0 {
+		return nil, errors.Errorf("relayer %s isn't enough tomo fee", relayer.String())
+	} else {
+		return new(big.Int).Sub(balance, fee), nil
+	}
+}
+
+func GetTokenBalance(addr common.Address, token common.Address, statedb *state.StateDB) *big.Int {
+	// TOMO native
+	if token.String() == tradingstate.TomoNativeAddress {
+		return statedb.GetBalance(addr)
+	}
+	// TRC tokens
+	if statedb.Exist(token) {
+		slot := TokenMappingSlot["balances"]
+		locHash := common.BigToHash(GetLocMappingAtKey(addr.Hash(), slot))
+		return statedb.GetState(token, locHash).Big()
+	} else {
+		return common.Big0
+	}
+}
+
+func SetTokenBalance(addr common.Address, balance *big.Int, token common.Address, statedb *state.StateDB) error {
+	// TOMO native
+	if token.String() == tradingstate.TomoNativeAddress {
+		statedb.SetBalance(addr, balance)
+		return nil
+	}
+
+	// TRC tokens
+	if statedb.Exist(token) {
+		slot := TokenMappingSlot["balances"]
+		locHash := common.BigToHash(GetLocMappingAtKey(addr.Hash(), slot))
+		statedb.SetState(token, locHash, common.BigToHash(balance))
+		return nil
+	} else {
+		return errors.Errorf("token %s isn't exist", token.String())
+	}
+}
+
+func SetSubRelayerFee(relayer common.Address, balance *big.Int, fee *big.Int, statedb *state.StateDB) {
+	slot := RelayerMappingSlot["RELAYER_LIST"]
+	locBig := GetLocMappingAtKey(relayer.Hash(), slot)
+	locBigDeposit := new(big.Int).SetUint64(uint64(0)).Add(locBig, RelayerStructMappingSlot["_deposit"])
+	locHashDeposit := common.BigToHash(locBigDeposit)
+	statedb.SetState(common.HexToAddress(tradingstate.RelayerRegistrationSMC), locHashDeposit, common.BigToHash(balance))
+	statedb.SubBalance(common.HexToAddress(tradingstate.RelayerRegistrationSMC), fee)
+}

--- a/legacy/tomoxlending/lendingstate/settle_balance.go
+++ b/legacy/tomoxlending/lendingstate/settle_balance.go
@@ -1,0 +1,257 @@
+package lendingstate
+
+import (
+	"encoding/json"
+	"errors"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	tradingstate "github.com/ethereum/go-ethereum/legacy/tomox/tradingstate"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+const DefaultFeeRate = 100 // 100 / TomoXBaseFee = 100 / 10000 = 1%
+var (
+	ErrQuantityTradeTooSmall  = errors.New("quantity trade too small")
+	ErrInvalidCollateralPrice = errors.New("unable to retrieve price of this collateral. Please try another collateral")
+)
+
+type TradeResult struct {
+	Fee      *big.Int
+	InToken  common.Address
+	InTotal  *big.Int
+	OutToken common.Address
+	OutTotal *big.Int
+}
+type LendingSettleBalance struct {
+	Taker                  TradeResult
+	Maker                  TradeResult
+	CollateralLockedAmount *big.Int
+}
+
+func (settleBalance *LendingSettleBalance) String() string {
+	jsonData, _ := json.Marshal(settleBalance)
+	return string(jsonData)
+}
+
+func GetSettleBalance(isTomoXLendingFork bool,
+	takerSide string,
+	lendTokenTOMOPrice,
+	collateralPrice,
+	depositRate,
+	borrowFeeRate *big.Int,
+	lendingToken,
+	collateralToken common.Address,
+	lendTokenDecimal,
+	collateralTokenDecimal *big.Int,
+	quantityToLend *big.Int) (*LendingSettleBalance, error) {
+	log.Debug("GetSettleBalance", "takerSide", takerSide, "borrowFeeRate", borrowFeeRate, "lendingToken", lendingToken, "collateralToken", collateralToken, "quantityToLend", quantityToLend)
+	if collateralPrice == nil || collateralPrice.Sign() <= 0 {
+		return nil, ErrInvalidCollateralPrice
+	}
+
+	//use the defaultFee to validate small orders
+	defaultFee := new(big.Int).Mul(quantityToLend, new(big.Int).SetUint64(DefaultFeeRate))
+	defaultFee = new(big.Int).Div(defaultFee, tradingstate.TomoXBaseFee)
+
+	var result *LendingSettleBalance
+
+	if !isTomoXLendingFork {
+		if takerSide == Borrowing {
+			// taker = Borrower : takerOutTotal = CollateralLockedAmount = quantityToLend * collateral Token Decimal/ CollateralPrice  * deposit rate
+			takerOutTotal := new(big.Int).Mul(quantityToLend, collateralTokenDecimal)
+			takerOutTotal = new(big.Int).Mul(takerOutTotal, depositRate) // eg: depositRate = 150%
+			takerOutTotal = new(big.Int).Div(takerOutTotal, big.NewInt(100))
+			takerOutTotal = new(big.Int).Div(takerOutTotal, collateralPrice)
+			// Fee
+			// takerFee = quantityToLend*borrowFeeRate/baseFee
+			takerFee := new(big.Int).Mul(quantityToLend, borrowFeeRate)
+			takerFee = new(big.Int).Div(takerFee, tradingstate.TomoXBaseFee)
+
+			if quantityToLend.Cmp(takerFee) <= 0 || quantityToLend.Cmp(defaultFee) <= 0 {
+				log.Debug("quantity lending too small", "quantityToLend", quantityToLend, "takerFee", takerFee)
+				return result, ErrQuantityTradeTooSmall
+			}
+			if lendingToken.String() != tradingstate.TomoNativeAddress && lendTokenTOMOPrice != nil && lendTokenTOMOPrice.Cmp(common.Big0) > 0 {
+				exTakerReceivedFee := new(big.Int).Mul(takerFee, lendTokenTOMOPrice)
+				exTakerReceivedFee = new(big.Int).Div(exTakerReceivedFee, lendTokenDecimal)
+
+				defaultFeeInTOMO := new(big.Int).Mul(defaultFee, lendTokenTOMOPrice)
+				defaultFeeInTOMO = new(big.Int).Div(defaultFeeInTOMO, lendTokenDecimal)
+
+				if (exTakerReceivedFee.Cmp(RelayerLendingFee) <= 0 && exTakerReceivedFee.Sign() > 0) || defaultFeeInTOMO.Cmp(RelayerLendingFee) <= 0 {
+					log.Debug("takerFee too small", "quantityToLend", quantityToLend, "takerFee", takerFee, "exTakerReceivedFee", exTakerReceivedFee, "borrowFeeRate", borrowFeeRate, "defaultFeeInTOMO", defaultFeeInTOMO)
+					return result, ErrQuantityTradeTooSmall
+				}
+			} else if lendingToken.String() == tradingstate.TomoNativeAddress {
+				exTakerReceivedFee := takerFee
+				if (exTakerReceivedFee.Cmp(RelayerLendingFee) <= 0 && exTakerReceivedFee.Sign() > 0) || defaultFee.Cmp(RelayerLendingFee) <= 0 {
+					log.Debug("takerFee too small", "quantityToLend", quantityToLend, "takerFee", takerFee, "exTakerReceivedFee", exTakerReceivedFee, "borrowFeeRate", borrowFeeRate, "defaultFee", defaultFee)
+					return result, ErrQuantityTradeTooSmall
+				}
+			}
+			result = &LendingSettleBalance{
+				//Borrower
+				Taker: TradeResult{
+					Fee:      takerFee,
+					InToken:  lendingToken,
+					InTotal:  new(big.Int).Sub(quantityToLend, takerFee),
+					OutToken: collateralToken,
+					OutTotal: takerOutTotal,
+				},
+				// Investor : makerOutTotal = quantityToLend
+				Maker: TradeResult{
+					Fee:      common.Big0,
+					InToken:  common.Address{},
+					InTotal:  common.Big0,
+					OutToken: lendingToken,
+					OutTotal: quantityToLend,
+				},
+				CollateralLockedAmount: takerOutTotal,
+			}
+		} else {
+			// maker =  Borrower : makerOutTotal = CollateralLockedAmount = quantityToLend * collateral Token Decimal / CollateralPrice  * deposit rate
+			makerOutTotal := new(big.Int).Mul(quantityToLend, collateralTokenDecimal)
+			makerOutTotal = new(big.Int).Mul(makerOutTotal, depositRate) // eg: depositRate = 150%
+			makerOutTotal = new(big.Int).Div(makerOutTotal, big.NewInt(100))
+			makerOutTotal = new(big.Int).Div(makerOutTotal, collateralPrice)
+			// Fee
+			makerFee := new(big.Int).Mul(quantityToLend, borrowFeeRate)
+			makerFee = new(big.Int).Div(makerFee, tradingstate.TomoXBaseFee)
+			if quantityToLend.Cmp(makerFee) <= 0 || quantityToLend.Cmp(defaultFee) <= 0 {
+				log.Debug("quantity lending too small", "quantityToLend", quantityToLend, "makerFee", makerFee)
+				return result, ErrQuantityTradeTooSmall
+			}
+			if lendingToken.String() != tradingstate.TomoNativeAddress && lendTokenTOMOPrice != nil && lendTokenTOMOPrice.Cmp(common.Big0) > 0 {
+				exMakerReceivedFee := new(big.Int).Mul(makerFee, lendTokenTOMOPrice)
+				exMakerReceivedFee = new(big.Int).Div(exMakerReceivedFee, lendTokenDecimal)
+
+				defaultFeeInTOMO := new(big.Int).Mul(defaultFee, lendTokenTOMOPrice)
+				defaultFeeInTOMO = new(big.Int).Div(defaultFeeInTOMO, lendTokenDecimal)
+
+				if (exMakerReceivedFee.Cmp(RelayerLendingFee) <= 0 && exMakerReceivedFee.Sign() > 0) || defaultFeeInTOMO.Cmp(RelayerLendingFee) <= 0 {
+					log.Debug("makerFee too small", "quantityToLend", quantityToLend, "makerFee", makerFee, "exMakerReceivedFee", exMakerReceivedFee, "borrowFeeRate", borrowFeeRate, "defaultFeeInTOMO", defaultFeeInTOMO)
+					return result, ErrQuantityTradeTooSmall
+				}
+			} else if lendingToken.String() == tradingstate.TomoNativeAddress {
+				exMakerReceivedFee := makerFee
+				if (exMakerReceivedFee.Cmp(RelayerLendingFee) <= 0 && exMakerReceivedFee.Sign() > 0) || defaultFee.Cmp(RelayerLendingFee) <= 0 {
+					log.Debug("makerFee too small", "quantityToLend", quantityToLend, "makerFee", makerFee, "exMakerReceivedFee", exMakerReceivedFee, "borrowFeeRate", borrowFeeRate, "defaultFee", defaultFee)
+					return result, ErrQuantityTradeTooSmall
+				}
+			}
+			result = &LendingSettleBalance{
+				Taker: TradeResult{
+					Fee:      common.Big0,
+					InToken:  common.Address{},
+					InTotal:  common.Big0,
+					OutToken: lendingToken,
+					OutTotal: quantityToLend,
+				},
+				Maker: TradeResult{
+					Fee:      makerFee,
+					InToken:  lendingToken,
+					InTotal:  new(big.Int).Add(quantityToLend, makerFee),
+					OutToken: collateralToken,
+					OutTotal: makerOutTotal,
+				},
+				CollateralLockedAmount: makerOutTotal,
+			}
+		}
+	} else {
+
+		collateralQuantity := new(big.Int).Mul(quantityToLend, collateralTokenDecimal)
+		collateralQuantity = new(big.Int).Mul(collateralQuantity, depositRate) // eg: depositRate = 150%
+		collateralQuantity = new(big.Int).Div(collateralQuantity, big.NewInt(100))
+		collateralQuantity = new(big.Int).Div(collateralQuantity, collateralPrice)
+
+		borrowFee := new(big.Int).Mul(quantityToLend, borrowFeeRate)
+		borrowFee = new(big.Int).Div(borrowFee, tradingstate.TomoXBaseFee)
+
+		if quantityToLend.Cmp(borrowFee) <= 0 || quantityToLend.Cmp(defaultFee) <= 0 {
+			log.Debug("quantity lending too small", "quantityToLend", quantityToLend, "borrowFee", borrowFee)
+			return result, ErrQuantityTradeTooSmall
+		}
+		if lendingToken.String() != tradingstate.TomoNativeAddress && lendTokenTOMOPrice != nil && lendTokenTOMOPrice.Cmp(common.Big0) > 0 {
+			// exReceivedFee: the fee amount which borrowingRelayer will receive
+			exReceivedFee := new(big.Int).Mul(borrowFee, lendTokenTOMOPrice)
+			exReceivedFee = new(big.Int).Div(exReceivedFee, lendTokenDecimal)
+
+			defaultFeeInTOMO := new(big.Int).Mul(defaultFee, lendTokenTOMOPrice)
+			defaultFeeInTOMO = new(big.Int).Div(defaultFeeInTOMO, lendTokenDecimal)
+
+			if (exReceivedFee.Cmp(RelayerLendingFee) <= 0 && exReceivedFee.Sign() > 0) || defaultFeeInTOMO.Cmp(RelayerLendingFee) <= 0 {
+				log.Debug("takerFee too small", "quantityToLend", quantityToLend, "borrowFee", borrowFee, "exReceivedFee", exReceivedFee, "borrowFeeRate", borrowFeeRate, "defaultFeeInTOMO", defaultFeeInTOMO)
+				return result, ErrQuantityTradeTooSmall
+			}
+		} else if lendingToken.String() == tradingstate.TomoNativeAddress {
+			exReceivedFee := borrowFee
+			if (exReceivedFee.Cmp(RelayerLendingFee) <= 0 && exReceivedFee.Sign() > 0) || defaultFee.Cmp(RelayerLendingFee) <= 0 {
+				log.Debug("takerFee too small", "quantityToLend", quantityToLend, "borrowFee", borrowFee, "exReceivedFee", exReceivedFee, "borrowFeeRate", borrowFeeRate, "defaultFee", defaultFee)
+				return result, ErrQuantityTradeTooSmall
+			}
+		}
+		borrowerReceivedQuantity := new(big.Int).Sub(quantityToLend, borrowFee)
+		borrowerTradeResult := TradeResult{
+			Fee:      borrowFee,
+			InToken:  lendingToken,
+			InTotal:  borrowerReceivedQuantity,
+			OutToken: collateralToken,
+			OutTotal: collateralQuantity,
+		}
+		investorTradeResult := TradeResult{
+			Fee:      common.Big0,
+			InToken:  common.Address{},
+			InTotal:  common.Big0,
+			OutToken: lendingToken,
+			OutTotal: quantityToLend,
+		}
+		if takerSide == Borrowing {
+			result = &LendingSettleBalance{
+				Taker:                  borrowerTradeResult,
+				Maker:                  investorTradeResult,
+				CollateralLockedAmount: collateralQuantity,
+			}
+		} else {
+			result = &LendingSettleBalance{
+				Taker:                  investorTradeResult,
+				Maker:                  borrowerTradeResult,
+				CollateralLockedAmount: collateralQuantity,
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// apr: annual percentage rate
+// this function returns actual interest rate base on borrowing time and apr
+// I = APR *(T + T1) / 2 / 365
+// T: term
+// T1: borrowingTime
+func CalculateInterestRate(finalizeTime, liquidationTime, term uint64, apr uint64) *big.Int {
+	startBorrowingTime := liquidationTime - term
+	borrowingTime := finalizeTime - startBorrowingTime
+
+	// the time interval which borrower have to pay interest
+	// (T + T1) / 2
+	timeToPayInterest := new(big.Int).Add(new(big.Int).SetUint64(term), new(big.Int).SetUint64(borrowingTime))
+	timeToPayInterest = new(big.Int).Div(timeToPayInterest, new(big.Int).SetUint64(2))
+
+	interestRate := new(big.Int).SetUint64(apr)
+	interestRate = new(big.Int).Mul(interestRate, timeToPayInterest)
+	interestRate = new(big.Int).Div(interestRate, new(big.Int).SetUint64(OneYear))
+	return interestRate
+}
+
+func CalculateTotalRepayValue(finalizeTime, liquidationTime, term uint64, apr uint64, tradeAmount *big.Int) *big.Int {
+	interestRate := CalculateInterestRate(finalizeTime, liquidationTime, term, apr)
+
+	// interest 10%
+	// user should send: 10 * BaseLendingInterest
+	// decimal = BaseLendingInterest * 100
+	baseInterestDecimal := new(big.Int).Mul(BaseLendingInterest, new(big.Int).SetUint64(100))
+	paymentBalance := new(big.Int).Mul(tradeAmount, new(big.Int).Add(baseInterestDecimal, interestRate))
+	paymentBalance = new(big.Int).Div(paymentBalance, baseInterestDecimal)
+	return paymentBalance
+}

--- a/legacy/tomoxlending/lendingstate/state_itemList.go
+++ b/legacy/tomoxlending/lendingstate/state_itemList.go
@@ -1,0 +1,194 @@
+// Copyright 2014 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package lendingstate
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+type itemListState struct {
+	lendingBook common.Hash
+	key         common.Hash
+	data        itemList
+
+	// DB error.
+	// State objects are used by the consensus core and VM which are
+	// unable to deal with database-level errors. Any error that occurs
+	// during a database read is memoized here and will eventually be returned
+	// by LendingStateDB.Commit.
+	dbErr error
+
+	// Write caches.
+	trie Trie // storage trie, which becomes non-nil on first access
+
+	cachedStorage map[common.Hash]common.Hash // Storage entry cache to avoid duplicate reads
+	dirtyStorage  map[common.Hash]common.Hash // Storage entries that need to be flushed to disk
+
+	onDirty func(price common.Hash) // Callback method to mark a state object newly dirty
+}
+
+func (s *itemListState) empty() bool {
+	return s.data.Volume == nil || s.data.Volume.Sign() == 0
+}
+
+func newItemListState(lendingBook common.Hash, key common.Hash, data itemList, onDirty func(price common.Hash)) *itemListState {
+	return &itemListState{
+		lendingBook:   lendingBook,
+		key:           key,
+		data:          data,
+		cachedStorage: make(map[common.Hash]common.Hash),
+		dirtyStorage:  make(map[common.Hash]common.Hash),
+		onDirty:       onDirty,
+	}
+}
+
+// EncodeRLP implements rlp.Encoder.
+func (c *itemListState) EncodeRLP(w io.Writer) error {
+	return rlp.Encode(w, c.data)
+}
+
+// setError remembers the first non-nil error it is called with.
+func (self *itemListState) setError(err error) {
+	if self.dbErr == nil {
+		self.dbErr = err
+	}
+}
+
+func (c *itemListState) getTrie(db Database) Trie {
+	if c.trie == nil {
+		var err error
+		c.trie, err = db.OpenStorageTrie(c.key, c.data.Root)
+		if err != nil {
+			c.trie, _ = db.OpenStorageTrie(c.key, EmptyHash)
+			c.setError(fmt.Errorf("can't create storage trie: %v", err))
+		}
+	}
+	return c.trie
+}
+
+func (self *itemListState) GetOrderAmount(db Database, orderId common.Hash) common.Hash {
+	amount, exists := self.cachedStorage[orderId]
+	if exists {
+		return amount
+	}
+	// Load from DB in case it is missing.
+	enc, err := self.getTrie(db).TryGet(orderId[:])
+	if err != nil {
+		self.setError(err)
+		return EmptyHash
+	}
+	if len(enc) > 0 {
+		_, content, _, err := rlp.Split(enc)
+		if err != nil {
+			self.setError(err)
+		}
+		amount.SetBytes(content)
+	}
+	if (amount != common.Hash{}) {
+		self.cachedStorage[orderId] = amount
+	}
+	return amount
+}
+
+func (self *itemListState) insertLendingItem(db Database, orderId common.Hash, amount common.Hash) {
+	self.setOrderItem(orderId, amount)
+	self.setError(self.getTrie(db).TryUpdate(orderId[:], amount[:]))
+}
+
+func (self *itemListState) removeOrderItem(db Database, orderId common.Hash) {
+	tr := self.getTrie(db)
+	self.setError(tr.TryDelete(orderId[:]))
+	self.setOrderItem(orderId, EmptyHash)
+}
+
+func (self *itemListState) setOrderItem(orderId common.Hash, amount common.Hash) {
+	self.cachedStorage[orderId] = amount
+	self.dirtyStorage[orderId] = amount
+
+	if self.onDirty != nil {
+		self.onDirty(self.key)
+		self.onDirty = nil
+	}
+}
+
+// updateAskTrie writes cached storage modifications into the object's storage trie.
+func (self *itemListState) updateTrie(db Database) Trie {
+	tr := self.getTrie(db)
+	for orderId, amount := range self.dirtyStorage {
+		delete(self.dirtyStorage, orderId)
+		if amount == EmptyHash {
+			self.setError(tr.TryDelete(orderId[:]))
+			continue
+		}
+		v, _ := rlp.EncodeToBytes(bytes.TrimLeft(amount[:], "\x00"))
+		self.setError(tr.TryUpdate(orderId[:], v))
+	}
+	return tr
+}
+
+// UpdateRoot sets the trie root to the current root tradeId of
+func (self *itemListState) updateRoot(db Database) error {
+	self.updateTrie(db)
+	if self.dbErr != nil {
+		return self.dbErr
+	}
+	root, _, err := self.trie.Commit(nil)
+	if err == nil {
+		self.data.Root = root
+	}
+	return err
+}
+
+func (self *itemListState) deepCopy(db *LendingStateDB, onDirty func(price common.Hash)) *itemListState {
+	stateOrderList := newItemListState(self.lendingBook, self.key, self.data, onDirty)
+	if self.trie != nil {
+		stateOrderList.trie = db.db.CopyTrie(self.trie)
+	}
+	for orderId, amount := range self.dirtyStorage {
+		stateOrderList.dirtyStorage[orderId] = amount
+	}
+	for orderId, amount := range self.cachedStorage {
+		stateOrderList.cachedStorage[orderId] = amount
+	}
+	return stateOrderList
+}
+
+func (c *itemListState) AddVolume(amount *big.Int) {
+	c.setVolume(new(big.Int).Add(c.data.Volume, amount))
+}
+
+func (c *itemListState) subVolume(amount *big.Int) {
+	c.setVolume(new(big.Int).Sub(c.data.Volume, amount))
+}
+
+func (self *itemListState) setVolume(volume *big.Int) {
+	self.data.Volume = volume
+	if self.onDirty != nil {
+		self.onDirty(self.key)
+		self.onDirty = nil
+	}
+}
+
+func (self *itemListState) Volume() *big.Int {
+	return self.data.Volume
+}

--- a/legacy/tomoxlending/lendingstate/state_lendingbook.go
+++ b/legacy/tomoxlending/lendingstate/state_lendingbook.go
@@ -1,0 +1,793 @@
+// Copyright 2014 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package lendingstate
+
+import (
+	"fmt"
+	"io"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+type lendingExchangeState struct {
+	lendingBook common.Hash
+	data        lendingObject
+	db          *LendingStateDB
+
+	// DB error.
+	// State objects are used by the consensus core and VM which are
+	// unable to deal with database-level errors. Any error that occurs
+	// during a database read is memoized here and will eventually be returned
+	// by LendingStateDB.Commit.
+	dbErr error
+
+	investingTrie       Trie
+	borrowingTrie       Trie
+	lendingItemTrie     Trie
+	lendingTradeTrie    Trie
+	liquidationTimeTrie Trie
+
+	liquidationTimeStates      map[common.Hash]*liquidationTimeState
+	liquidationTimestatesDirty map[common.Hash]struct{}
+
+	investingStates      map[common.Hash]*itemListState
+	investingStatesDirty map[common.Hash]struct{}
+
+	borrowingStates      map[common.Hash]*itemListState
+	borrowingStatesDirty map[common.Hash]struct{}
+
+	lendingItemStates      map[common.Hash]*lendingItemState
+	lendingItemStatesDirty map[common.Hash]struct{}
+
+	lendingTradeStates      map[common.Hash]*lendingTradeState
+	lendingTradeStatesDirty map[common.Hash]struct{}
+
+	onDirty func(hash common.Hash) // Callback method to mark a state object newly dirty
+}
+
+// empty returns whether the tradeId is considered empty.
+func (s *lendingExchangeState) empty() bool {
+	if s.data.Nonce != 0 {
+		return false
+	}
+	if s.data.TradeNonce != 0 {
+		return false
+	}
+	if !params.EmptyHash(s.data.InvestingRoot) {
+		return false
+	}
+	if !params.EmptyHash(s.data.BorrowingRoot) {
+		return false
+	}
+	if !params.EmptyHash(s.data.LendingItemRoot) {
+		return false
+	}
+	if !params.EmptyHash(s.data.LendingTradeRoot) {
+		return false
+	}
+	if !params.EmptyHash(s.data.LiquidationTimeRoot) {
+		return false
+	}
+	return true
+}
+
+func newStateExchanges(db *LendingStateDB, hash common.Hash, data lendingObject, onDirty func(addr common.Hash)) *lendingExchangeState {
+	return &lendingExchangeState{
+		db:                         db,
+		lendingBook:                hash,
+		data:                       data,
+		investingStates:            make(map[common.Hash]*itemListState),
+		borrowingStates:            make(map[common.Hash]*itemListState),
+		lendingItemStates:          make(map[common.Hash]*lendingItemState),
+		lendingTradeStates:         make(map[common.Hash]*lendingTradeState),
+		liquidationTimeStates:      make(map[common.Hash]*liquidationTimeState),
+		investingStatesDirty:       make(map[common.Hash]struct{}),
+		borrowingStatesDirty:       make(map[common.Hash]struct{}),
+		lendingItemStatesDirty:     make(map[common.Hash]struct{}),
+		lendingTradeStatesDirty:    make(map[common.Hash]struct{}),
+		liquidationTimestatesDirty: make(map[common.Hash]struct{}),
+		onDirty:                    onDirty,
+	}
+}
+
+// EncodeRLP implements rlp.Encoder.
+func (self *lendingExchangeState) EncodeRLP(w io.Writer) error {
+	return rlp.Encode(w, self.data)
+}
+
+// setError remembers the first non-nil error it is called with.
+func (self *lendingExchangeState) setError(err error) {
+	if self.dbErr == nil {
+		self.dbErr = err
+	}
+}
+
+/**
+  Get Trie
+*/
+
+func (self *lendingExchangeState) getLendingItemTrie(db Database) Trie {
+	if self.lendingItemTrie == nil {
+		var err error
+		self.lendingItemTrie, err = db.OpenStorageTrie(self.lendingBook, self.data.LendingItemRoot)
+		if err != nil {
+			self.lendingItemTrie, _ = db.OpenStorageTrie(self.lendingBook, EmptyHash)
+			self.setError(fmt.Errorf("can't create Lendings trie: %v", err))
+		}
+	}
+	return self.lendingItemTrie
+}
+
+func (self *lendingExchangeState) getLendingTradeTrie(db Database) Trie {
+	if self.lendingTradeTrie == nil {
+		var err error
+		self.lendingTradeTrie, err = db.OpenStorageTrie(self.lendingBook, self.data.LendingTradeRoot)
+		if err != nil {
+			self.lendingTradeTrie, _ = db.OpenStorageTrie(self.lendingBook, EmptyHash)
+			self.setError(fmt.Errorf("can't create Lendings trie: %v", err))
+		}
+	}
+	return self.lendingTradeTrie
+}
+func (self *lendingExchangeState) getInvestingTrie(db Database) Trie {
+	if self.investingTrie == nil {
+		var err error
+		self.investingTrie, err = db.OpenStorageTrie(self.lendingBook, self.data.InvestingRoot)
+		if err != nil {
+			self.investingTrie, _ = db.OpenStorageTrie(self.lendingBook, EmptyHash)
+			self.setError(fmt.Errorf("can't create Lendings trie: %v", err))
+		}
+	}
+	return self.investingTrie
+}
+
+func (self *lendingExchangeState) getBorrowingTrie(db Database) Trie {
+	if self.borrowingTrie == nil {
+		var err error
+		self.borrowingTrie, err = db.OpenStorageTrie(self.lendingBook, self.data.BorrowingRoot)
+		if err != nil {
+			self.borrowingTrie, _ = db.OpenStorageTrie(self.lendingBook, EmptyHash)
+			self.setError(fmt.Errorf("can't create bids trie: %v", err))
+		}
+	}
+	return self.borrowingTrie
+}
+
+func (self *lendingExchangeState) getLiquidationTimeTrie(db Database) Trie {
+	if self.liquidationTimeTrie == nil {
+		var err error
+		self.liquidationTimeTrie, err = db.OpenStorageTrie(self.lendingBook, self.data.LiquidationTimeRoot)
+		if err != nil {
+			self.liquidationTimeTrie, _ = db.OpenStorageTrie(self.lendingBook, EmptyHash)
+			self.setError(fmt.Errorf("can't create bids trie: %v", err))
+		}
+	}
+	return self.liquidationTimeTrie
+}
+
+/*
+*
+
+	Get State
+*/
+func (self *lendingExchangeState) getBorrowingOrderList(db Database, rate common.Hash) (stateOrderList *itemListState) {
+	// Prefer 'live' objects.
+	if obj := self.borrowingStates[rate]; obj != nil {
+		return obj
+	}
+
+	// Load the object from the database.
+	enc, err := self.getBorrowingTrie(db).TryGet(rate[:])
+	if len(enc) == 0 {
+		self.setError(err)
+		return nil
+	}
+	var data itemList
+	if err := rlp.DecodeBytes(enc, &data); err != nil {
+		log.Error("Failed to decode state order list object", "rate", rate, "err", err)
+		return nil
+	}
+	// Insert into the live set.
+	obj := newItemListState(self.lendingBook, rate, data, self.MarkBorrowingDirty)
+	self.borrowingStates[rate] = obj
+	return obj
+}
+
+func (self *lendingExchangeState) getInvestingOrderList(db Database, rate common.Hash) (stateOrderList *itemListState) {
+	// Prefer 'live' objects.
+	if obj := self.investingStates[rate]; obj != nil {
+		return obj
+	}
+
+	// Load the object from the database.
+	enc, err := self.getInvestingTrie(db).TryGet(rate[:])
+	if len(enc) == 0 {
+		self.setError(err)
+		return nil
+	}
+	var data itemList
+	if err := rlp.DecodeBytes(enc, &data); err != nil {
+		log.Error("Failed to decode state order list object", "rate", rate, "err", err)
+		return nil
+	}
+	// Insert into the live set.
+	obj := newItemListState(self.lendingBook, rate, data, self.MarkInvestingDirty)
+	self.investingStates[rate] = obj
+	return obj
+}
+
+func (self *lendingExchangeState) getLiquidationTimeOrderList(db Database, time common.Hash) (stateObject *liquidationTimeState) {
+	// Prefer 'live' objects.
+	if obj := self.liquidationTimeStates[time]; obj != nil {
+		return obj
+	}
+
+	// Load the object from the database.
+	enc, err := self.getLiquidationTimeTrie(db).TryGet(time[:])
+	if len(enc) == 0 {
+		self.setError(err)
+		return nil
+	}
+	var data itemList
+	if err := rlp.DecodeBytes(enc, &data); err != nil {
+		log.Error("Failed to decode state liquidation time", "time", time, "err", err)
+		return nil
+	}
+	// Insert into the live set.
+	obj := newLiquidationTimeState(self.lendingBook, time, data, self.MarkLiquidationTimeDirty)
+	self.liquidationTimeStates[time] = obj
+	return obj
+}
+
+func (self *lendingExchangeState) getLendingItem(db Database, lendingId common.Hash) (stateObject *lendingItemState) {
+	// Prefer 'live' objects.
+	if obj := self.lendingItemStates[lendingId]; obj != nil {
+		return obj
+	}
+
+	// Load the object from the database.
+	enc, err := self.getLendingItemTrie(db).TryGet(lendingId[:])
+	if len(enc) == 0 {
+		self.setError(err)
+		return nil
+	}
+	var data LendingItem
+	if err := rlp.DecodeBytes(enc, &data); err != nil {
+		log.Error("Failed to decode state lending item", "tradeId", lendingId, "err", err)
+		return nil
+	}
+	// Insert into the live set.
+	obj := newLendinItemState(self.lendingBook, lendingId, data, self.MarkLendingItemDirty)
+	self.lendingItemStates[lendingId] = obj
+	return obj
+}
+
+func (self *lendingExchangeState) getLendingTrade(db Database, tradeId common.Hash) (stateObject *lendingTradeState) {
+	// Prefer 'live' objects.
+	if obj := self.lendingTradeStates[tradeId]; obj != nil {
+		return obj
+	}
+
+	// Load the object from the database.
+	enc, err := self.getLendingTradeTrie(db).TryGet(tradeId[:])
+	if len(enc) == 0 {
+		self.setError(err)
+		return nil
+	}
+	var data LendingTrade
+	if err := rlp.DecodeBytes(enc, &data); err != nil {
+		log.Error("Failed to decode state lending trade", "tradeId", tradeId, "err", err)
+		return nil
+	}
+	// Insert into the live set.
+	obj := newLendingTradeState(self.lendingBook, tradeId, data, self.MarkLendingTradeDirty)
+	self.lendingTradeStates[tradeId] = obj
+	return obj
+}
+
+/*
+*
+
+	Update Trie
+*/
+func (self *lendingExchangeState) updateLendingTimeTrie(db Database) Trie {
+	tr := self.getLendingItemTrie(db)
+	for lendingId, lendingItem := range self.lendingItemStates {
+		if _, isDirty := self.lendingItemStatesDirty[lendingId]; isDirty {
+			delete(self.lendingItemStatesDirty, lendingId)
+			if lendingItem.empty() {
+				self.setError(tr.TryDelete(lendingId[:]))
+				continue
+			}
+			// Encoding []byte cannot fail, ok to ignore the error.
+			v, _ := rlp.EncodeToBytes(lendingItem)
+			self.setError(tr.TryUpdate(lendingId[:], v))
+		}
+	}
+	return tr
+}
+
+func (self *lendingExchangeState) updateLendingTradeTrie(db Database) Trie {
+	tr := self.getLendingTradeTrie(db)
+	for tradeId, lendingTradeItem := range self.lendingTradeStates {
+		if _, isDirty := self.lendingTradeStatesDirty[tradeId]; isDirty {
+			delete(self.lendingTradeStatesDirty, tradeId)
+			if lendingTradeItem.empty() {
+				self.setError(tr.TryDelete(tradeId[:]))
+				continue
+			}
+			// Encoding []byte cannot fail, ok to ignore the error.
+			v, _ := rlp.EncodeToBytes(lendingTradeItem)
+			self.setError(tr.TryUpdate(tradeId[:], v))
+		}
+	}
+	return tr
+}
+func (self *lendingExchangeState) updateBorrowingTrie(db Database) Trie {
+	tr := self.getBorrowingTrie(db)
+	for rate, orderList := range self.borrowingStates {
+		if _, isDirty := self.borrowingStatesDirty[rate]; isDirty {
+			delete(self.borrowingStatesDirty, rate)
+			if orderList.empty() {
+				self.setError(tr.TryDelete(rate[:]))
+				continue
+			}
+			orderList.updateRoot(db)
+			// Encoding []byte cannot fail, ok to ignore the error.
+			v, _ := rlp.EncodeToBytes(orderList)
+			self.setError(tr.TryUpdate(rate[:], v))
+		}
+	}
+	return tr
+}
+
+func (self *lendingExchangeState) updateInvestingTrie(db Database) Trie {
+	tr := self.getInvestingTrie(db)
+	for rate, orderList := range self.investingStates {
+		if _, isDirty := self.investingStatesDirty[rate]; isDirty {
+			delete(self.investingStatesDirty, rate)
+			if orderList.empty() {
+				self.setError(tr.TryDelete(rate[:]))
+				continue
+			}
+			orderList.updateRoot(db)
+			// Encoding []byte cannot fail, ok to ignore the error.
+			v, _ := rlp.EncodeToBytes(orderList)
+			self.setError(tr.TryUpdate(rate[:], v))
+		}
+	}
+	return tr
+}
+
+func (self *lendingExchangeState) updateLiquidationTimeTrie(db Database) Trie {
+	tr := self.getLiquidationTimeTrie(db)
+	for time, itemList := range self.liquidationTimeStates {
+		if _, isDirty := self.liquidationTimestatesDirty[time]; isDirty {
+			delete(self.liquidationTimestatesDirty, time)
+			if itemList.empty() {
+				self.setError(tr.TryDelete(time[:]))
+				continue
+			}
+			itemList.updateRoot(db)
+			// Encoding []byte cannot fail, ok to ignore the error.
+			v, _ := rlp.EncodeToBytes(itemList)
+			self.setError(tr.TryUpdate(time[:], v))
+		}
+	}
+	return tr
+}
+
+/**
+  Update Root
+*/
+
+func (self *lendingExchangeState) updateOrderRoot(db Database) {
+	self.updateLendingTimeTrie(db)
+	self.data.LendingItemRoot = self.lendingItemTrie.Hash()
+}
+
+func (self *lendingExchangeState) updateInvestingRoot(db Database) error {
+	self.updateInvestingTrie(db)
+	if self.dbErr != nil {
+		return self.dbErr
+	}
+	self.data.InvestingRoot = self.investingTrie.Hash()
+	return nil
+}
+
+func (self *lendingExchangeState) updateBorrowingRoot(db Database) {
+	self.updateBorrowingTrie(db)
+	self.data.BorrowingRoot = self.borrowingTrie.Hash()
+}
+
+func (self *lendingExchangeState) updateLiquidationTimeRoot(db Database) {
+	self.updateLiquidationTimeTrie(db)
+	self.data.LiquidationTimeRoot = self.liquidationTimeTrie.Hash()
+}
+
+func (self *lendingExchangeState) updateLendingTradeRoot(db Database) {
+	self.updateLendingTradeTrie(db)
+	self.data.LendingTradeRoot = self.lendingTradeTrie.Hash()
+}
+
+/**
+  Commit Trie
+*/
+
+func (self *lendingExchangeState) CommitLendingItemTrie(db Database) error {
+	self.updateLendingTimeTrie(db)
+	if self.dbErr != nil {
+		return self.dbErr
+	}
+	root, _, err := self.lendingItemTrie.Commit(nil)
+	if err == nil {
+		self.data.LendingItemRoot = root
+	}
+	return err
+}
+
+func (self *lendingExchangeState) CommitLendingTradeTrie(db Database) error {
+	self.updateLendingTradeTrie(db)
+	if self.dbErr != nil {
+		return self.dbErr
+	}
+	root, _, err := self.lendingTradeTrie.Commit(nil)
+	if err == nil {
+		self.data.LendingTradeRoot = root
+	}
+	return err
+}
+
+func (self *lendingExchangeState) CommitInvestingTrie(db Database) error {
+	self.updateInvestingTrie(db)
+	if self.dbErr != nil {
+		return self.dbErr
+	}
+	root, _, err := self.investingTrie.Commit(func(_ []byte, leaf []byte, parent common.Hash) error {
+		var orderList itemList
+		if err := rlp.DecodeBytes(leaf, &orderList); err != nil {
+			return nil
+		}
+		if orderList.Root != EmptyRoot {
+			db.TrieDB().Reference(orderList.Root, parent)
+		}
+		return nil
+	})
+	if err == nil {
+		self.data.InvestingRoot = root
+	}
+	return err
+}
+
+func (self *lendingExchangeState) CommitBorrowingTrie(db Database) error {
+	self.updateBorrowingTrie(db)
+	if self.dbErr != nil {
+		return self.dbErr
+	}
+	root, _, err := self.borrowingTrie.Commit(func(_ []byte, leaf []byte, parent common.Hash) error {
+		var orderList itemList
+		if err := rlp.DecodeBytes(leaf, &orderList); err != nil {
+			return nil
+		}
+		if orderList.Root != EmptyRoot {
+			db.TrieDB().Reference(orderList.Root, parent)
+		}
+		return nil
+	})
+	if err == nil {
+		self.data.BorrowingRoot = root
+	}
+	return err
+}
+
+func (self *lendingExchangeState) CommitLiquidationTimeTrie(db Database) error {
+	self.updateLiquidationTimeTrie(db)
+	if self.dbErr != nil {
+		return self.dbErr
+	}
+	root, _, err := self.liquidationTimeTrie.Commit(func(_ []byte, leaf []byte, parent common.Hash) error {
+		var orderList itemList
+		if err := rlp.DecodeBytes(leaf, &orderList); err != nil {
+			return nil
+		}
+		if orderList.Root != EmptyRoot {
+			db.TrieDB().Reference(orderList.Root, parent)
+		}
+		return nil
+	})
+	if err == nil {
+		self.data.LiquidationTimeRoot = root
+	}
+	return err
+}
+
+/*
+*
+Get Trie Data
+*/
+func (self *lendingExchangeState) getBestInvestingInterest(db Database) common.Hash {
+	trie := self.getInvestingTrie(db)
+	encKey, encValue, err := trie.TryGetBestLeftKeyAndValue()
+	if err != nil {
+		log.Error("Failed find best investing rate", "orderbook", self.lendingBook.Hex())
+		return EmptyHash
+	}
+	if len(encKey) == 0 || len(encValue) == 0 {
+		log.Debug("Not found get best investing rate", "encKey", encKey, "encValue", encValue)
+		return EmptyHash
+	}
+	// Insert into the live set.
+	interest := common.BytesToHash(encKey)
+	if _, exist := self.investingStates[interest]; !exist {
+		var data itemList
+		if err := rlp.DecodeBytes(encValue, &data); err != nil {
+			log.Error("Failed to decode state get best investing rate", "err", err)
+			return EmptyHash
+		}
+		obj := newItemListState(self.lendingBook, interest, data, self.MarkInvestingDirty)
+		self.investingStates[interest] = obj
+	}
+	return interest
+}
+
+func (self *lendingExchangeState) getBestBorrowingInterest(db Database) common.Hash {
+	trie := self.getBorrowingTrie(db)
+	encKey, encValue, err := trie.TryGetBestRightKeyAndValue()
+	if err != nil {
+		log.Error("Failed find best key bid trie ", "orderbook", self.lendingBook.Hex())
+		return EmptyHash
+	}
+	if len(encKey) == 0 || len(encValue) == 0 {
+		log.Debug("Not found get best bid trie", "encKey", encKey, "encValue", encValue)
+		return EmptyHash
+	}
+	// Insert into the live set.
+	interest := common.BytesToHash(encKey)
+	if _, exist := self.borrowingStates[interest]; !exist {
+		var data itemList
+		if err := rlp.DecodeBytes(encValue, &data); err != nil {
+			log.Error("Failed to decode state get best bid trie", "err", err)
+			return EmptyHash
+		}
+		obj := newItemListState(self.lendingBook, interest, data, self.MarkBorrowingDirty)
+		self.borrowingStates[interest] = obj
+	}
+	return interest
+}
+
+func (self *lendingExchangeState) getLowestLiquidationTime(db Database) (common.Hash, *liquidationTimeState) {
+	trie := self.getLiquidationTimeTrie(db)
+	encKey, encValue, err := trie.TryGetBestLeftKeyAndValue()
+	if err != nil {
+		log.Error("Failed find best liquidation time trie ", "orderBook", self.lendingBook.Hex())
+		return EmptyHash, nil
+	}
+	if len(encKey) == 0 || len(encValue) == 0 {
+		log.Debug("Not found get liquidation time trie", "encKey", encKey, "encValue", encValue)
+		return EmptyHash, nil
+	}
+	price := common.BytesToHash(encKey)
+	obj, exist := self.liquidationTimeStates[price]
+	if !exist {
+		var data itemList
+		if err := rlp.DecodeBytes(encValue, &data); err != nil {
+			log.Error("Failed to decode state get liquidation time trie", "err", err)
+			return EmptyHash, nil
+		}
+		obj = newLiquidationTimeState(self.lendingBook, price, data, self.MarkLiquidationTimeDirty)
+		self.liquidationTimeStates[price] = obj
+	}
+	if obj.empty() {
+		return EmptyHash, nil
+	}
+	return price, obj
+}
+
+func (self *lendingExchangeState) deepCopy(db *LendingStateDB, onDirty func(hash common.Hash)) *lendingExchangeState {
+	stateExchanges := newStateExchanges(db, self.lendingBook, self.data, onDirty)
+	if self.investingTrie != nil {
+		stateExchanges.investingTrie = db.db.CopyTrie(self.investingTrie)
+	}
+	if self.borrowingTrie != nil {
+		stateExchanges.borrowingTrie = db.db.CopyTrie(self.borrowingTrie)
+	}
+	if self.lendingItemTrie != nil {
+		stateExchanges.lendingItemTrie = db.db.CopyTrie(self.lendingItemTrie)
+	}
+	for key, value := range self.borrowingStates {
+		stateExchanges.borrowingStates[key] = value.deepCopy(db, self.MarkBorrowingDirty)
+	}
+	for key := range self.borrowingStatesDirty {
+		stateExchanges.borrowingStatesDirty[key] = struct{}{}
+	}
+	for key, value := range self.investingStates {
+		stateExchanges.investingStates[key] = value.deepCopy(db, self.MarkInvestingDirty)
+	}
+	for key := range self.investingStatesDirty {
+		stateExchanges.investingStatesDirty[key] = struct{}{}
+	}
+	for key, value := range self.lendingItemStates {
+		stateExchanges.lendingItemStates[key] = value.deepCopy(self.MarkLendingItemDirty)
+	}
+	for orderId := range self.lendingItemStatesDirty {
+		stateExchanges.lendingItemStatesDirty[orderId] = struct{}{}
+	}
+	for key, value := range self.lendingTradeStates {
+		stateExchanges.lendingTradeStates[key] = value.deepCopy(self.MarkLendingTradeDirty)
+	}
+	for orderId := range self.lendingTradeStatesDirty {
+		stateExchanges.lendingTradeStatesDirty[orderId] = struct{}{}
+	}
+	for time, orderList := range self.liquidationTimeStates {
+		stateExchanges.liquidationTimeStates[time] = orderList.deepCopy(db, self.MarkLiquidationTimeDirty)
+	}
+	for time := range self.liquidationTimestatesDirty {
+		stateExchanges.liquidationTimestatesDirty[time] = struct{}{}
+	}
+	return stateExchanges
+}
+
+// Returns the address of the contract/tradeId
+func (self *lendingExchangeState) Hash() common.Hash {
+	return self.lendingBook
+}
+
+func (self *lendingExchangeState) setNonce(nonce uint64) {
+	self.data.Nonce = nonce
+	if self.onDirty != nil {
+		self.onDirty(self.Hash())
+		self.onDirty = nil
+	}
+}
+
+func (self *lendingExchangeState) Nonce() uint64 {
+	return self.data.Nonce
+}
+
+func (self *lendingExchangeState) setTradeNonce(nonce uint64) {
+	self.data.TradeNonce = nonce
+	if self.onDirty != nil {
+		self.onDirty(self.Hash())
+		self.onDirty = nil
+	}
+}
+func (self *lendingExchangeState) TradeNonce() uint64 {
+	return self.data.TradeNonce
+}
+
+func (self *lendingExchangeState) removeInvestingOrderList(db Database, stateOrderList *itemListState) {
+	self.setError(self.investingTrie.TryDelete(stateOrderList.key[:]))
+}
+
+func (self *lendingExchangeState) removeBorrowingOrderList(db Database, stateOrderList *itemListState) {
+	self.setError(self.borrowingTrie.TryDelete(stateOrderList.key[:]))
+}
+
+func (self *lendingExchangeState) createInvestingOrderList(db Database, price common.Hash) (newobj *itemListState) {
+	newobj = newItemListState(self.lendingBook, price, itemList{Volume: Zero}, self.MarkInvestingDirty)
+	self.investingStates[price] = newobj
+	self.investingStatesDirty[price] = struct{}{}
+	data, err := rlp.EncodeToBytes(newobj)
+	if err != nil {
+		panic(fmt.Errorf("can't encode order list object at %x: %v", price[:], err))
+	}
+	self.setError(self.getInvestingTrie(db).TryUpdate(price[:], data))
+	if self.onDirty != nil {
+		self.onDirty(self.Hash())
+		self.onDirty = nil
+	}
+	return newobj
+}
+
+func (self *lendingExchangeState) MarkBorrowingDirty(price common.Hash) {
+	self.borrowingStatesDirty[price] = struct{}{}
+	if self.onDirty != nil {
+		self.onDirty(self.Hash())
+		self.onDirty = nil
+	}
+}
+
+func (self *lendingExchangeState) MarkInvestingDirty(price common.Hash) {
+	self.investingStatesDirty[price] = struct{}{}
+	if self.onDirty != nil {
+		self.onDirty(self.Hash())
+		self.onDirty = nil
+	}
+}
+
+func (self *lendingExchangeState) MarkLendingItemDirty(lending common.Hash) {
+	self.lendingItemStatesDirty[lending] = struct{}{}
+	if self.onDirty != nil {
+		self.onDirty(self.Hash())
+		self.onDirty = nil
+	}
+}
+
+func (self *lendingExchangeState) MarkLendingTradeDirty(tradeId common.Hash) {
+	self.lendingTradeStatesDirty[tradeId] = struct{}{}
+	if self.onDirty != nil {
+		self.onDirty(self.Hash())
+		self.onDirty = nil
+	}
+}
+
+func (self *lendingExchangeState) MarkLiquidationTimeDirty(orderId common.Hash) {
+	self.liquidationTimestatesDirty[orderId] = struct{}{}
+	if self.onDirty != nil {
+		self.onDirty(self.Hash())
+		self.onDirty = nil
+	}
+}
+
+func (self *lendingExchangeState) createBorrowingOrderList(db Database, price common.Hash) (newobj *itemListState) {
+	newobj = newItemListState(self.lendingBook, price, itemList{Volume: Zero}, self.MarkBorrowingDirty)
+	self.borrowingStates[price] = newobj
+	self.borrowingStatesDirty[price] = struct{}{}
+	data, err := rlp.EncodeToBytes(newobj)
+	if err != nil {
+		panic(fmt.Errorf("can't encode order list object at %x: %v", price[:], err))
+	}
+	self.setError(self.getBorrowingTrie(db).TryUpdate(price[:], data))
+	if self.onDirty != nil {
+		self.onDirty(self.Hash())
+		self.onDirty = nil
+	}
+	return newobj
+}
+
+func (self *lendingExchangeState) createLendingItem(db Database, orderId common.Hash, order LendingItem) (newobj *lendingItemState) {
+	newobj = newLendinItemState(self.lendingBook, orderId, order, self.MarkLendingItemDirty)
+	orderIdHash := common.BigToHash(new(big.Int).SetUint64(order.LendingId))
+	self.lendingItemStates[orderIdHash] = newobj
+	self.lendingItemStatesDirty[orderIdHash] = struct{}{}
+	if self.onDirty != nil {
+		self.onDirty(self.lendingBook)
+		self.onDirty = nil
+	}
+	return newobj
+}
+
+func (self *lendingExchangeState) createLiquidationTime(db Database, time common.Hash) (newobj *liquidationTimeState) {
+	newobj = newLiquidationTimeState(time, self.lendingBook, itemList{Volume: Zero}, self.MarkLiquidationTimeDirty)
+	self.liquidationTimeStates[time] = newobj
+	self.liquidationTimestatesDirty[time] = struct{}{}
+	data, err := rlp.EncodeToBytes(newobj)
+	if err != nil {
+		panic(fmt.Errorf("can't encode liquidation time at %x: %v", time[:], err))
+	}
+	self.setError(self.getLiquidationTimeTrie(db).TryUpdate(time[:], data))
+	if self.onDirty != nil {
+		self.onDirty(self.lendingBook)
+		self.onDirty = nil
+	}
+	return newobj
+}
+
+func (self *lendingExchangeState) insertLendingTrade(tradeId common.Hash, order LendingTrade) (newobj *lendingTradeState) {
+	newobj = newLendingTradeState(self.lendingBook, tradeId, order, self.MarkLendingTradeDirty)
+	self.lendingTradeStates[tradeId] = newobj
+	self.lendingTradeStatesDirty[tradeId] = struct{}{}
+	if self.onDirty != nil {
+		self.onDirty(self.lendingBook)
+		self.onDirty = nil
+	}
+	return newobj
+}

--- a/legacy/tomoxlending/lendingstate/state_lendingitem.go
+++ b/legacy/tomoxlending/lendingstate/state_lendingitem.go
@@ -1,0 +1,67 @@
+// Copyright 2014 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package lendingstate
+
+import (
+	"io"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+type lendingItemState struct {
+	orderBook common.Hash
+	orderId   common.Hash
+	data      LendingItem
+	onDirty   func(orderId common.Hash) // Callback method to mark a state object newly dirty
+}
+
+func (s *lendingItemState) empty() bool {
+	return s.data.Quantity == nil || s.data.Quantity.Cmp(Zero) == 0
+}
+
+func newLendinItemState(orderBook common.Hash, orderId common.Hash, data LendingItem, onDirty func(orderId common.Hash)) *lendingItemState {
+	return &lendingItemState{
+		orderBook: orderBook,
+		orderId:   orderId,
+		data:      data,
+		onDirty:   onDirty,
+	}
+}
+
+// EncodeRLP implements rlp.Encoder.
+func (c *lendingItemState) EncodeRLP(w io.Writer) error {
+	return rlp.Encode(w, c.data)
+}
+
+func (self *lendingItemState) deepCopy(onDirty func(orderId common.Hash)) *lendingItemState {
+	stateOrderList := newLendinItemState(self.orderBook, self.orderId, self.data, onDirty)
+	return stateOrderList
+}
+
+func (self *lendingItemState) setVolume(volume *big.Int) {
+	self.data.Quantity = volume
+	if self.onDirty != nil {
+		self.onDirty(self.orderId)
+		self.onDirty = nil
+	}
+}
+
+func (self *lendingItemState) Quantity() *big.Int {
+	return self.data.Quantity
+}

--- a/legacy/tomoxlending/lendingstate/state_lendingtrade.go
+++ b/legacy/tomoxlending/lendingstate/state_lendingtrade.go
@@ -1,0 +1,78 @@
+// Copyright 2014 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package lendingstate
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rlp"
+	"io"
+	"math/big"
+)
+
+type lendingTradeState struct {
+	orderBook common.Hash
+	tradeId   common.Hash
+	data      LendingTrade
+	onDirty   func(orderId common.Hash) // Callback method to mark a state object newly dirty
+}
+
+func (s *lendingTradeState) empty() bool {
+	return s.data.Amount.Sign() == 0
+}
+
+func newLendingTradeState(orderBook common.Hash, tradeId common.Hash, data LendingTrade, onDirty func(orderId common.Hash)) *lendingTradeState {
+	return &lendingTradeState{
+		orderBook: orderBook,
+		tradeId:   tradeId,
+		data:      data,
+		onDirty:   onDirty,
+	}
+}
+
+// EncodeRLP implements rlp.Encoder.
+func (c *lendingTradeState) EncodeRLP(w io.Writer) error {
+	return rlp.Encode(w, c.data)
+}
+
+func (self *lendingTradeState) deepCopy(onDirty func(orderId common.Hash)) *lendingTradeState {
+	stateOrderList := newLendingTradeState(self.orderBook, self.tradeId, self.data, onDirty)
+	return stateOrderList
+}
+
+func (self *lendingTradeState) SetCollateralLockedAmount(amount *big.Int) {
+	self.data.CollateralLockedAmount = amount
+	if self.onDirty != nil {
+		self.onDirty(self.tradeId)
+		self.onDirty = nil
+	}
+}
+
+func (self *lendingTradeState) SetLiquidationPrice(price *big.Int) {
+	self.data.LiquidationPrice = price
+	if self.onDirty != nil {
+		self.onDirty(self.tradeId)
+		self.onDirty = nil
+	}
+}
+
+func (self *lendingTradeState) SetAmount(amount *big.Int) {
+	self.data.Amount = amount
+	if self.onDirty != nil {
+		self.onDirty(self.tradeId)
+		self.onDirty = nil
+	}
+}

--- a/legacy/tomoxlending/lendingstate/state_liquidationtime.go
+++ b/legacy/tomoxlending/lendingstate/state_liquidationtime.go
@@ -1,0 +1,214 @@
+// Copyright 2014 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package lendingstate
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/ethereum/go-ethereum/trie"
+)
+
+type liquidationTimeState struct {
+	time        common.Hash
+	lendingBook common.Hash
+	data        itemList
+
+	// DB error.
+	// State objects are used by the consensus core and VM which are
+	// unable to deal with database-level errors. Any error that occurs
+	// during a database read is memoized here and will eventually be returned
+	// by TradingStateDB.Commit.
+	dbErr error
+
+	// Write caches.
+	trie Trie // storage trie, which becomes non-nil on first access
+
+	cachedStorage map[common.Hash]common.Hash
+	dirtyStorage  map[common.Hash]common.Hash
+
+	onDirty func(time common.Hash) // Callback method to mark a state object newly dirty
+}
+
+func (s *liquidationTimeState) empty() bool {
+	return s.data.Volume == nil || s.data.Volume.Sign() == 0
+}
+
+func newLiquidationTimeState(time common.Hash, lendingBook common.Hash, data itemList, onDirty func(time common.Hash)) *liquidationTimeState {
+	return &liquidationTimeState{
+		lendingBook:   lendingBook,
+		time:          time,
+		data:          data,
+		cachedStorage: make(map[common.Hash]common.Hash),
+		dirtyStorage:  make(map[common.Hash]common.Hash),
+		onDirty:       onDirty,
+	}
+}
+
+func (self *liquidationTimeState) EncodeRLP(w io.Writer) error {
+	return rlp.Encode(w, self.data)
+}
+
+func (self *liquidationTimeState) setError(err error) {
+	if self.dbErr == nil {
+		self.dbErr = err
+	}
+}
+
+func (self *liquidationTimeState) getTrie(db Database) Trie {
+	if self.trie == nil {
+		var err error
+		self.trie, err = db.OpenStorageTrie(self.lendingBook, self.data.Root)
+		if err != nil {
+			self.trie, _ = db.OpenStorageTrie(self.time, EmptyHash)
+			self.setError(fmt.Errorf("can't create storage trie: %v", err))
+		}
+	}
+	return self.trie
+}
+
+func (self *liquidationTimeState) Exist(db Database, tradeId common.Hash) bool {
+	amount, exists := self.cachedStorage[tradeId]
+	if exists {
+		return true
+	}
+	// Load from DB in case it is missing.
+	enc, err := self.getTrie(db).TryGet(tradeId[:])
+	if err != nil {
+		self.setError(err)
+		return false
+	}
+	if len(enc) > 0 {
+		_, content, _, err := rlp.Split(enc)
+		if err != nil {
+			self.setError(err)
+		}
+		amount.SetBytes(content)
+	}
+	if (amount != common.Hash{}) {
+		self.cachedStorage[tradeId] = amount
+	}
+	return true
+}
+
+func (self *liquidationTimeState) getAllTradeIds(db Database) []common.Hash {
+	tradeIds := []common.Hash{}
+	lendingBookTrie := self.getTrie(db)
+	if lendingBookTrie == nil {
+		return tradeIds
+	}
+	for id, value := range self.cachedStorage {
+		if !params.EmptyHash(value) {
+			tradeIds = append(tradeIds, id)
+		}
+	}
+	orderListIt := trie.NewIterator(lendingBookTrie.NodeIterator(nil))
+	for orderListIt.Next() {
+		id := common.BytesToHash(orderListIt.Key)
+		if _, exist := self.cachedStorage[id]; exist {
+			continue
+		}
+		tradeIds = append(tradeIds, id)
+	}
+	return tradeIds
+}
+
+func (self *liquidationTimeState) insertTradeId(db Database, tradeId common.Hash) {
+	self.setTradeId(tradeId, tradeId)
+	self.setError(self.getTrie(db).TryUpdate(tradeId[:], tradeId[:]))
+}
+
+func (self *liquidationTimeState) removeTradeId(db Database, tradeId common.Hash) {
+	tr := self.getTrie(db)
+	self.setError(tr.TryDelete(tradeId[:]))
+	self.setTradeId(tradeId, EmptyHash)
+}
+
+func (self *liquidationTimeState) setTradeId(tradeId common.Hash, value common.Hash) {
+	self.cachedStorage[tradeId] = value
+	self.dirtyStorage[tradeId] = value
+
+	if self.onDirty != nil {
+		self.onDirty(self.lendingBook)
+		self.onDirty = nil
+	}
+}
+
+func (self *liquidationTimeState) updateTrie(db Database) Trie {
+	tr := self.getTrie(db)
+	for key, value := range self.dirtyStorage {
+		delete(self.dirtyStorage, key)
+		if value == EmptyHash {
+			self.setError(tr.TryDelete(key[:]))
+			continue
+		}
+		v, _ := rlp.EncodeToBytes(bytes.TrimLeft(value[:], "\x00"))
+		self.setError(tr.TryUpdate(key[:], v))
+	}
+	return tr
+}
+
+func (self *liquidationTimeState) updateRoot(db Database) error {
+	self.updateTrie(db)
+	if self.dbErr != nil {
+		return self.dbErr
+	}
+	root, _, err := self.trie.Commit(nil)
+	if err == nil {
+		self.data.Root = root
+	}
+	return err
+}
+
+func (self *liquidationTimeState) deepCopy(db *LendingStateDB, onDirty func(time common.Hash)) *liquidationTimeState {
+	stateLendingBook := newLiquidationTimeState(self.lendingBook, self.time, self.data, onDirty)
+	if self.trie != nil {
+		stateLendingBook.trie = db.db.CopyTrie(self.trie)
+	}
+	for key, value := range self.dirtyStorage {
+		stateLendingBook.dirtyStorage[key] = value
+	}
+	for key, value := range self.cachedStorage {
+		stateLendingBook.cachedStorage[key] = value
+	}
+	return stateLendingBook
+}
+
+func (c *liquidationTimeState) AddVolume(amount *big.Int) {
+	c.setVolume(new(big.Int).Add(c.data.Volume, amount))
+}
+
+func (c *liquidationTimeState) subVolume(amount *big.Int) {
+	c.setVolume(new(big.Int).Sub(c.data.Volume, amount))
+}
+
+func (self *liquidationTimeState) setVolume(volume *big.Int) {
+	self.data.Volume = volume
+	if self.onDirty != nil {
+		self.onDirty(self.lendingBook)
+		self.onDirty = nil
+	}
+}
+
+func (self *liquidationTimeState) Volume() *big.Int {
+	return self.data.Volume
+}

--- a/legacy/tomoxlending/lendingstate/statedb.go
+++ b/legacy/tomoxlending/lendingstate/statedb.go
@@ -1,0 +1,671 @@
+// Copyright 2014 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// Package state provides a caching layer atop the Ethereum state trie.
+package lendingstate
+
+import (
+	"fmt"
+	"math/big"
+	"sort"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+type revision struct {
+	id           int
+	journalIndex int
+}
+
+type LendingStateDB struct {
+	db   Database
+	trie Trie
+
+	// This map holds 'live' objects, which will get modified while processing a state transition.
+	lendingExchangeStates      map[common.Hash]*lendingExchangeState
+	lendingExchangeStatesDirty map[common.Hash]struct{}
+
+	// DB error.
+	// State objects are used by the consensus core and VM which are
+	// unable to deal with database-level errors. Any error that occurs
+	// during a database read is memoized here and will eventually be returned
+	// by LendingStateDB.Commit.
+	dbErr error
+
+	// Journal of state modifications. This is the backbone of
+	// Snapshot and RevertToSnapshot.
+	journal        journal
+	validRevisions []revision
+	nextRevisionId int
+
+	lock sync.Mutex
+}
+
+// Create a new state from a given trie.
+func New(root common.Hash, db Database) (*LendingStateDB, error) {
+	tr, err := db.OpenTrie(root)
+	if err != nil {
+		log.Error("Error when init new lending state trie ", "root", root.Hex(), "err", err)
+		return nil, err
+	}
+	return &LendingStateDB{
+		db:                         db,
+		trie:                       tr,
+		lendingExchangeStates:      make(map[common.Hash]*lendingExchangeState),
+		lendingExchangeStatesDirty: make(map[common.Hash]struct{}),
+	}, nil
+}
+
+// setError remembers the first non-nil error it is called with.
+func (self *LendingStateDB) setError(err error) {
+	if self.dbErr == nil {
+		self.dbErr = err
+	}
+}
+
+func (self *LendingStateDB) Error() error {
+	return self.dbErr
+}
+
+// Exist reports whether the given tradeId address exists in the state.
+// Notably this also returns true for suicided lenddinges.
+func (self *LendingStateDB) Exist(addr common.Hash) bool {
+	return self.getLendingExchange(addr) != nil
+}
+
+// Empty returns whether the state object is either non-existent
+// or empty according to the EIP161 specification (balance = nonce = code = 0)
+func (self *LendingStateDB) Empty(addr common.Hash) bool {
+	so := self.getLendingExchange(addr)
+	return so == nil || so.empty()
+}
+
+func (self *LendingStateDB) GetNonce(addr common.Hash) uint64 {
+	stateObject := self.getLendingExchange(addr)
+	if stateObject != nil {
+		return stateObject.Nonce()
+	}
+	return 0
+}
+
+func (self *LendingStateDB) GetTradeNonce(addr common.Hash) uint64 {
+	stateObject := self.getLendingExchange(addr)
+	if stateObject != nil {
+		return stateObject.TradeNonce()
+	}
+	return 0
+}
+
+// Database retrieves the low level database supporting the lower level trie ops.
+func (self *LendingStateDB) Database() Database {
+	return self.db
+}
+
+func (self *LendingStateDB) SetNonce(addr common.Hash, nonce uint64) {
+	stateObject := self.GetOrNewLendingExchangeObject(addr)
+	if stateObject != nil {
+		self.journal = append(self.journal, nonceChange{
+			hash: addr,
+			prev: stateObject.Nonce(),
+		})
+		stateObject.setNonce(nonce)
+	}
+}
+
+func (self *LendingStateDB) SetTradeNonce(addr common.Hash, nonce uint64) {
+	stateObject := self.GetOrNewLendingExchangeObject(addr)
+	if stateObject != nil {
+		self.journal = append(self.journal, tradeNonceChange{
+			hash: addr,
+			prev: stateObject.TradeNonce(),
+		})
+		stateObject.setTradeNonce(nonce)
+	}
+}
+
+func (self *LendingStateDB) InsertLendingItem(orderBook common.Hash, orderId common.Hash, order LendingItem) {
+	interestHash := common.BigToHash(order.Interest)
+	stateExchange := self.getLendingExchange(orderBook)
+	if stateExchange == nil {
+		stateExchange = self.createLendingExchangeObject(orderBook)
+	}
+	var stateOrderList *itemListState
+	switch order.Side {
+	case Investing:
+		stateOrderList = stateExchange.getInvestingOrderList(self.db, interestHash)
+		if stateOrderList == nil {
+			stateOrderList = stateExchange.createInvestingOrderList(self.db, interestHash)
+		}
+	case Borrowing:
+		stateOrderList = stateExchange.getBorrowingOrderList(self.db, interestHash)
+		if stateOrderList == nil {
+			stateOrderList = stateExchange.createBorrowingOrderList(self.db, interestHash)
+		}
+	default:
+		return
+	}
+	self.journal = append(self.journal, insertOrder{
+		orderBook: orderBook,
+		orderId:   orderId,
+		order:     &order,
+	})
+	stateExchange.createLendingItem(self.db, orderId, order)
+	stateOrderList.insertLendingItem(self.db, orderId, common.BigToHash(order.Quantity))
+	stateOrderList.AddVolume(order.Quantity)
+}
+
+func (self *LendingStateDB) InsertTradingItem(orderBook common.Hash, tradeId uint64, order LendingTrade) {
+	tradeIdHash := params.Uint64ToHash(tradeId)
+	stateExchange := self.getLendingExchange(orderBook)
+	if stateExchange == nil {
+		stateExchange = self.createLendingExchangeObject(orderBook)
+	}
+	prvTrade := self.GetLendingTrade(orderBook, tradeIdHash)
+	self.journal = append(self.journal, insertTrading{
+		orderBook: orderBook,
+		tradeId:   tradeId,
+		prvTrade:  &prvTrade,
+	})
+	stateExchange.insertLendingTrade(tradeIdHash, order)
+}
+
+func (self *LendingStateDB) UpdateLiquidationPrice(orderBook common.Hash, tradeId uint64, price *big.Int) {
+	tradeIdHash := params.Uint64ToHash(tradeId)
+	stateExchange := self.getLendingExchange(orderBook)
+	if stateExchange == nil {
+		stateExchange = self.createLendingExchangeObject(orderBook)
+	}
+	stateLendingTrade := stateExchange.getLendingTrade(self.db, tradeIdHash)
+	self.journal = append(self.journal, liquidationPriceChange{
+		orderBook: orderBook,
+		tradeId:   tradeIdHash,
+		prev:      stateLendingTrade.data.LiquidationPrice,
+	})
+	stateLendingTrade.SetLiquidationPrice(price)
+}
+func (self *LendingStateDB) UpdateCollateralLockedAmount(orderBook common.Hash, tradeId uint64, amount *big.Int) {
+	tradeIdHash := params.Uint64ToHash(tradeId)
+	stateExchange := self.getLendingExchange(orderBook)
+	if stateExchange == nil {
+		stateExchange = self.createLendingExchangeObject(orderBook)
+	}
+	stateLendingTrade := stateExchange.getLendingTrade(self.db, tradeIdHash)
+	self.journal = append(self.journal, collateralLockedAmount{
+		orderBook: orderBook,
+		tradeId:   tradeIdHash,
+		prev:      stateLendingTrade.data.CollateralLockedAmount,
+	})
+	stateLendingTrade.SetCollateralLockedAmount(amount)
+}
+func (self *LendingStateDB) GetLendingOrder(orderBook common.Hash, orderId common.Hash) LendingItem {
+	stateObject := self.GetOrNewLendingExchangeObject(orderBook)
+	if stateObject == nil {
+		return EmptyLendingOrder
+	}
+	stateOrderItem := stateObject.getLendingItem(self.db, orderId)
+	if stateOrderItem == nil {
+		return EmptyLendingOrder
+	}
+	return stateOrderItem.data
+}
+
+func (self *LendingStateDB) GetLendingTrade(orderBook common.Hash, tradeId common.Hash) LendingTrade {
+	stateObject := self.GetOrNewLendingExchangeObject(orderBook)
+	if stateObject == nil {
+		return EmptyLendingTrade
+	}
+	stateOrderItem := stateObject.getLendingTrade(self.db, tradeId)
+	if stateOrderItem == nil || stateOrderItem.empty() {
+		return EmptyLendingTrade
+	}
+	return stateOrderItem.data
+}
+
+func (self *LendingStateDB) SubAmountLendingItem(orderBook common.Hash, orderId common.Hash, price *big.Int, amount *big.Int, side string) error {
+	priceHash := common.BigToHash(price)
+	lendingExchange := self.GetOrNewLendingExchangeObject(orderBook)
+	if lendingExchange == nil {
+		return fmt.Errorf("Order book not found : %s ", orderBook.Hex())
+	}
+	var orderList *itemListState
+	switch side {
+	case Investing:
+		orderList = lendingExchange.getInvestingOrderList(self.db, priceHash)
+	case Borrowing:
+		orderList = lendingExchange.getBorrowingOrderList(self.db, priceHash)
+	default:
+		return fmt.Errorf("Order type not found : %s ", side)
+	}
+	if orderList == nil || orderList.empty() {
+		return fmt.Errorf("Order list empty  order book : %s , order id  : %s , key  : %s ", orderBook, orderId.Hex(), priceHash.Hex())
+	}
+	lendingItem := lendingExchange.getLendingItem(self.db, orderId)
+	if lendingItem == nil || lendingItem.empty() {
+		return fmt.Errorf("Order item empty  order book : %s , order id  : %s , key  : %s ", orderBook, orderId.Hex(), priceHash.Hex())
+	}
+	currentAmount := new(big.Int).SetBytes(orderList.GetOrderAmount(self.db, orderId).Bytes()[:])
+	if currentAmount.Cmp(amount) < 0 {
+		return fmt.Errorf("Order amount not enough : %s , have : %d , want : %d ", orderId.Hex(), currentAmount, amount)
+	}
+	self.journal = append(self.journal, subAmountOrder{
+		orderBook: orderBook,
+		orderId:   orderId,
+		order:     self.GetLendingOrder(orderBook, orderId),
+		amount:    amount,
+	})
+	newAmount := new(big.Int).Sub(currentAmount, amount)
+	lendingItem.setVolume(newAmount)
+	log.Debug("SubAmountOrderItem", "tradeId", orderId.Hex(), "side", side, "key", price.Uint64(), "amount", amount.Uint64(), "new amount", newAmount.Uint64())
+	orderList.subVolume(amount)
+	if newAmount.Sign() == 0 {
+		orderList.removeOrderItem(self.db, orderId)
+	} else {
+		orderList.setOrderItem(orderId, common.BigToHash(newAmount))
+	}
+	if orderList.empty() {
+		switch side {
+		case Investing:
+			lendingExchange.removeInvestingOrderList(self.db, orderList)
+		case Borrowing:
+			lendingExchange.removeBorrowingOrderList(self.db, orderList)
+		default:
+		}
+	}
+	return nil
+}
+
+func (self *LendingStateDB) CancelLendingOrder(orderBook common.Hash, order *LendingItem) error {
+	interestHash := common.BigToHash(order.Interest)
+	orderIdHash := common.BigToHash(new(big.Int).SetUint64(order.LendingId))
+	stateObject := self.GetOrNewLendingExchangeObject(orderBook)
+	if stateObject == nil {
+		return fmt.Errorf("Order book not found : %s ", orderBook.Hex())
+	}
+	lendingItem := stateObject.getLendingItem(self.db, orderIdHash)
+	var orderList *itemListState
+	switch lendingItem.data.Side {
+	case Investing:
+		orderList = stateObject.getInvestingOrderList(self.db, interestHash)
+	case Borrowing:
+		orderList = stateObject.getBorrowingOrderList(self.db, interestHash)
+	default:
+		return fmt.Errorf("Order side not found : %s ", order.Side)
+	}
+	if orderList == nil || orderList.empty() {
+		return fmt.Errorf("Order list empty  order book : %s , order id  : %s , key  : %s ", orderBook, orderIdHash.Hex(), interestHash.Hex())
+	}
+	if lendingItem == nil || lendingItem.empty() {
+		return fmt.Errorf("Order item empty  order book : %s , order id  : %s , key  : %s ", orderBook, orderIdHash.Hex(), interestHash.Hex())
+	}
+	if lendingItem.data.UserAddress != order.UserAddress {
+		return fmt.Errorf("Error Order User Address mismatch when cancel order book : %s , order id  : %s , got : %s , expect : %s ", orderBook, orderIdHash.Hex(), lendingItem.data.UserAddress.Hex(), order.UserAddress.Hex())
+	}
+	self.journal = append(self.journal, cancelOrder{
+		orderBook: orderBook,
+		orderId:   orderIdHash,
+		order:     self.GetLendingOrder(orderBook, orderIdHash),
+	})
+	lendingItem.setVolume(big.NewInt(0))
+	currentAmount := new(big.Int).SetBytes(orderList.GetOrderAmount(self.db, orderIdHash).Bytes()[:])
+	orderList.subVolume(currentAmount)
+	orderList.removeOrderItem(self.db, orderIdHash)
+	if orderList.empty() {
+		switch order.Side {
+		case Investing:
+			stateObject.removeInvestingOrderList(self.db, orderList)
+		case Borrowing:
+			stateObject.removeBorrowingOrderList(self.db, orderList)
+		default:
+		}
+	}
+	return nil
+}
+
+func (self *LendingStateDB) GetBestInvestingRate(orderBook common.Hash) (*big.Int, *big.Int) {
+	stateObject := self.getLendingExchange(orderBook)
+	if stateObject != nil {
+		investingHash := stateObject.getBestInvestingInterest(self.db)
+		if params.EmptyHash(investingHash) {
+			return Zero, Zero
+		}
+		orderList := stateObject.getInvestingOrderList(self.db, investingHash)
+		if orderList == nil {
+			log.Error("order list investing not found", "key", investingHash.Hex())
+			return Zero, Zero
+		}
+		return new(big.Int).SetBytes(investingHash.Bytes()), orderList.Volume()
+	}
+	return Zero, Zero
+}
+
+func (self *LendingStateDB) GetBestBorrowRate(orderBook common.Hash) (*big.Int, *big.Int) {
+	stateObject := self.getLendingExchange(orderBook)
+	if stateObject != nil {
+		priceHash := stateObject.getBestBorrowingInterest(self.db)
+		if params.EmptyHash(priceHash) {
+			return Zero, Zero
+		}
+		orderList := stateObject.getBorrowingOrderList(self.db, priceHash)
+		if orderList == nil {
+			log.Error("order list ask not found", "key", priceHash.Hex())
+			return Zero, Zero
+		}
+		return new(big.Int).SetBytes(priceHash.Bytes()), orderList.Volume()
+	}
+	return Zero, Zero
+}
+
+func (self *LendingStateDB) GetBestLendingIdAndAmount(orderBook common.Hash, price *big.Int, side string) (common.Hash, *big.Int, error) {
+	stateObject := self.GetOrNewLendingExchangeObject(orderBook)
+	if stateObject != nil {
+		var stateOrderList *itemListState
+		switch side {
+		case Investing:
+			stateOrderList = stateObject.getInvestingOrderList(self.db, common.BigToHash(price))
+		case Borrowing:
+			stateOrderList = stateObject.getBorrowingOrderList(self.db, common.BigToHash(price))
+		default:
+			return EmptyHash, Zero, fmt.Errorf("not found side :%s ", side)
+		}
+		if stateOrderList != nil {
+			key, _, err := stateOrderList.getTrie(self.db).TryGetBestLeftKeyAndValue()
+			if err != nil {
+				return EmptyHash, Zero, err
+			}
+			orderId := common.BytesToHash(key)
+			amount := stateOrderList.GetOrderAmount(self.db, orderId)
+			return orderId, new(big.Int).SetBytes(amount.Bytes()), nil
+		}
+		return EmptyHash, Zero, fmt.Errorf("not found order list with orderBook : %s , key : %d , side :%s ", orderBook.Hex(), price, side)
+	}
+	return EmptyHash, Zero, fmt.Errorf("not found orderBook : %s ", orderBook.Hex())
+}
+
+// updateLendingExchange writes the given object to the trie.
+func (self *LendingStateDB) updateLendingExchange(stateObject *lendingExchangeState) {
+	addr := stateObject.Hash()
+	data, err := rlp.EncodeToBytes(stateObject)
+	if err != nil {
+		panic(fmt.Errorf("can't encode object at %x: %v", addr[:], err))
+	}
+	self.setError(self.trie.TryUpdate(addr[:], data))
+}
+
+// Retrieve a state object given my the address. Returns nil if not found.
+func (self *LendingStateDB) getLendingExchange(addr common.Hash) (stateObject *lendingExchangeState) {
+	// Prefer 'live' objects.
+	if obj := self.lendingExchangeStates[addr]; obj != nil {
+		return obj
+	}
+	// Load the object from the database.
+	enc, err := self.trie.TryGet(addr[:])
+	if len(enc) == 0 {
+		self.setError(err)
+		return nil
+	}
+	var data lendingObject
+	if err := rlp.DecodeBytes(enc, &data); err != nil {
+		log.Error("Failed to decode state object", "addr", addr, "err", err)
+		return nil
+	}
+	// Insert into the live set.
+	obj := newStateExchanges(self, addr, data, self.MarkLendingExchangeObjectDirty)
+	self.lendingExchangeStates[addr] = obj
+	return obj
+}
+
+func (self *LendingStateDB) setLendingExchangeObject(object *lendingExchangeState) {
+	self.lendingExchangeStates[object.Hash()] = object
+	self.lendingExchangeStatesDirty[object.Hash()] = struct{}{}
+}
+
+// Retrieve a state object or create a new state object if nil.
+func (self *LendingStateDB) GetOrNewLendingExchangeObject(addr common.Hash) *lendingExchangeState {
+	stateExchangeObject := self.getLendingExchange(addr)
+	if stateExchangeObject == nil {
+		stateExchangeObject = self.createLendingExchangeObject(addr)
+	}
+	return stateExchangeObject
+}
+
+// MarkStateLendObjectDirty adds the specified object to the dirty map to avoid costly
+// state object cache iteration to find a handful of modified ones.
+func (self *LendingStateDB) MarkLendingExchangeObjectDirty(addr common.Hash) {
+	self.lendingExchangeStatesDirty[addr] = struct{}{}
+}
+
+// createStateOrderListObject creates a new state object. If there is an existing tradeId with
+// the given address, it is overwritten and returned as the second return value.
+func (self *LendingStateDB) createLendingExchangeObject(hash common.Hash) (newobj *lendingExchangeState) {
+	newobj = newStateExchanges(self, hash, lendingObject{}, self.MarkLendingExchangeObjectDirty)
+	newobj.setNonce(0) // sets the object to dirty
+	self.setLendingExchangeObject(newobj)
+	return newobj
+}
+
+// Copy creates a deep, independent copy of the state.
+// Snapshots of the copied state cannot be applied to the copy.
+func (self *LendingStateDB) Copy() *LendingStateDB {
+	self.lock.Lock()
+	defer self.lock.Unlock()
+
+	// Copy all the basic fields, initialize the memory ones
+	state := &LendingStateDB{
+		db:                         self.db,
+		trie:                       self.db.CopyTrie(self.trie),
+		lendingExchangeStates:      make(map[common.Hash]*lendingExchangeState, len(self.lendingExchangeStatesDirty)),
+		lendingExchangeStatesDirty: make(map[common.Hash]struct{}, len(self.lendingExchangeStatesDirty)),
+	}
+	// Copy the dirty states, logs, and preimages
+	for addr := range self.lendingExchangeStatesDirty {
+		state.lendingExchangeStatesDirty[addr] = struct{}{}
+	}
+	for addr, exchangeObject := range self.lendingExchangeStates {
+		state.lendingExchangeStates[addr] = exchangeObject.deepCopy(state, state.MarkLendingExchangeObjectDirty)
+	}
+
+	return state
+}
+
+func (s *LendingStateDB) clearJournalAndRefund() {
+	s.journal = nil
+	s.validRevisions = s.validRevisions[:0]
+}
+
+// Snapshot returns an identifier for the current revision of the state.
+func (self *LendingStateDB) Snapshot() int {
+	id := self.nextRevisionId
+	self.nextRevisionId++
+	self.validRevisions = append(self.validRevisions, revision{id, len(self.journal)})
+	return id
+}
+
+// RevertToSnapshot reverts all state changes made since the given revision.
+func (self *LendingStateDB) RevertToSnapshot(revid int) {
+	// Find the snapshot in the stack of valid snapshots.
+	idx := sort.Search(len(self.validRevisions), func(i int) bool {
+		return self.validRevisions[i].id >= revid
+	})
+	if idx == len(self.validRevisions) || self.validRevisions[idx].id != revid {
+		panic(fmt.Errorf("revision id %v cannot be reverted", revid))
+	}
+	snapshot := self.validRevisions[idx].journalIndex
+
+	// Replay the journal to undo changes.
+	for i := len(self.journal) - 1; i >= snapshot; i-- {
+		self.journal[i].undo(self)
+	}
+	self.journal = self.journal[:snapshot]
+
+	// Remove invalidated snapshots from the stack.
+	self.validRevisions = self.validRevisions[:idx]
+}
+
+// Finalise finalises the state by removing the self destructed objects
+// and clears the journal as well as the refunds.
+func (s *LendingStateDB) Finalise() {
+	// Commit objects to the trie.
+	for addr, stateObject := range s.lendingExchangeStates {
+		if _, isDirty := s.lendingExchangeStatesDirty[addr]; isDirty {
+			// Write any storage changes in the state object to its storage trie.
+			if err := stateObject.updateInvestingRoot(s.db); err != nil {
+				log.Error("LendingStateDB: failed to update investing root", "err", err)
+			}
+			stateObject.updateBorrowingRoot(s.db)
+			stateObject.updateOrderRoot(s.db)
+			stateObject.updateLendingTradeRoot(s.db)
+			stateObject.updateLiquidationTimeRoot(s.db)
+			// Update the object in the main tradeId trie.
+			s.updateLendingExchange(stateObject)
+			//delete(s.investingStatesDirty, addr)
+		}
+	}
+	s.clearJournalAndRefund()
+}
+
+// IntermediateRoot computes the current root orderBook of the state trie.
+// It is called in between transactions to get the root orderBook that
+// goes into transaction receipts.
+func (s *LendingStateDB) IntermediateRoot() common.Hash {
+	s.Finalise()
+	return s.trie.Hash()
+}
+
+// Commit writes the state to the underlying in-memory trie database.
+func (s *LendingStateDB) Commit() (root common.Hash, err error) {
+	defer s.clearJournalAndRefund()
+	// Commit objects to the trie.
+	for addr, stateObject := range s.lendingExchangeStates {
+		if _, isDirty := s.lendingExchangeStatesDirty[addr]; isDirty {
+			// Write any storage changes in the state object to its storage trie.
+			if err := stateObject.CommitInvestingTrie(s.db); err != nil {
+				return EmptyHash, err
+			}
+			if err := stateObject.CommitBorrowingTrie(s.db); err != nil {
+				return EmptyHash, err
+			}
+			if err := stateObject.CommitLendingItemTrie(s.db); err != nil {
+				return EmptyHash, err
+			}
+			if err := stateObject.CommitLendingTradeTrie(s.db); err != nil {
+				return EmptyHash, err
+			}
+			if err := stateObject.CommitLiquidationTimeTrie(s.db); err != nil {
+				return EmptyHash, err
+			}
+			// Update the object in the main tradeId trie.
+			s.updateLendingExchange(stateObject)
+			delete(s.lendingExchangeStatesDirty, addr)
+		}
+	}
+	// Write trie changes.
+	root, _, err = s.trie.Commit(func(_ []byte, leaf []byte, parent common.Hash) error {
+		var exchange lendingObject
+		if err := rlp.DecodeBytes(leaf, &exchange); err != nil {
+			return nil
+		}
+		if exchange.InvestingRoot != EmptyRoot {
+			s.db.TrieDB().Reference(exchange.InvestingRoot, parent)
+		}
+		if exchange.BorrowingRoot != EmptyRoot {
+			s.db.TrieDB().Reference(exchange.BorrowingRoot, parent)
+		}
+		if exchange.LendingItemRoot != EmptyRoot {
+			s.db.TrieDB().Reference(exchange.LendingItemRoot, parent)
+		}
+		if exchange.LendingTradeRoot != EmptyRoot {
+			s.db.TrieDB().Reference(exchange.LendingTradeRoot, parent)
+		}
+		if exchange.LiquidationTimeRoot != EmptyRoot {
+			s.db.TrieDB().Reference(exchange.LiquidationTimeRoot, parent)
+		}
+		return nil
+	})
+	log.Debug("Lending State Trie cache stats after commit", "root", root.Hex())
+	return root, err
+}
+
+func (self *LendingStateDB) InsertLiquidationTime(lendingBook common.Hash, time *big.Int, tradeId uint64) {
+	timeHash := common.BigToHash(time)
+	lendingExchangeState := self.getLendingExchange(lendingBook)
+	if lendingExchangeState == nil {
+		lendingExchangeState = self.createLendingExchangeObject(lendingBook)
+	}
+	liquidationTime := lendingExchangeState.getLiquidationTimeOrderList(self.db, timeHash)
+	if liquidationTime == nil {
+		liquidationTime = lendingExchangeState.createLiquidationTime(self.db, timeHash)
+	}
+	liquidationTime.insertTradeId(self.db, params.Uint64ToHash(tradeId))
+	liquidationTime.AddVolume(One)
+}
+
+func (self *LendingStateDB) RemoveLiquidationTime(lendingBook common.Hash, tradeId uint64, time uint64) error {
+	timeHash := params.Uint64ToHash(time)
+	tradeIdHash := params.Uint64ToHash(tradeId)
+	lendingExchangeState := self.getLendingExchange(lendingBook)
+	if lendingExchangeState == nil {
+		return fmt.Errorf("lending book not found : %s ", lendingBook.Hex())
+	}
+	liquidationTime := lendingExchangeState.getLiquidationTimeOrderList(self.db, timeHash)
+	if liquidationTime == nil {
+		return fmt.Errorf("liquidation time not found : %s , %d ", lendingBook.Hex(), time)
+	}
+	if !liquidationTime.Exist(self.db, tradeIdHash) {
+		return fmt.Errorf("tradeId not exist : %s , %d , %d ", lendingBook.Hex(), time, tradeId)
+	}
+	liquidationTime.removeTradeId(self.db, tradeIdHash)
+	liquidationTime.subVolume(One)
+	if liquidationTime.Volume().Sign() == 0 {
+		lendingExchangeState.getLiquidationTimeTrie(self.db).TryDelete(timeHash[:])
+	}
+	return nil
+}
+
+func (self *LendingStateDB) GetLowestLiquidationTime(lendingBook common.Hash, time *big.Int) (*big.Int, []common.Hash) {
+	liquidationData := []common.Hash{}
+	lendingExchangeState := self.getLendingExchange(lendingBook)
+	if lendingExchangeState == nil {
+		return common.Big0, liquidationData
+	}
+	lowestPriceHash, liquidationState := lendingExchangeState.getLowestLiquidationTime(self.db)
+	lowestTime := new(big.Int).SetBytes(lowestPriceHash[:])
+	if liquidationState != nil && lowestTime.Sign() > 0 && lowestTime.Cmp(time) <= 0 {
+		liquidationData = liquidationState.getAllTradeIds(self.db)
+	}
+	return lowestTime, liquidationData
+}
+
+func (self *LendingStateDB) CancelLendingTrade(orderBook common.Hash, tradeId uint64) error {
+	tradeIdHash := params.Uint64ToHash(tradeId)
+	stateObject := self.GetOrNewLendingExchangeObject(orderBook)
+	if stateObject == nil {
+		return fmt.Errorf("Order book not found : %s ", orderBook.Hex())
+	}
+	lendingTrade := stateObject.getLendingTrade(self.db, tradeIdHash)
+	if lendingTrade == nil || lendingTrade.empty() {
+		return fmt.Errorf("lending trade empty  order book : %s , trade id  : %s , trade id hash  : %s ", orderBook, tradeIdHash.Hex(), tradeIdHash.Hex())
+	}
+	self.journal = append(self.journal, cancelTrading{
+		orderBook: orderBook,
+		order:     self.GetLendingTrade(orderBook, tradeIdHash),
+	})
+	lendingTrade.SetAmount(Zero)
+	return nil
+}

--- a/legacy/tomoxlending/lendingstate/tomox_trie.go
+++ b/legacy/tomoxlending/lendingstate/tomox_trie.go
@@ -1,0 +1,226 @@
+// Copyright 2015 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package lendingstate
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/trie"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// TomoXTrie wraps a trie with key hashing. In a secure trie, all
+// access operations hash the key using keccak256. This prevents
+// calling code from creating long chains of nodes that
+// increase the access time.
+//
+// Contrary to a regular trie, a TomoXTrie can only be created with
+// New and must have an attached database. The database also stores
+// the preimage of each key.
+//
+// TomoXTrie is not safe for concurrent use.
+type TomoXTrie struct {
+	trie             trie.Trie
+	hashKeyBuf       [common.HashLength]byte
+	secKeyCache      map[string][]byte
+	secKeyCacheOwner *TomoXTrie // Pointer to self, replace the key cache on mismatch
+}
+
+// NewTomoXTrie creates a trie with an existing root node from a backing database
+// and optional intermediate in-memory node pool.
+//
+// If root is the zero hash or the sha3 hash of an empty string, the
+// trie is initially empty. Otherwise, New will panic if db is nil
+// and returns MissingNodeError if the root node cannot be found.
+//
+// Accessing the trie loads nodes from the database or node pool on demand.
+// Loaded nodes are kept around until their 'cache generation' expires.
+// A new cache generation is created by each call to Commit.
+// cachelimit sets the number of past cache generations to keep.
+func NewTomoXTrie(root common.Hash, db *trie.Database) (*TomoXTrie, error) {
+	if db == nil {
+		panic("trie.NewTomoXTrie called without a database")
+	}
+	trie, err := trie.New(root, db)
+	if err != nil {
+		return nil, err
+	}
+	return &TomoXTrie{trie: *trie}, nil
+}
+
+// Get returns the value for key stored in the trie.
+// The value bytes must not be modified by the caller.
+func (t *TomoXTrie) Get(key []byte) []byte {
+	res, err := t.TryGet(key)
+	if err != nil {
+		log.Error(fmt.Sprintf("Unhandled trie error: %v", err))
+	}
+	return res
+}
+
+// TryGet returns the value for key stored in the trie.
+// The value bytes must not be modified by the caller.
+// If a node was not found in the database, a MissingNodeError is returned.
+func (t *TomoXTrie) TryGet(key []byte) ([]byte, error) {
+	return t.trie.TryGet(key)
+}
+
+// TryGetBestLeftKeyAndValue returns the value of max left leaf
+// If a node was not found in the database, a MissingNodeError is returned.
+func (t *TomoXTrie) TryGetBestLeftKeyAndValue() ([]byte, []byte, error) {
+	return t.trie.TryGetBestLeftKeyAndValue()
+}
+
+// TryGetAllLeftKeyAndValue is included for interface symmetry with TradingStateDB.Trie.
+// NOTE: The `limit` parameter semantics here differ from victionchain: the underlying
+// vic-geth trie implementation interprets limit as a count (max entries), not a key upper bound.
+// This method is not called by any lending state code path and must not be called
+// with a key-bound argument — doing so will silently return all entries.
+func (t *TomoXTrie) TryGetAllLeftKeyAndValue(limit []byte) ([][]byte, [][]byte, error) {
+	// Convert legacy []byte limit to int maxCount (default to large number)
+	maxCount := 10000
+
+	if len(limit) > 0 {
+		// Use the limit as a byte-encoded int
+		maxCount = int(new(big.Int).SetBytes(limit).Int64())
+		if maxCount <= 0 {
+			maxCount = 10000
+		}
+	}
+	return t.trie.TryGetAllLeftKeyAndValue(maxCount)
+}
+
+// TryGetBestRightKeyAndValue returns the value of max right leaf
+// If a node was not found in the database, a MissingNodeError is returned.
+func (t *TomoXTrie) TryGetBestRightKeyAndValue() ([]byte, []byte, error) {
+	return t.trie.TryGetBestRightKeyAndValue()
+}
+
+// Update associates key with value in the trie. Subsequent calls to
+// Get will return value. If value has length zero, any existing value
+// is deleted from the trie and calls to Get will return nil.
+//
+// The value bytes must not be modified by the caller while they are
+// stored in the trie.
+func (t *TomoXTrie) Update(key, value []byte) {
+	if err := t.TryUpdate(key, value); err != nil {
+		log.Error(fmt.Sprintf("Unhandled trie error: %v", err))
+	}
+}
+
+// TryUpdate associates key with value in the trie. Subsequent calls to
+// Get will return value. If value has length zero, any existing value
+// is deleted from the trie and calls to Get will return nil.
+//
+// The value bytes must not be modified by the caller while they are
+// stored in the trie.
+//
+// If a node was not found in the database, a MissingNodeError is returned.
+func (t *TomoXTrie) TryUpdate(key, value []byte) error {
+	err := t.trie.TryUpdate(key, value)
+	if err != nil {
+		return err
+	}
+	t.getSecKeyCache()[string(key)] = common.CopyBytes(key)
+	return nil
+}
+
+// Delete removes any existing value for key from the trie.
+func (t *TomoXTrie) Delete(key []byte) {
+	if err := t.TryDelete(key); err != nil {
+		log.Error(fmt.Sprintf("Unhandled trie error: %v", err))
+	}
+}
+
+// TryDelete removes any existing value for key from the trie.
+// If a node was not found in the database, a MissingNodeError is returned.
+func (t *TomoXTrie) TryDelete(key []byte) error {
+	delete(t.getSecKeyCache(), string(key))
+	return t.trie.TryDelete(key)
+}
+
+// GetKey returns the sha3 preimage of a hashed key that was
+// previously used to store a value.
+func (t *TomoXTrie) GetKey(shaKey []byte) []byte {
+	if key, ok := t.getSecKeyCache()[string(shaKey)]; ok {
+		return key
+	}
+	key, _ := t.trie.Database().Preimage(common.BytesToHash(shaKey))
+	return key
+}
+
+// Commit writes all nodes and the secure hash pre-images to the trie's database.
+// Nodes are stored with their sha3 hash as the key.
+//
+// Committing flushes nodes from memory. Subsequent Get calls will load nodes
+// from the database.
+func (t *TomoXTrie) Commit(onleaf trie.LeafCallback) (common.Hash, int, error) {
+	// Write all the pre-images to the actual disk database
+	if len(t.getSecKeyCache()) > 0 {
+		t.trie.Database().GetLock().Lock()
+		for hk, key := range t.secKeyCache {
+			t.trie.Database().InsertPreimage(common.BytesToHash([]byte(hk)), key)
+		}
+		t.trie.Database().GetLock().Unlock()
+
+		t.secKeyCache = make(map[string][]byte)
+	}
+	// Commit the trie to its intermediate node database
+	hash, err := t.trie.Commit(onleaf)
+	return hash, 0, err
+}
+
+func (t *TomoXTrie) Hash() common.Hash {
+	return t.trie.Hash()
+}
+
+func (t *TomoXTrie) Copy() *TomoXTrie {
+	cpy := *t
+	return &cpy
+}
+
+// NodeIterator returns an iterator that returns nodes of the underlying trie. Iteration
+// starts at the key after the given start key.
+func (t *TomoXTrie) NodeIterator(start []byte) trie.NodeIterator {
+	return t.trie.NodeIterator(start)
+}
+
+// getSecKeyCache returns the current secure key cache, creating a new one if
+// ownership changed (i.e. the current secure trie is a copy of another owning
+// the actual cache).
+func (t *TomoXTrie) getSecKeyCache() map[string][]byte {
+	if t != t.secKeyCacheOwner {
+		t.secKeyCacheOwner = t
+		t.secKeyCache = make(map[string][]byte)
+	}
+	return t.secKeyCache
+}
+
+// Prove constructs a merkle proof for key. The result contains all encoded nodes
+// on the path to the value at key. The value itself is also included in the last
+// node and can be retrieved by verifying the proof.
+//
+// If the trie does not contain a value for key, the returned proof contains all
+// nodes of the longest existing prefix of the key (at least the root node), ending
+// with the node that proves the absence of the key.
+func (t *TomoXTrie) Prove(key []byte, fromLevel uint, proofDb ethdb.KeyValueWriter) error {
+	return t.trie.Prove(key, fromLevel, proofDb)
+}

--- a/legacy/tomoxlending/lendingstate/trade.go
+++ b/legacy/tomoxlending/lendingstate/trade.go
@@ -1,0 +1,59 @@
+package lendingstate
+
+import (
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"golang.org/x/crypto/sha3"
+)
+
+const (
+	TradeStatusOpen       = "OPEN"
+	TradeStatusClosed     = "CLOSED"
+	TradeStatusLiquidated = "LIQUIDATED"
+)
+
+type LendingTrade struct {
+	Borrower               common.Address `json:"borrower"`
+	Investor               common.Address `json:"investor"`
+	LendingToken           common.Address `json:"lendingToken"`
+	CollateralToken        common.Address `json:"collateralToken"`
+	BorrowingOrderHash     common.Hash    `json:"borrowingOrderHash"`
+	InvestingOrderHash     common.Hash    `json:"investingOrderHash"`
+	BorrowingRelayer       common.Address `json:"borrowingRelayer"`
+	InvestingRelayer       common.Address `json:"investingRelayer"`
+	Term                   uint64         `json:"term"`
+	Interest               uint64         `json:"interest"`
+	CollateralPrice        *big.Int       `json:"collateralPrice"`
+	LiquidationPrice       *big.Int       `json:"liquidationPrice"`
+	CollateralLockedAmount *big.Int       `json:"collateralLockedAmount"`
+	AutoTopUp              bool           `json:"autoTopUp"`
+	LiquidationTime        uint64         `json:"liquidationTime"`
+	DepositRate            *big.Int       `json:"depositRate"`
+	LiquidationRate        *big.Int       `json:"liquidationRate"`
+	RecallRate             *big.Int       `json:"recallRate"`
+	Amount                 *big.Int       `json:"amount"`
+	BorrowingFee           *big.Int       `json:"borrowingFee"`
+	InvestingFee           *big.Int       `json:"investingFee"`
+	Status                 string         `json:"status"`
+	TakerOrderSide         string         `json:"takerOrderSide"`
+	TakerOrderType         string         `json:"takerOrderType"`
+	MakerOrderType         string         `json:"makerOrderType"`
+	TradeId                uint64         `json:"tradeId"`
+	Hash                   common.Hash    `json:"hash"`
+	TxHash                 common.Hash    `json:"txHash"`
+	ExtraData              string         `json:"extraData"`
+	CreatedAt              time.Time      `json:"createdAt"`
+	UpdatedAt              time.Time      `json:"updatedAt"`
+}
+
+func (t *LendingTrade) ComputeHash() common.Hash {
+	sha := sha3.NewLegacyKeccak256().(crypto.KeccakState)
+	sha.Write(t.InvestingOrderHash.Bytes())
+	sha.Write(t.BorrowingOrderHash.Bytes())
+	var result [32]byte
+	sha.Read(result[:])
+	return common.BytesToHash(result[:])
+}

--- a/legacy/tomoxlending/order_processor.go
+++ b/legacy/tomoxlending/order_processor.go
@@ -1,0 +1,1218 @@
+package tomoxlending
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/legacy/tomox/tradingstate"
+	"github.com/ethereum/go-ethereum/legacy/tomoxlending/lendingstate"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+func (l *Lending) CommitOrder(header *types.Header, coinbase common.Address, chain tradingstate.ChainContext, statedb *state.StateDB, lendingStateDB *lendingstate.LendingStateDB, tradingStateDb *tradingstate.TradingStateDB, lendingOrderBook common.Hash, order *lendingstate.LendingItem) ([]*lendingstate.LendingTrade, []*lendingstate.LendingItem, error) {
+	lendingSnap := lendingStateDB.Snapshot()
+	tradingSnap := tradingStateDb.Snapshot()
+	dbSnap := statedb.Snapshot()
+	trades, rejects, err := l.ApplyOrder(header, coinbase, chain, statedb, lendingStateDB, tradingStateDb, lendingOrderBook, order)
+	if err != nil {
+		lendingStateDB.RevertToSnapshot(lendingSnap)
+		tradingStateDb.RevertToSnapshot(tradingSnap)
+		statedb.RevertToSnapshot(dbSnap)
+		return nil, nil, err
+	}
+	return trades, rejects, err
+}
+
+func (l *Lending) ApplyOrder(header *types.Header, coinbase common.Address, chain tradingstate.ChainContext, statedb *state.StateDB, lendingStateDB *lendingstate.LendingStateDB, tradingStateDb *tradingstate.TradingStateDB, lendingOrderBook common.Hash, order *lendingstate.LendingItem) ([]*lendingstate.LendingTrade, []*lendingstate.LendingItem, error) {
+	var (
+		rejects []*lendingstate.LendingItem
+		trades  []*lendingstate.LendingTrade
+		err     error
+	)
+	nonce := lendingStateDB.GetNonce(order.UserAddress.Hash())
+	log.Debug("ApplyOrder", "addr", order.UserAddress, "statenonce", nonce, "ordernonce", order.Nonce)
+	if big.NewInt(int64(nonce)).Cmp(order.Nonce) == -1 {
+		return nil, nil, ErrNonceTooHigh
+	} else if big.NewInt(int64(nonce)).Cmp(order.Nonce) == 1 {
+		return nil, nil, ErrNonceTooLow
+	}
+
+	log.Debug("Exchange add user nonce:", "address", order.UserAddress, "status", order.Status, "nonce", nonce+1)
+	lendingStateDB.SetNonce(order.UserAddress.Hash(), nonce+1)
+
+	lendingSnap := lendingStateDB.Snapshot()
+	tradingSnap := tradingStateDb.Snapshot()
+	dbSnap := statedb.Snapshot()
+	// revert if process order fail
+	defer func() {
+		if err != nil {
+			lendingStateDB.RevertToSnapshot(lendingSnap)
+			tradingStateDb.RevertToSnapshot(tradingSnap)
+			statedb.RevertToSnapshot(dbSnap)
+		}
+	}()
+
+	if err := order.VerifyLendingItem(statedb); err != nil {
+		log.Debug("invalid lending order", "order", lendingstate.ToJSON(order), "err", err)
+		rejects = append(rejects, order)
+		return trades, rejects, nil
+	}
+
+	switch order.Type {
+	case lendingstate.TopUp:
+		err, reject, newLendingTrade := l.ProcessTopUp(lendingStateDB, statedb, tradingStateDb, order)
+		if err != nil || reject {
+			rejects = append(rejects, order)
+		}
+		trades = append(trades, newLendingTrade)
+		return trades, rejects, nil
+	case lendingstate.Repay:
+		lendingTrade, err := l.ProcessRepay(header, chain, lendingStateDB, statedb, tradingStateDb, lendingOrderBook, order)
+		if err != nil {
+			log.Debug("Can not process payment", "err", err)
+			rejects = append(rejects, order)
+		}
+		trades = append(trades, lendingTrade)
+		return trades, rejects, nil
+	default:
+	}
+
+	if order.Status == lendingstate.LendingStatusCancelled {
+		err, reject := l.ProcessCancelOrder(header, lendingStateDB, statedb, tradingStateDb, chain, coinbase, lendingOrderBook, order)
+		if err != nil || reject {
+			rejects = append(rejects, order)
+		}
+		return trades, rejects, nil
+	}
+
+	if order.Type != lendingstate.Market {
+		if order.Interest.Sign() == 0 || common.BigToHash(order.Interest).Big().Cmp(order.Interest) != 0 {
+			log.Debug("Reject order Interest invalid", "Interest", order.Interest)
+			rejects = append(rejects, order)
+			return trades, rejects, nil
+		}
+	}
+	if order.Quantity.Sign() == 0 || common.BigToHash(order.Quantity).Big().Cmp(order.Quantity) != 0 {
+		log.Debug("Reject order quantity invalid", "quantity", order.Quantity)
+		rejects = append(rejects, order)
+		return trades, rejects, nil
+	}
+	orderType := order.Type
+	// if we do not use auto-increment orderid, we must set Interest slot to avoid conflict
+	if orderType == lendingstate.Market {
+		log.Debug("Process maket order", "side", order.Side, "quantity", order.Quantity, "Interest", order.Interest)
+		trades, rejects, err = l.processMarketOrder(header, coinbase, chain, statedb, lendingStateDB, tradingStateDb, lendingOrderBook, order)
+		if err != nil {
+			trades = []*lendingstate.LendingTrade{}
+			rejects = append(rejects, order)
+		}
+	} else {
+		log.Debug("Process limit order", "side", order.Side, "quantity", order.Quantity, "Interest", order.Interest)
+		trades, rejects, err = l.processLimitOrder(header, coinbase, chain, statedb, lendingStateDB, tradingStateDb, lendingOrderBook, order)
+		if err != nil {
+			trades = []*lendingstate.LendingTrade{}
+			rejects = append(rejects, order)
+		}
+	}
+	return trades, rejects, nil
+}
+
+// processMarketOrder : process the market order
+func (l *Lending) processMarketOrder(header *types.Header, coinbase common.Address, chain tradingstate.ChainContext, statedb *state.StateDB, lendingStateDB *lendingstate.LendingStateDB, tradingStateDb *tradingstate.TradingStateDB, lendingOrderBook common.Hash, order *lendingstate.LendingItem) ([]*lendingstate.LendingTrade, []*lendingstate.LendingItem, error) {
+	var (
+		trades     []*lendingstate.LendingTrade
+		newTrades  []*lendingstate.LendingTrade
+		rejects    []*lendingstate.LendingItem
+		newRejects []*lendingstate.LendingItem
+		err        error
+	)
+	quantityToTrade := order.Quantity
+	side := order.Side
+	// speedup the comparison, do not assign because it is pointer
+	zero := lendingstate.Zero
+	if side == lendingstate.Borrowing {
+		bestInterest, volume := lendingStateDB.GetBestInvestingRate(lendingOrderBook)
+		log.Debug("processMarketOrder ", "side", side, "bestInterest", bestInterest, "quantityToTrade", quantityToTrade, "volume", volume)
+		for quantityToTrade.Cmp(zero) > 0 && bestInterest.Cmp(zero) > 0 {
+			quantityToTrade, newTrades, newRejects, err = l.processOrderList(header, coinbase, chain, statedb, lendingStateDB, tradingStateDb, lendingstate.Investing, lendingOrderBook, bestInterest, quantityToTrade, order)
+			if err != nil {
+				return nil, nil, err
+			}
+			trades = append(trades, newTrades...)
+			rejects = append(rejects, newRejects...)
+			bestInterest, volume = lendingStateDB.GetBestInvestingRate(lendingOrderBook)
+			log.Debug("processMarketOrder ", "side", side, "bestInterest", bestInterest, "quantityToTrade", quantityToTrade, "volume", volume)
+		}
+	} else {
+		bestInterest, volume := lendingStateDB.GetBestBorrowRate(lendingOrderBook)
+		log.Debug("processMarketOrder ", "side", side, "bestInterest", bestInterest, "quantityToTrade", quantityToTrade, "volume", volume)
+		for quantityToTrade.Cmp(zero) > 0 && bestInterest.Cmp(zero) > 0 {
+			quantityToTrade, newTrades, newRejects, err = l.processOrderList(header, coinbase, chain, statedb, lendingStateDB, tradingStateDb, lendingstate.Borrowing, lendingOrderBook, bestInterest, quantityToTrade, order)
+			if err != nil {
+				return nil, nil, err
+			}
+			trades = append(trades, newTrades...)
+			rejects = append(rejects, newRejects...)
+			bestInterest, volume = lendingStateDB.GetBestBorrowRate(lendingOrderBook)
+			log.Debug("processMarketOrder ", "side", side, "bestInterest", bestInterest, "quantityToTrade", quantityToTrade, "volume", volume)
+		}
+	}
+	return trades, rejects, nil
+}
+
+// processLimitOrder : process the limit order, can change the quote
+// If not care for performance, we should make a copy of quote to prevent further reference problem
+func (l *Lending) processLimitOrder(header *types.Header, coinbase common.Address, chain tradingstate.ChainContext, statedb *state.StateDB, lendingStateDB *lendingstate.LendingStateDB, tradingStateDb *tradingstate.TradingStateDB, lendingOrderBook common.Hash, order *lendingstate.LendingItem) ([]*lendingstate.LendingTrade, []*lendingstate.LendingItem, error) {
+	var (
+		trades     []*lendingstate.LendingTrade
+		newTrades  []*lendingstate.LendingTrade
+		rejects    []*lendingstate.LendingItem
+		newRejects []*lendingstate.LendingItem
+		err        error
+	)
+	quantityToTrade := order.Quantity
+	side := order.Side
+	Interest := order.Interest
+
+	// speedup the comparison, do not assign because it is pointer
+	zero := lendingstate.Zero
+	if side == lendingstate.Borrowing {
+		minInterest, volume := lendingStateDB.GetBestInvestingRate(lendingOrderBook)
+		log.Debug("processLimitOrder ", "side", side, "minInterest", minInterest, "orderInterest", Interest, "volume", volume)
+		for quantityToTrade.Cmp(zero) > 0 && Interest.Cmp(minInterest) >= 0 && minInterest.Cmp(zero) > 0 {
+			log.Debug("Min Interest in Investing tree", "Interest", minInterest.String())
+			quantityToTrade, newTrades, newRejects, err = l.processOrderList(header, coinbase, chain, statedb, lendingStateDB, tradingStateDb, lendingstate.Investing, lendingOrderBook, minInterest, quantityToTrade, order)
+			if err != nil {
+				return nil, nil, err
+			}
+			trades = append(trades, newTrades...)
+			rejects = append(rejects, newRejects...)
+			log.Debug("New trade found", "newTrades", newTrades, "quantityToTrade", quantityToTrade)
+			minInterest, volume = lendingStateDB.GetBestInvestingRate(lendingOrderBook)
+			log.Debug("processLimitOrder ", "side", side, "minInterest", minInterest, "orderInterest", Interest, "volume", volume)
+		}
+	} else {
+		maxInterest, volume := lendingStateDB.GetBestBorrowRate(lendingOrderBook)
+		log.Debug("processLimitOrder ", "side", side, "maxInterest", maxInterest, "orderInterest", Interest, "volume", volume)
+		for quantityToTrade.Cmp(zero) > 0 && Interest.Cmp(maxInterest) <= 0 && maxInterest.Cmp(zero) > 0 {
+			log.Debug("Max Interest in Borrowing tree", "Interest", maxInterest.String())
+			quantityToTrade, newTrades, newRejects, err = l.processOrderList(header, coinbase, chain, statedb, lendingStateDB, tradingStateDb, lendingstate.Borrowing, lendingOrderBook, maxInterest, quantityToTrade, order)
+			if err != nil {
+				return nil, nil, err
+			}
+			trades = append(trades, newTrades...)
+			rejects = append(rejects, newRejects...)
+			log.Debug("New trade found", "newTrades", newTrades, "quantityToTrade", quantityToTrade)
+			maxInterest, volume = lendingStateDB.GetBestBorrowRate(lendingOrderBook)
+			log.Debug("processLimitOrder ", "side", side, "maxInterest", maxInterest, "orderInterest", Interest, "volume", volume)
+		}
+	}
+	if quantityToTrade.Cmp(zero) > 0 {
+		oldOrderId := lendingStateDB.GetNonce(lendingOrderBook)
+		order.LendingId = oldOrderId + 1
+		order.Quantity = quantityToTrade
+		lendingStateDB.SetNonce(lendingOrderBook, oldOrderId+1)
+		orderIdHash := common.BigToHash(new(big.Int).SetUint64(order.LendingId))
+		lendingStateDB.InsertLendingItem(lendingOrderBook, orderIdHash, *order)
+		log.Debug("After matching, order (unmatched part) is now added to tree", "side", order.Side, "order", order)
+		investingRate, investingVolume := lendingStateDB.GetBestInvestingRate(lendingOrderBook)
+		borrowingRate, borrowingVolume := lendingStateDB.GetBestBorrowRate(lendingOrderBook)
+		log.Debug("After matching", "side", order.Side, "LendingId", order.LendingId, "investingRate", investingRate, "investingVolume", investingVolume, "borrowingRate", borrowingRate, "borrowingVolume", borrowingVolume)
+	}
+	return trades, rejects, nil
+}
+
+// processOrderList : process the order list
+func (l *Lending) processOrderList(header *types.Header, coinbase common.Address, chain tradingstate.ChainContext, statedb *state.StateDB, lendingStateDB *lendingstate.LendingStateDB, tradingStateDb *tradingstate.TradingStateDB, side string, lendingOrderBook common.Hash, Interest *big.Int, quantityStillToTrade *big.Int, order *lendingstate.LendingItem) (*big.Int, []*lendingstate.LendingTrade, []*lendingstate.LendingItem, error) {
+	quantityToTrade := lendingstate.CloneBigInt(quantityStillToTrade)
+	log.Debug("Process matching between order and orderlist", "quantityToTrade", quantityToTrade)
+	var (
+		trades  []*lendingstate.LendingTrade
+		rejects []*lendingstate.LendingItem
+	)
+	for quantityToTrade.Sign() > 0 {
+		orderId, amount, err := lendingStateDB.GetBestLendingIdAndAmount(lendingOrderBook, Interest, side)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		var oldestOrder lendingstate.LendingItem
+		if amount.Sign() > 0 {
+			oldestOrder = lendingStateDB.GetLendingOrder(lendingOrderBook, orderId)
+		}
+		log.Debug("found order ", "orderId ", orderId, "side", oldestOrder.Side, "amount", amount, "side", side, "Interest", Interest)
+		if oldestOrder.Quantity == nil || oldestOrder.Quantity.Sign() == 0 && amount.Sign() == 0 {
+			break
+		}
+		var (
+			tradedQuantity    *big.Int
+			maxTradedQuantity *big.Int
+		)
+		if quantityToTrade.Cmp(amount) <= 0 {
+			maxTradedQuantity = lendingstate.CloneBigInt(quantityToTrade)
+		} else {
+			maxTradedQuantity = lendingstate.CloneBigInt(amount)
+		}
+		collateralToken := order.CollateralToken
+		borrowFee := lendingstate.GetFee(statedb, order.Relayer)
+		if order.Side == lendingstate.Investing {
+			collateralToken = oldestOrder.CollateralToken
+			borrowFee = lendingstate.GetFee(statedb, oldestOrder.Relayer)
+		}
+		if collateralToken.String() == lendingstate.EmptyAddress {
+			return nil, nil, nil, fmt.Errorf("empty collateral")
+		}
+		collateralPrice := tradingstate.BasePrice
+		depositRate, liquidationRate, recallRate := lendingstate.GetCollateralDetail(statedb, collateralToken)
+		if depositRate == nil || depositRate.Sign() <= 0 {
+			return nil, nil, nil, fmt.Errorf("invalid depositRate %v", depositRate)
+		}
+		if liquidationRate == nil || liquidationRate.Sign() <= 0 {
+			return nil, nil, nil, fmt.Errorf("invalid liquidationRate %v", liquidationRate)
+		}
+		if recallRate == nil || recallRate.Sign() <= 0 {
+			return nil, nil, nil, fmt.Errorf("invalid recallRate %v", recallRate)
+		}
+
+		lendTokenTOMOPrice, collateralPrice, err := l.GetCollateralPrices(header, chain, statedb, tradingStateDb, collateralToken, order.LendingToken)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		if lendTokenTOMOPrice == nil || lendTokenTOMOPrice.Sign() <= 0 {
+			return nil, nil, nil, fmt.Errorf("invalid lendToken price")
+		}
+		if collateralPrice == nil || collateralPrice.Sign() <= 0 {
+			return nil, nil, nil, fmt.Errorf("invalid collateral price")
+		}
+		tradedQuantity, collateralLockedAmount, rejectMaker, settleBalanceResult, err := l.getLendQuantity(lendTokenTOMOPrice, collateralPrice, depositRate, borrowFee, coinbase, chain, header, statedb, order, &oldestOrder, maxTradedQuantity)
+		if err != nil && err == lendingstate.ErrQuantityTradeTooSmall && tradedQuantity != nil && tradedQuantity.Sign() >= 0 {
+			if tradedQuantity.Cmp(maxTradedQuantity) == 0 {
+				if quantityToTrade.Cmp(amount) == 0 { // reject Taker & maker
+					rejects = append(rejects, order)
+					quantityToTrade = lendingstate.Zero
+					rejects = append(rejects, &oldestOrder)
+					err = lendingStateDB.CancelLendingOrder(lendingOrderBook, &oldestOrder)
+					log.Debug("Reject order maker", "lending id ", oldestOrder.LendingId, "err", err)
+					if err != nil {
+						return nil, nil, nil, err
+					}
+					break
+				} else if quantityToTrade.Cmp(amount) < 0 { // reject Taker
+					rejects = append(rejects, order)
+					quantityToTrade = lendingstate.Zero
+					break
+				} else { // reject maker
+					rejects = append(rejects, &oldestOrder)
+					err = lendingStateDB.CancelLendingOrder(lendingOrderBook, &oldestOrder)
+					log.Debug("Reject order maker", "lending id ", oldestOrder.LendingId, "err", err)
+					if err != nil {
+						return nil, nil, nil, err
+					}
+					continue
+				}
+			} else {
+				if rejectMaker { // reject maker
+					rejects = append(rejects, &oldestOrder)
+					err = lendingStateDB.CancelLendingOrder(lendingOrderBook, &oldestOrder)
+					log.Debug("Reject order maker", "lending id ", oldestOrder.LendingId, "err", err)
+					if err != nil {
+						return nil, nil, nil, err
+					}
+					continue
+				} else { // reject Taker
+					rejects = append(rejects, order)
+					quantityToTrade = lendingstate.Zero
+					break
+				}
+			}
+		} else if err != nil {
+			return nil, nil, nil, err
+		}
+		if tradedQuantity.Sign() == 0 && !rejectMaker {
+			log.Debug("Reject order Taker ", "tradedQuantity", tradedQuantity, "rejectMaker", rejectMaker)
+			rejects = append(rejects, order)
+			quantityToTrade = lendingstate.Zero
+			break
+		}
+		if tradedQuantity.Sign() > 0 {
+			quantityToTrade = lendingstate.Sub(quantityToTrade, tradedQuantity)
+			lendingStateDB.SubAmountLendingItem(lendingOrderBook, orderId, Interest, tradedQuantity, side)
+			log.Debug("Update quantity for orderId", "orderId", orderId.Hex())
+			log.Debug("LEND", "lendingOrderBook", lendingOrderBook.Hex(), "Taker Interest", Interest, "maker Interest", order.Interest, "Amount", tradedQuantity, "orderId", orderId, "side", side)
+			tradingId := lendingStateDB.GetTradeNonce(lendingOrderBook) + 1
+			liquidationTime := header.Time + order.Term
+			liquidationPrice := new(big.Int).Mul(collateralPrice, liquidationRate)
+			liquidationPrice = new(big.Int).Div(liquidationPrice, depositRate)
+			lendingTrade := lendingstate.LendingTrade{
+				TradeId:                tradingId,
+				Term:                   oldestOrder.Term,
+				LendingToken:           oldestOrder.LendingToken,
+				CollateralToken:        collateralToken,
+				Amount:                 tradedQuantity,
+				LiquidationTime:        liquidationTime,
+				LiquidationPrice:       liquidationPrice,
+				Interest:               oldestOrder.Interest.Uint64(),
+				DepositRate:            depositRate,
+				LiquidationRate:        liquidationRate,
+				RecallRate:             recallRate,
+				CollateralLockedAmount: collateralLockedAmount,
+			}
+			lendingTrade.Status = lendingstate.TradeStatusOpen
+			lendingTrade.TakerOrderSide = order.Side
+			lendingTrade.TakerOrderType = order.Type
+			lendingTrade.MakerOrderType = oldestOrder.Type
+			lendingTrade.InvestingFee = lendingstate.Zero // current design: no investing fee
+			lendingTrade.CollateralPrice = collateralPrice
+
+			switch order.Side {
+			case lendingstate.Borrowing:
+				// taker is a borrower
+				lendingTrade.BorrowingOrderHash = order.Hash
+				lendingTrade.InvestingOrderHash = oldestOrder.Hash
+				lendingTrade.BorrowingRelayer = order.Relayer
+				lendingTrade.InvestingRelayer = oldestOrder.Relayer
+				lendingTrade.Borrower = order.UserAddress
+				lendingTrade.Investor = oldestOrder.UserAddress
+				lendingTrade.AutoTopUp = order.AutoTopUp
+				// fee
+				if settleBalanceResult != nil {
+					lendingTrade.BorrowingFee = settleBalanceResult.Taker.Fee
+				}
+			case lendingstate.Investing:
+				// taker is an investor
+				lendingTrade.BorrowingOrderHash = oldestOrder.Hash
+				lendingTrade.InvestingOrderHash = order.Hash
+				lendingTrade.BorrowingRelayer = oldestOrder.Relayer
+				lendingTrade.InvestingRelayer = order.Relayer
+				lendingTrade.Borrower = oldestOrder.UserAddress
+				lendingTrade.Investor = order.UserAddress
+				lendingTrade.AutoTopUp = oldestOrder.AutoTopUp
+				// fee
+				if settleBalanceResult != nil {
+					lendingTrade.BorrowingFee = settleBalanceResult.Maker.Fee
+				}
+			}
+			lendingTrade.Hash = lendingTrade.ComputeHash()
+
+			log.Debug("InsertTradingItem", "lendingOrderBook", lendingOrderBook.Hex(), "tradingId", tradingId, "lendingTrade", lendingTrade.Amount)
+			lendingStateDB.InsertTradingItem(lendingOrderBook, tradingId, lendingTrade)
+			log.Debug("InsertLiquidationTime", "lendingOrderBook", lendingOrderBook.Hex(), "tradingId", tradingId, "liquidationTime", liquidationTime)
+			lendingStateDB.InsertLiquidationTime(lendingOrderBook, new(big.Int).SetUint64(liquidationTime), tradingId)
+			log.Debug("SetTradeNonce", "lendingOrderBook", lendingOrderBook.Hex(), "nonce", tradingId+1)
+			lendingStateDB.SetTradeNonce(lendingOrderBook, tradingId)
+			log.Debug("InsertLiquidationPrice", "TradingOrderBookHash", tradingstate.GetTradingOrderBookHash(collateralToken, order.LendingToken).Hex(), "tradingId", tradingId, "lendingOrderBook", lendingOrderBook.Hex(), "liquidationPrice", liquidationPrice)
+			tradingStateDb.InsertLiquidationPrice(tradingstate.GetTradingOrderBookHash(collateralToken, order.LendingToken), liquidationPrice, lendingOrderBook, tradingId)
+			trades = append(trades, &lendingTrade)
+		}
+		if rejectMaker {
+			rejects = append(rejects, &oldestOrder)
+			err := lendingStateDB.CancelLendingOrder(lendingOrderBook, &oldestOrder)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+		}
+	}
+	return quantityToTrade, trades, rejects, nil
+}
+
+func (l *Lending) getLendQuantity(
+	lendTokenTOMOPrice,
+	collateralPrice,
+	depositRate,
+	borrowFee *big.Int,
+	coinbase common.Address, chain tradingstate.ChainContext, header *types.Header, statedb *state.StateDB, takerOrder *lendingstate.LendingItem, makerOrder *lendingstate.LendingItem, quantityToTrade *big.Int) (*big.Int, *big.Int, bool, *lendingstate.LendingSettleBalance, error) {
+	if collateralPrice == nil || collateralPrice.Sign() == 0 {
+		if takerOrder.Side == lendingstate.Borrowing {
+			log.Debug("Reject lending order taker , can not found  collateral price ")
+			return lendingstate.Zero, lendingstate.Zero, false, nil, nil
+		} else {
+			log.Debug("Reject lending order maker , can not found  collateral price ")
+			return lendingstate.Zero, lendingstate.Zero, true, nil, nil
+		}
+	}
+	LendingTokenDecimal, err := l.tomox.GetTokenDecimal(chain, statedb, makerOrder.LendingToken)
+	if err != nil || LendingTokenDecimal.Sign() == 0 {
+		return lendingstate.Zero, lendingstate.Zero, false, nil, fmt.Errorf("Fail to get tokenDecimal. Token: %v . Err: %v", makerOrder.LendingToken.String(), err)
+	}
+	collateralToken := makerOrder.CollateralToken
+	if takerOrder.Side == lendingstate.Borrowing {
+		collateralToken = takerOrder.CollateralToken
+	}
+	collateralTokenDecimal, err := l.tomox.GetTokenDecimal(chain, statedb, collateralToken)
+	if err != nil || collateralTokenDecimal.Sign() == 0 {
+		return lendingstate.Zero, lendingstate.Zero, false, nil, fmt.Errorf("fail to get tokenDecimal. Token: %v . Err: %v", collateralToken.String(), err)
+	}
+	if takerOrder.Relayer.String() == makerOrder.Relayer.String() {
+		if err := lendingstate.CheckRelayerFee(takerOrder.Relayer, new(big.Int).Mul(lendingstate.RelayerLendingFee, big.NewInt(2)), statedb); err != nil {
+			log.Debug("Reject order Taker Exchnage = Maker Exchange , relayer not enough fee ", "err", err)
+			return lendingstate.Zero, lendingstate.Zero, false, nil, nil
+		}
+	} else {
+		if err := lendingstate.CheckRelayerFee(takerOrder.Relayer, lendingstate.RelayerLendingFee, statedb); err != nil {
+			log.Debug("Reject order Taker , relayer not enough fee ", "err", err)
+			return lendingstate.Zero, lendingstate.Zero, false, nil, nil
+		}
+		if err := lendingstate.CheckRelayerFee(makerOrder.Relayer, lendingstate.RelayerLendingFee, statedb); err != nil {
+			log.Debug("Reject order maker , relayer not enough fee ", "err", err)
+			return lendingstate.Zero, lendingstate.Zero, true, nil, nil
+		}
+	}
+	var takerBalance, makerBalance *big.Int
+	var lendToken common.Address
+	switch takerOrder.Side {
+	case lendingstate.Borrowing:
+		takerBalance = lendingstate.GetTokenBalance(takerOrder.UserAddress, takerOrder.CollateralToken, statedb)
+		makerBalance = lendingstate.GetTokenBalance(makerOrder.UserAddress, takerOrder.LendingToken, statedb)
+		lendToken = takerOrder.LendingToken
+	case lendingstate.Investing:
+		takerBalance = lendingstate.GetTokenBalance(takerOrder.UserAddress, makerOrder.LendingToken, statedb)
+		makerBalance = lendingstate.GetTokenBalance(makerOrder.UserAddress, makerOrder.CollateralToken, statedb)
+		lendToken = makerOrder.LendingToken
+	default:
+		takerBalance = big.NewInt(0)
+		makerBalance = big.NewInt(0)
+	}
+	quantity, rejectMaker := GetLendQuantity(takerOrder.Side, collateralTokenDecimal, depositRate, collateralPrice, takerBalance, makerBalance, quantityToTrade)
+	log.Debug("GetLendQuantity", "side", takerOrder.Side, "takerBalance", takerBalance, "makerBalance", makerBalance, "LendingToken", makerOrder.LendingToken, "CollateralToken", collateralToken, "quantity", quantity, "rejectMaker", rejectMaker)
+	if quantity.Sign() > 0 {
+		// Apply Match Order
+		isTomoXLendingFork := chain.Config().IsTIPTomoXLending(header.Number)
+		settleBalanceResult, err := lendingstate.GetSettleBalance(isTomoXLendingFork, takerOrder.Side, lendTokenTOMOPrice, collateralPrice, depositRate, borrowFee, lendToken, collateralToken, LendingTokenDecimal, collateralTokenDecimal, quantity)
+		log.Debug("GetSettleBalance", "settleBalanceResult", settleBalanceResult, "err", err)
+		if err == nil {
+			err = DoSettleBalance(coinbase, takerOrder, makerOrder, settleBalanceResult, statedb)
+		}
+		if err != nil {
+			return quantity, lendingstate.Zero, rejectMaker, nil, err
+		}
+		return quantity, settleBalanceResult.CollateralLockedAmount, rejectMaker, settleBalanceResult, nil
+	}
+	return quantity, lendingstate.Zero, rejectMaker, nil, nil
+}
+
+func GetLendQuantity(takerSide string, collateralTokenDecimal *big.Int, depositRate *big.Int, collateralPrice *big.Int, takerBalance *big.Int, makerBalance *big.Int, quantityToLend *big.Int) (*big.Int, bool) {
+	if takerSide == lendingstate.Borrowing {
+		// taker = Borrower : takerOutTotal = CollateralLockedAmount = quantityToLend * collateral Token Decimal/ CollateralPrice  * deposit rate
+		takerOutTotal := new(big.Int).Mul(quantityToLend, collateralTokenDecimal)
+		takerOutTotal = new(big.Int).Mul(takerOutTotal, depositRate)
+		takerOutTotal = new(big.Int).Div(takerOutTotal, big.NewInt(100)) // depositRate in percentage format
+		takerOutTotal = new(big.Int).Div(takerOutTotal, collateralPrice)
+		// Investor : makerOutTotal = quantityToLend
+		makerOutTotal := quantityToLend
+		if takerBalance.Cmp(takerOutTotal) >= 0 && makerBalance.Cmp(makerOutTotal) >= 0 {
+			return quantityToLend, false
+		} else if takerBalance.Cmp(takerOutTotal) < 0 && makerBalance.Cmp(makerOutTotal) >= 0 {
+			newQuantityLend := new(big.Int).Mul(takerBalance, collateralPrice)
+			newQuantityLend = new(big.Int).Mul(newQuantityLend, big.NewInt(100)) // depositRate in percentage format
+			newQuantityLend = new(big.Int).Div(newQuantityLend, depositRate)
+			newQuantityLend = new(big.Int).Div(newQuantityLend, collateralTokenDecimal)
+			if newQuantityLend.Sign() == 0 {
+				log.Debug("Reject lending order Taker , not enough balance ", "takerSide", takerSide, "takerBalance", takerBalance, "takerOutTotal", takerOutTotal)
+			}
+			return newQuantityLend, false
+		} else if takerBalance.Cmp(takerOutTotal) >= 0 && makerBalance.Cmp(makerOutTotal) < 0 {
+			log.Debug("Reject lending order maker , not enough balance ", "makerBalance", makerBalance, " makerOutTotal", makerOutTotal)
+			return makerBalance, true
+		} else {
+			// takerBalance.Cmp(takerOutTotal) < 0 && makerBalance.Cmp(makerOutTotal) < 0
+			newQuantityLend := new(big.Int).Mul(takerBalance, collateralPrice)
+			newQuantityLend = new(big.Int).Mul(newQuantityLend, big.NewInt(100)) // depositRate in percentage format
+			newQuantityLend = new(big.Int).Div(newQuantityLend, depositRate)
+			newQuantityLend = new(big.Int).Div(newQuantityLend, collateralTokenDecimal)
+			if newQuantityLend.Cmp(makerBalance) <= 0 {
+				if newQuantityLend.Sign() == 0 {
+					log.Debug("Reject lending order Taker , not enough balance ", "takerSide", takerSide, "takerBalance", takerBalance, "makerBalance", makerBalance, " newQuantityLend ", newQuantityLend)
+				}
+				return newQuantityLend, false
+			}
+			log.Debug("Reject lending order maker , not enough balance ", "takerSide", takerSide, "takerBalance", takerBalance, "makerBalance", makerBalance, " newQuantityLend ", newQuantityLend)
+			return makerBalance, true
+		}
+	} else {
+		// maker =  Borrower : makerOutTotal = CollateralLockedAmount = quantityToLend * collateral Token Decimal / CollateralPrice  * deposit rate
+		makerOutTotal := new(big.Int).Mul(quantityToLend, collateralTokenDecimal)
+		makerOutTotal = new(big.Int).Mul(makerOutTotal, depositRate)
+		makerOutTotal = new(big.Int).Div(makerOutTotal, big.NewInt(100)) // depositRate in percentage format
+		makerOutTotal = new(big.Int).Div(makerOutTotal, collateralPrice)
+		// Investor : makerOutTotal = quantityToLend
+		takerOutTotal := quantityToLend
+		if takerBalance.Cmp(takerOutTotal) >= 0 && makerBalance.Cmp(makerOutTotal) >= 0 {
+			return quantityToLend, false
+		} else if takerBalance.Cmp(takerOutTotal) < 0 && makerBalance.Cmp(makerOutTotal) >= 0 {
+			if takerBalance.Sign() == 0 {
+				log.Debug("Reject lending order Taker , not enough balance ", "takerSide", takerSide, "takerBalance", takerBalance, "takerOutTotal", takerOutTotal)
+			}
+			return takerBalance, false
+		} else if takerBalance.Cmp(takerOutTotal) >= 0 && makerBalance.Cmp(makerOutTotal) < 0 {
+			newQuantityLend := new(big.Int).Mul(makerBalance, collateralPrice)
+			newQuantityLend = new(big.Int).Mul(newQuantityLend, big.NewInt(100)) // depositRate in percentage format
+			newQuantityLend = new(big.Int).Div(newQuantityLend, depositRate)
+			newQuantityLend = new(big.Int).Div(newQuantityLend, collateralTokenDecimal)
+			log.Debug("Reject lending order maker , not enough balance ", "makerBalance", makerBalance, " makerOutTotal", makerOutTotal)
+			return newQuantityLend, true
+		} else {
+			// takerBalance.Cmp(takerOutTotal) < 0 && makerBalance.Cmp(makerOutTotal) < 0
+			newQuantityLend := new(big.Int).Mul(makerBalance, collateralPrice)
+			newQuantityLend = new(big.Int).Mul(newQuantityLend, big.NewInt(100)) // depositRate in percentage format
+			newQuantityLend = new(big.Int).Div(newQuantityLend, depositRate)
+			newQuantityLend = new(big.Int).Div(newQuantityLend, collateralTokenDecimal)
+			if newQuantityLend.Cmp(takerBalance) <= 0 {
+				log.Debug("Reject lending order maker , not enough balance ", "takerSide", takerSide, "takerBalance", takerBalance, "makerBalance", makerBalance, " newQuantityLend ", newQuantityLend)
+				return newQuantityLend, true
+			}
+			if takerBalance.Sign() == 0 {
+				log.Debug("Reject lending order Taker , not enough balance ", "takerSide", takerSide, "takerBalance", takerBalance, "makerBalance", makerBalance, " newQuantityLend ", newQuantityLend)
+			}
+			return takerBalance, false
+		}
+	}
+}
+
+func DoSettleBalance(coinbase common.Address, takerOrder, makerOrder *lendingstate.LendingItem, settleBalance *lendingstate.LendingSettleBalance, statedb *state.StateDB) error {
+	takerExOwner := lendingstate.GetRelayerOwner(takerOrder.Relayer, statedb)
+	makerExOwner := lendingstate.GetRelayerOwner(makerOrder.Relayer, statedb)
+	matchingFee := big.NewInt(0)
+	// masternodes only charge borrower relayer fee
+	matchingFee = new(big.Int).Add(matchingFee, lendingstate.RelayerLendingFee)
+
+	if params.EmptyHash(takerExOwner.Hash()) || params.EmptyHash(makerExOwner.Hash()) {
+		return fmt.Errorf("Echange owner empty , Taker: %v , maker : %v ", takerExOwner, makerExOwner)
+	}
+	mapBalances := map[common.Address]map[common.Address]*big.Int{}
+	//Checking balance
+	if takerOrder.Side == lendingstate.Borrowing {
+		relayerFee, err := lendingstate.CheckSubRelayerFee(takerOrder.Relayer, lendingstate.RelayerLendingFee, statedb, map[common.Address]*big.Int{})
+		if err != nil {
+			return err
+		}
+		lendingstate.SetSubRelayerFee(takerOrder.Relayer, relayerFee, lendingstate.RelayerLendingFee, statedb)
+		newTakerInTotal, err := lendingstate.CheckAddTokenBalance(takerOrder.UserAddress, settleBalance.Taker.InTotal, settleBalance.Taker.InToken, statedb, mapBalances)
+		if err != nil {
+			return err
+		}
+		if mapBalances[settleBalance.Taker.InToken] == nil {
+			mapBalances[settleBalance.Taker.InToken] = map[common.Address]*big.Int{}
+		}
+		mapBalances[settleBalance.Taker.InToken][takerOrder.UserAddress] = newTakerInTotal
+		newTakerOutTotal, err := lendingstate.CheckSubTokenBalance(takerOrder.UserAddress, settleBalance.Taker.OutTotal, settleBalance.Taker.OutToken, statedb, mapBalances)
+		if err != nil {
+			return err
+		}
+		if mapBalances[settleBalance.Taker.OutToken] == nil {
+			mapBalances[settleBalance.Taker.OutToken] = map[common.Address]*big.Int{}
+		}
+		mapBalances[settleBalance.Taker.OutToken][takerOrder.UserAddress] = newTakerOutTotal
+		newMakerOutTotal, err := lendingstate.CheckSubTokenBalance(makerOrder.UserAddress, settleBalance.Maker.OutTotal, settleBalance.Maker.OutToken, statedb, mapBalances)
+		if err != nil {
+			return err
+		}
+		if mapBalances[settleBalance.Maker.OutToken] == nil {
+			mapBalances[settleBalance.Maker.OutToken] = map[common.Address]*big.Int{}
+		}
+		mapBalances[settleBalance.Maker.OutToken][makerOrder.UserAddress] = newMakerOutTotal
+		newTakerFee, err := lendingstate.CheckAddTokenBalance(takerExOwner, settleBalance.Taker.Fee, settleBalance.Taker.InToken, statedb, mapBalances)
+		if err != nil {
+			return err
+		}
+		mapBalances[settleBalance.Taker.InToken][takerExOwner] = newTakerFee
+
+		newCollateralTokenLock, err := lendingstate.CheckAddTokenBalance(common.HexToAddress(lendingstate.LendingLockAddress), settleBalance.Taker.OutTotal, settleBalance.Taker.OutToken, statedb, mapBalances)
+		if err != nil {
+			return err
+		}
+		mapBalances[settleBalance.Taker.OutToken][common.HexToAddress(lendingstate.LendingLockAddress)] = newCollateralTokenLock
+	} else {
+		relayerFee, err := lendingstate.CheckSubRelayerFee(makerOrder.Relayer, lendingstate.RelayerLendingFee, statedb, map[common.Address]*big.Int{})
+		if err != nil {
+			return err
+		}
+		lendingstate.SetSubRelayerFee(makerOrder.Relayer, relayerFee, lendingstate.RelayerLendingFee, statedb)
+		newTakerOutTotal, err := lendingstate.CheckSubTokenBalance(takerOrder.UserAddress, settleBalance.Taker.OutTotal, settleBalance.Taker.OutToken, statedb, mapBalances)
+		if err != nil {
+			return err
+		}
+		if mapBalances[settleBalance.Taker.OutToken] == nil {
+			mapBalances[settleBalance.Taker.OutToken] = map[common.Address]*big.Int{}
+		}
+		mapBalances[settleBalance.Taker.OutToken][takerOrder.UserAddress] = newTakerOutTotal
+		newMakerInTotal, err := lendingstate.CheckAddTokenBalance(makerOrder.UserAddress, settleBalance.Maker.InTotal, settleBalance.Maker.InToken, statedb, mapBalances)
+		if err != nil {
+			return err
+		}
+		if mapBalances[settleBalance.Maker.InToken] == nil {
+			mapBalances[settleBalance.Maker.InToken] = map[common.Address]*big.Int{}
+		}
+		mapBalances[settleBalance.Maker.InToken][makerOrder.UserAddress] = newMakerInTotal
+		newMakerOutTotal, err := lendingstate.CheckSubTokenBalance(makerOrder.UserAddress, settleBalance.Maker.OutTotal, settleBalance.Maker.OutToken, statedb, mapBalances)
+		if err != nil {
+			return err
+		}
+		if mapBalances[settleBalance.Maker.OutToken] == nil {
+			mapBalances[settleBalance.Maker.OutToken] = map[common.Address]*big.Int{}
+		}
+		mapBalances[settleBalance.Maker.OutToken][makerOrder.UserAddress] = newMakerOutTotal
+		newMakerFee, err := lendingstate.CheckAddTokenBalance(makerExOwner, settleBalance.Maker.Fee, settleBalance.Maker.InToken, statedb, mapBalances)
+		if err != nil {
+			return err
+		}
+		mapBalances[settleBalance.Maker.InToken][makerExOwner] = newMakerFee
+
+		newCollateralTokenLock, err := lendingstate.CheckAddTokenBalance(common.HexToAddress(lendingstate.LendingLockAddress), settleBalance.Maker.OutTotal, settleBalance.Maker.OutToken, statedb, mapBalances)
+		if err != nil {
+			return err
+		}
+		mapBalances[settleBalance.Maker.OutToken][common.HexToAddress(lendingstate.LendingLockAddress)] = newCollateralTokenLock
+	}
+	masternodeOwner, _ := statedb.VicGetValidatorInfo(common.HexToAddress(tradingstate.ValidatorContract), coinbase)
+	statedb.AddBalance(masternodeOwner, matchingFee)
+	for token, balances := range mapBalances {
+		for adrr, value := range balances {
+			lendingstate.SetTokenBalance(adrr, value, token, statedb)
+		}
+	}
+	return nil
+}
+
+func (l *Lending) ProcessCancelOrder(header *types.Header, lendingStateDB *lendingstate.LendingStateDB, statedb *state.StateDB, tradingStateDb *tradingstate.TradingStateDB, chain tradingstate.ChainContext, coinbase common.Address, lendingOrderBook common.Hash, order *lendingstate.LendingItem) (error, bool) {
+	originOrder := lendingStateDB.GetLendingOrder(lendingOrderBook, common.BigToHash(new(big.Int).SetUint64(order.LendingId)))
+	if originOrder == lendingstate.EmptyLendingOrder {
+		return fmt.Errorf("lendingOrder not found. Id: %v. LendToken: %s . Term: %v. CollateralToken: %v", order.LendingId, order.LendingToken.Hex(), order.Term, order.CollateralToken.Hex()), false
+	}
+	if originOrder.Hash != order.Hash {
+		return fmt.Errorf("invalid lending hash. GotHash: %s. ExpectedHash: %s . LendToken: %s . Term: %v. CollateralToken: %v", order.Hash.Hex(), originOrder.Hash.Hex(), order.LendingToken.Hex(), order.Term, order.CollateralToken.Hex()), false
+	}
+	if originOrder.UserAddress != order.UserAddress {
+		return fmt.Errorf("userAddress doesnot match. Expected: %s . Got: %s", originOrder.UserAddress.Hex(), order.UserAddress.Hex()), false
+	}
+	if err := lendingstate.CheckRelayerFee(originOrder.Relayer, lendingstate.RelayerLendingCancelFee, statedb); err != nil {
+		log.Debug("Relayer not enough fee when cancel order", "err", err)
+		return nil, true
+	}
+	lendTokenDecimal, err := l.tomox.GetTokenDecimal(chain, statedb, originOrder.LendingToken)
+	if err != nil || lendTokenDecimal == nil || lendTokenDecimal.Sign() <= 0 {
+		log.Debug("Fail to get tokenDecimal ", "Token", originOrder.LendingToken.String(), "err", err)
+		return err, false
+	}
+	var tokenBalance *big.Int
+	switch originOrder.Side {
+	case lendingstate.Investing:
+		tokenBalance = lendingstate.GetTokenBalance(originOrder.UserAddress, originOrder.LendingToken, statedb)
+	case lendingstate.Borrowing:
+		tokenBalance = lendingstate.GetTokenBalance(originOrder.UserAddress, originOrder.CollateralToken, statedb)
+	default:
+		log.Debug("Not found order side", "Side", originOrder.Side)
+		return nil, true
+	}
+	log.Debug("ProcessCancelOrder", "LendingToken", originOrder.LendingToken, "CollateralToken", originOrder.CollateralToken, "makerInterest", originOrder.Interest, "lendTokenDecimal", lendTokenDecimal, "quantity", originOrder.Quantity)
+	collateralPrice := tradingstate.BasePrice
+	collateralTokenDecimal := tradingstate.BasePrice
+	if originOrder.Side == lendingstate.Borrowing {
+		_, collateralPrice, err = l.GetCollateralPrices(header, chain, statedb, tradingStateDb, originOrder.CollateralToken, originOrder.LendingToken)
+		if err != nil || collateralPrice == nil || collateralPrice.Sign() <= 0 {
+			return err, false
+		}
+		collateralTokenDecimal, err = l.tomox.GetTokenDecimal(chain, statedb, originOrder.CollateralToken)
+		if err != nil || collateralTokenDecimal == nil || collateralTokenDecimal.Sign() <= 0 {
+			log.Debug("Fail to get tokenDecimal ", "Token", originOrder.LendingToken.String(), "err", err)
+			return err, false
+		}
+	}
+	feeRate := lendingstate.GetFee(statedb, originOrder.Relayer)
+	tokenCancelFee, tokenPriceInTOMO := common.Big0, common.Big0
+	if !chain.Config().IsTIPTomoXCancelFee(header.Number) {
+		tokenCancelFee = getCancelFeeV1(collateralTokenDecimal, collateralPrice, feeRate, &originOrder)
+	} else {
+		tokenCancelFee, tokenPriceInTOMO = l.getCancelFee(chain, statedb, tradingStateDb, &originOrder, feeRate)
+	}
+
+	if tokenBalance.Cmp(tokenCancelFee) < 0 {
+		log.Debug("User not enough balance when cancel order", "Side", originOrder.Side, "Interest", originOrder.Interest, "Quantity", originOrder.Quantity, "balance", tokenBalance, "fee", tokenCancelFee)
+		return nil, true
+	}
+	err = lendingStateDB.CancelLendingOrder(lendingOrderBook, &originOrder)
+	if err != nil {
+		log.Debug("Error when cancel order", "order", &originOrder)
+		return err, false
+	}
+	// relayers pay TOMO for masternode
+	lendingstate.SubRelayerFee(originOrder.Relayer, lendingstate.RelayerLendingCancelFee, statedb)
+	masternodeOwner, _ := statedb.VicGetValidatorInfo(common.HexToAddress(tradingstate.ValidatorContract), coinbase)
+	statedb.AddBalance(masternodeOwner, lendingstate.RelayerLendingCancelFee)
+	relayerOwner := lendingstate.GetRelayerOwner(originOrder.Relayer, statedb)
+	switch originOrder.Side {
+	case lendingstate.Investing:
+		// users pay token for relayer
+		lendingstate.SubTokenBalance(originOrder.UserAddress, tokenCancelFee, originOrder.LendingToken, statedb)
+		lendingstate.AddTokenBalance(relayerOwner, tokenCancelFee, originOrder.LendingToken, statedb)
+	case lendingstate.Borrowing:
+		// users pay token for relayer
+		lendingstate.SubTokenBalance(originOrder.UserAddress, tokenCancelFee, originOrder.CollateralToken, statedb)
+		lendingstate.AddTokenBalance(relayerOwner, tokenCancelFee, originOrder.CollateralToken, statedb)
+	default:
+	}
+	extraData, _ := json.Marshal(struct {
+		CancelFee        string
+		TokenPriceInTOMO string
+	}{
+		CancelFee:        tokenCancelFee.Text(10),
+		TokenPriceInTOMO: tokenPriceInTOMO.Text(10),
+	})
+	order.ExtraData = string(extraData)
+
+	return nil, false
+}
+
+func (l *Lending) ProcessTopUp(lendingStateDB *lendingstate.LendingStateDB, statedb *state.StateDB, tradingStateDb *tradingstate.TradingStateDB, order *lendingstate.LendingItem) (error, bool, *lendingstate.LendingTrade) {
+	lendingTradeId := params.Uint64ToHash(order.LendingTradeId)
+	lendingBook := lendingstate.GetLendingOrderBookHash(order.LendingToken, order.Term)
+	lendingTrade := lendingStateDB.GetLendingTrade(lendingBook, lendingTradeId)
+	if lendingTrade == lendingstate.EmptyLendingTrade {
+		return fmt.Errorf("process deposit for emptyLendingTrade is not allowed. lendingTradeId: %v", lendingTradeId.Hex()), true, nil
+	}
+	if order.UserAddress.String() != lendingTrade.Borrower.String() {
+		return fmt.Errorf("ProcessTopUp: invalid userAddress . UserAddress: %s . Borrower: %s", order.UserAddress.Hex(), lendingTrade.Borrower.Hex()), true, nil
+	}
+	if order.Relayer.String() != lendingTrade.BorrowingRelayer.String() {
+		return fmt.Errorf("ProcessTopUp: invalid relayerAddress . Got: %s . Expect: %s", order.Relayer.Hex(), lendingTrade.BorrowingRelayer.Hex()), true, nil
+	}
+	if order.Quantity.Sign() <= 0 || lendingTrade.TradeId != lendingTradeId.Big().Uint64() {
+		log.Debug("ProcessTopUp: invalid quantity", "Quantity", order.Quantity, "lendingTradeId", lendingTradeId.Hex())
+		return nil, true, nil
+	}
+	return l.ProcessTopUpLendingTrade(lendingStateDB, statedb, tradingStateDb, lendingTradeId, lendingBook, order.Quantity)
+}
+
+// return hash: hash of lendingTrade
+func (l *Lending) ProcessRepay(header *types.Header, chain tradingstate.ChainContext, lendingStateDB *lendingstate.LendingStateDB, statedb *state.StateDB, tradingstateDB *tradingstate.TradingStateDB, lendingBook common.Hash, order *lendingstate.LendingItem) (trade *lendingstate.LendingTrade, err error) {
+	lendingTradeId := order.LendingTradeId
+	lendingTradeIdHash := params.Uint64ToHash(lendingTradeId)
+	lendingTrade := lendingStateDB.GetLendingTrade(lendingBook, lendingTradeIdHash)
+	if lendingTrade == lendingstate.EmptyLendingTrade || lendingTrade.TradeId != lendingTradeIdHash.Big().Uint64() {
+		return nil, fmt.Errorf("ProcessRepay for emptyLendingTrade is not allowed. lendingTradeId: %v", lendingTradeId)
+	}
+	if order.UserAddress.String() != lendingTrade.Borrower.String() {
+		return nil, fmt.Errorf("ProcessRepay: invalid userAddress . UserAddress: %s . Borrower: %s", order.UserAddress.Hex(), lendingTrade.Borrower.Hex())
+	}
+	if order.Relayer.String() != lendingTrade.BorrowingRelayer.String() {
+		return nil, fmt.Errorf("ProcessRepay: invalid relayerAddress . Got: %s . Expect: %s", order.Relayer.Hex(), lendingTrade.BorrowingRelayer.Hex())
+	}
+	return l.ProcessRepayLendingTrade(header, chain, lendingStateDB, statedb, tradingstateDB, lendingBook, lendingTradeId)
+}
+
+// return liquidatedTrade
+func (l *Lending) LiquidationExpiredTrade(header *types.Header, chain tradingstate.ChainContext, lendingStateDB *lendingstate.LendingStateDB, statedb *state.StateDB, tradingstateDB *tradingstate.TradingStateDB, lendingBook common.Hash, lendingTradeId uint64) (*lendingstate.LendingTrade, error) {
+	lendingTradeIdHash := params.Uint64ToHash(lendingTradeId)
+	lendingTrade := lendingStateDB.GetLendingTrade(lendingBook, lendingTradeIdHash)
+	if lendingTrade.TradeId != lendingTradeId {
+		return nil, fmt.Errorf("Lending Trade Id not found : %d ", lendingTradeId)
+	}
+	repayAmount := lendingTrade.CollateralLockedAmount
+
+	_, collateralPrice, err := l.GetCollateralPrices(header, chain, statedb, tradingstateDB, lendingTrade.CollateralToken, lendingTrade.LendingToken)
+	if err != nil || collateralPrice == nil || collateralPrice.Sign() <= 0 {
+		// if cannot get collateralPrice, liquidate all collateral
+		log.Error("LiquidationExpiredTrade: cannot get collateralPrice", "err", err)
+	} else {
+		// repayAmount= CollateralLockedAmount * LiquidationPrice / collateralPrice + interestAmount
+		repayAmount = new(big.Int).Mul(lendingTrade.CollateralLockedAmount, lendingTrade.LiquidationPrice)
+		repayAmount = new(big.Int).Div(repayAmount, collateralPrice)
+		_, liquidationRate, _ := lendingstate.GetCollateralDetail(statedb, lendingTrade.CollateralToken)
+		collateralAmount := new(big.Int).Mul(repayAmount, big.NewInt(100))
+		collateralAmount = new(big.Int).Div(collateralAmount, liquidationRate)
+		totalCollateralAmount := lendingstate.CalculateTotalRepayValue(header.Time, lendingTrade.LiquidationTime, lendingTrade.Term, lendingTrade.Interest, collateralAmount)
+		interestAmount := new(big.Int).Sub(totalCollateralAmount, collateralAmount)
+		repayAmount = new(big.Int).Add(repayAmount, interestAmount)
+	}
+
+	recallAmount := common.Big0
+	if repayAmount.Cmp(lendingTrade.CollateralLockedAmount) < 0 {
+		recallAmount = new(big.Int).Sub(lendingTrade.CollateralLockedAmount, repayAmount)
+		lendingstate.AddTokenBalance(lendingTrade.Borrower, recallAmount, lendingTrade.CollateralToken, statedb)
+	} else {
+		repayAmount = lendingTrade.CollateralLockedAmount
+	}
+	lendingstate.SubTokenBalance(common.HexToAddress(lendingstate.LendingLockAddress), lendingTrade.CollateralLockedAmount, lendingTrade.CollateralToken, statedb)
+	lendingstate.AddTokenBalance(lendingTrade.Investor, repayAmount, lendingTrade.CollateralToken, statedb)
+
+	err = lendingStateDB.RemoveLiquidationTime(lendingBook, lendingTradeId, lendingTrade.LiquidationTime)
+	if err != nil {
+		log.Debug("LiquidationTrade RemoveLiquidationTime", "err", err)
+		return nil, err
+	}
+	err = tradingstateDB.RemoveLiquidationPrice(tradingstate.GetTradingOrderBookHash(lendingTrade.CollateralToken, lendingTrade.LendingToken), lendingTrade.LiquidationPrice, lendingBook, lendingTradeId)
+	if err != nil {
+		log.Debug("LiquidationTrade RemoveLiquidationPrice", "err", err)
+		return nil, err
+	}
+	err = lendingStateDB.CancelLendingTrade(lendingBook, lendingTradeId)
+	if err != nil {
+		log.Debug("LiquidationTrade CancelLendingTrade", "err", err)
+		return nil, err
+	}
+	// update liquidationData mongodb
+	liquidationData := lendingstate.LiquidationData{
+		RecallAmount:      recallAmount,
+		LiquidationAmount: repayAmount,
+		CollateralPrice:   collateralPrice,
+		Reason:            lendingstate.LiquidatedByTime,
+	}
+	extraData, _ := json.Marshal(liquidationData)
+	lendingTrade.ExtraData = string(extraData)
+	return &lendingTrade, nil
+}
+
+// return liquidatedTrade
+func (l *Lending) LiquidationTrade(lendingStateDB *lendingstate.LendingStateDB, statedb *state.StateDB, tradingstateDB *tradingstate.TradingStateDB, lendingBook common.Hash, lendingTradeId uint64) (*lendingstate.LendingTrade, error) {
+	lendingTradeIdHash := params.Uint64ToHash(lendingTradeId)
+	lendingTrade := lendingStateDB.GetLendingTrade(lendingBook, lendingTradeIdHash)
+	if lendingTrade.TradeId != lendingTradeId {
+		return nil, fmt.Errorf("Lending Trade Id not found : %d ", lendingTradeId)
+	}
+	lendingstate.SubTokenBalance(common.HexToAddress(lendingstate.LendingLockAddress), lendingTrade.CollateralLockedAmount, lendingTrade.CollateralToken, statedb)
+	lendingstate.AddTokenBalance(lendingTrade.Investor, lendingTrade.CollateralLockedAmount, lendingTrade.CollateralToken, statedb)
+
+	err := lendingStateDB.RemoveLiquidationTime(lendingBook, lendingTradeId, lendingTrade.LiquidationTime)
+	if err != nil {
+		log.Debug("LiquidationTrade RemoveLiquidationTime", "err", err)
+		return nil, err
+	}
+	err = tradingstateDB.RemoveLiquidationPrice(tradingstate.GetTradingOrderBookHash(lendingTrade.CollateralToken, lendingTrade.LendingToken), lendingTrade.LiquidationPrice, lendingBook, lendingTradeId)
+	if err != nil {
+		log.Debug("LiquidationTrade RemoveLiquidationPrice", "err", err)
+		return nil, err
+	}
+	err = lendingStateDB.CancelLendingTrade(lendingBook, lendingTradeId)
+	if err != nil {
+		log.Debug("LiquidationTrade CancelLendingTrade", "err", err)
+		return nil, err
+	}
+	return &lendingTrade, nil
+}
+
+// cancellation fee = 1/10 borrowing fee
+// deprecated after hardfork at TIPTomoXCancellationFee
+func getCancelFeeV1(collateralTokenDecimal *big.Int, collateralPrice, borrowFee *big.Int, order *lendingstate.LendingItem) *big.Int {
+	cancelFee := big.NewInt(0)
+	if order.Side == lendingstate.Investing {
+		// cancel fee = quantityToLend*borrowFee/LendingCancelFee
+		cancelFee = new(big.Int).Mul(order.Quantity, borrowFee)
+		cancelFee = new(big.Int).Div(cancelFee, tradingstate.TomoXBaseCancelFee)
+	} else {
+		//Fee = quantityToLend * collateralTokenDecimal/collateralPrice *borrowFee/LendingCancelFee
+		cancelFee = new(big.Int).Mul(order.Quantity, collateralTokenDecimal)
+		cancelFee = new(big.Int).Mul(cancelFee, borrowFee)
+		cancelFee = new(big.Int).Div(cancelFee, collateralPrice)
+		cancelFee = new(big.Int).Div(cancelFee, tradingstate.TomoXBaseCancelFee)
+	}
+	return cancelFee
+}
+
+// return tokenQuantity, tokenPriceInTOMO
+func (l *Lending) getCancelFee(chain tradingstate.ChainContext, statedb *state.StateDB, tradingStateDb *tradingstate.TradingStateDB, order *lendingstate.LendingItem, feeRate *big.Int) (*big.Int, *big.Int) {
+	if feeRate == nil || feeRate.Sign() == 0 {
+		return common.Big0, common.Big0
+	}
+	cancelFee, tokenPriceInTOMO := common.Big0, common.Big0
+	var err error
+	if order.Side == lendingstate.Investing {
+		cancelFee, tokenPriceInTOMO, err = l.tomox.ConvertTOMOToToken(chain, statedb, tradingStateDb, order.LendingToken, lendingstate.RelayerLendingCancelFee)
+	} else {
+		cancelFee, tokenPriceInTOMO, err = l.tomox.ConvertTOMOToToken(chain, statedb, tradingStateDb, order.CollateralToken, lendingstate.RelayerLendingCancelFee)
+	}
+	if err != nil {
+		return common.Big0, common.Big0
+	}
+	return cancelFee, tokenPriceInTOMO
+}
+
+func (l *Lending) GetMediumTradePriceBeforeEpoch(chain tradingstate.ChainContext, statedb *state.StateDB, tradingStateDb *tradingstate.TradingStateDB, baseToken common.Address, quoteToken common.Address) (*big.Int, error) {
+	price := tradingStateDb.GetMediumPriceBeforeEpoch(tradingstate.GetTradingOrderBookHash(baseToken, quoteToken))
+	if price != nil && price.Sign() > 0 {
+		log.Debug("getMediumTradePriceBeforeEpoch", "baseToken", baseToken.Hex(), "quoteToken", quoteToken.Hex(), "price", price)
+		return price, nil
+	} else {
+		inversePrice := tradingStateDb.GetMediumPriceBeforeEpoch(tradingstate.GetTradingOrderBookHash(quoteToken, baseToken))
+		log.Debug("getMediumTradePriceBeforeEpoch", "baseToken", baseToken.Hex(), "quoteToken", quoteToken.Hex(), "inversePrice", inversePrice)
+		if inversePrice != nil && inversePrice.Sign() > 0 {
+			quoteTokenDecimal, err := l.tomox.GetTokenDecimal(chain, statedb, quoteToken)
+			if err != nil || quoteTokenDecimal.Sign() == 0 {
+				return nil, fmt.Errorf("Fail to get tokenDecimal. Token: %v . Err: %v", quoteToken.String(), err)
+			}
+			baseTokenDecimal, err := l.tomox.GetTokenDecimal(chain, statedb, baseToken)
+			if err != nil || baseTokenDecimal.Sign() == 0 {
+				return nil, fmt.Errorf("Fail to get tokenDecimal. Token: %v . Err: %v", baseToken, err)
+			}
+			price = new(big.Int).Mul(baseTokenDecimal, quoteTokenDecimal)
+			price = new(big.Int).Div(price, inversePrice)
+			log.Debug("getMediumTradePriceBeforeEpoch", "baseToken", baseToken.Hex(), "quoteToken", quoteToken.Hex(), "baseTokenDecimal", baseTokenDecimal, "quoteTokenDecimal", quoteTokenDecimal, "inversePrice", inversePrice)
+			return price, nil
+		}
+	}
+	return nil, nil
+}
+
+// LendToken and CollateralToken must meet at least one of following conditions
+// - Have direct pair in TomoX: lendToken/CollateralToken or CollateralToken/LendToken
+// - Have pairs with TOMO:
+// -  lendToken/TOMO and CollateralToken/TOMO
+// -  TOMO/lendToken and TOMO/CollateralToken
+func (l *Lending) GetCollateralPrices(header *types.Header, chain tradingstate.ChainContext, statedb *state.StateDB, tradingStateDb *tradingstate.TradingStateDB, collateralToken common.Address, lendingToken common.Address) (*big.Int, *big.Int, error) {
+	// lendTokenTOMOPrice: price of ticker lendToken/TOMO
+	// collateralTOMOPrice: price of ticker collateralToken/TOMO
+	// collateralPrice: price of ticker collateralToken/lendToken
+
+	collateralPriceFromContract, updatedBlock := lendingstate.GetCollateralPrice(statedb, collateralToken, lendingToken)
+	collateralPriceUpdatedFromContract := updatedBlock.Uint64()/chain.Config().Posv.Epoch == header.Number.Uint64()/chain.Config().Posv.Epoch
+
+	lendTokenTOMOPrice, err := l.GetTOMOBasePrices(header, chain, statedb, tradingStateDb, lendingToken)
+	if err != nil {
+		return nil, nil, err
+	}
+	if collateralPriceUpdatedFromContract {
+		log.Debug("Getting collateral/lending token price from contract", "price", collateralPriceFromContract)
+		return lendTokenTOMOPrice, collateralPriceFromContract, nil
+	}
+	lendingTokenDecimal, err := l.tomox.GetTokenDecimal(chain, statedb, lendingToken)
+	log.Debug("GetTokenDecimal", "lendingToken", lendingToken, "err", err)
+	if err != nil || lendingTokenDecimal == nil || lendingTokenDecimal.Sign() == 0 {
+		return nil, nil, err
+	}
+	collateralTokenDecimal, err := l.tomox.GetTokenDecimal(chain, statedb, collateralToken)
+	log.Debug("GetTokenDecimal", "collateralToken", collateralToken, "err", err)
+	if err != nil || collateralTokenDecimal == nil || collateralTokenDecimal.Sign() == 0 {
+		return nil, nil, err
+	}
+	var collateralPrice *big.Int
+	inverseCollateralPriceFromContract, updatedBlock := lendingstate.GetCollateralPrice(statedb, lendingToken, collateralToken)
+	inverseCollateralPriceUpdatedFromContract := updatedBlock.Uint64()/chain.Config().Posv.Epoch == header.Number.Uint64()/chain.Config().Posv.Epoch
+	if inverseCollateralPriceUpdatedFromContract {
+		log.Debug("Getting lending/collateral token price from contract", "price", inverseCollateralPriceFromContract)
+		collateralPrice = new(big.Int).Mul(lendingTokenDecimal, collateralTokenDecimal)
+		collateralPrice = new(big.Int).Div(collateralPrice, inverseCollateralPriceFromContract)
+		return lendTokenTOMOPrice, collateralPrice, nil
+	}
+	// if contract doesn't provide any price information
+	// getting price from pair in tomox
+	lastAveragePrice, err := l.GetMediumTradePriceBeforeEpoch(chain, statedb, tradingStateDb, collateralToken, lendingToken)
+	if err != nil {
+		return nil, nil, err
+	}
+	if lastAveragePrice != nil && lastAveragePrice.Sign() > 0 {
+		log.Debug("Getting collateral/lending from direct pair in tomox", "lendToken", lendingToken.Hex(), "collateralToken", collateralToken.Hex(), "price", lastAveragePrice)
+		return lendTokenTOMOPrice, lastAveragePrice, nil
+	}
+	collateralTOMOPrice, err := l.GetTOMOBasePrices(header, chain, statedb, tradingStateDb, collateralToken)
+	if err != nil {
+		return nil, nil, err
+	}
+	if collateralTOMOPrice == nil || lendTokenTOMOPrice == nil {
+		return common.Big0, common.Big0, nil
+	}
+	// Calculate collateral/LendToken price from collateral/TOMO, lendToken/TOMO
+	collateralPrice = new(big.Int).Mul(collateralTOMOPrice, lendingTokenDecimal)
+	collateralPrice = new(big.Int).Div(collateralPrice, lendTokenTOMOPrice)
+	log.Debug("GetCollateralPrices: Calculate collateral/LendToken price from collateral/TOMO, lendToken/TOMO", "collateralPrice", collateralPrice,
+		"collateralTOMOPrice", collateralTOMOPrice, "lendingTokenDecimal", lendingTokenDecimal, "lendTokenTOMOPrice", lendTokenTOMOPrice)
+	return lendTokenTOMOPrice, collateralPrice, nil
+}
+
+func (l *Lending) GetTOMOBasePrices(header *types.Header, chain tradingstate.ChainContext, statedb *state.StateDB, tradingStateDb *tradingstate.TradingStateDB, token common.Address) (*big.Int, error) {
+
+	tokenTOMOPriceFromContract, updatedBlock := lendingstate.GetCollateralPrice(statedb, token, common.HexToAddress(tradingstate.TomoNativeAddress))
+	tokenTOMOPriceUpdatedFromContract := updatedBlock.Uint64()/chain.Config().Posv.Epoch == header.Number.Uint64()/chain.Config().Posv.Epoch
+
+	if token == common.HexToAddress(tradingstate.TomoNativeAddress) {
+		return tradingstate.BasePrice, nil
+	} else if tokenTOMOPriceUpdatedFromContract {
+		// getting lendToken price from contract first
+		// otherwise, getting from tomox lendToken/TOMO
+		log.Debug("Getting token/TOMO price from contract", "price", tokenTOMOPriceFromContract)
+		return tokenTOMOPriceFromContract, nil
+	} else {
+		tomoTokenPriceFromContract, updatedBlock := lendingstate.GetCollateralPrice(statedb, common.HexToAddress(tradingstate.TomoNativeAddress), token)
+		tomoTokenPriceUpdatedFromContract := updatedBlock.Uint64()/chain.Config().Posv.Epoch == header.Number.Uint64()/chain.Config().Posv.Epoch
+		if tomoTokenPriceUpdatedFromContract && tomoTokenPriceFromContract != nil && tomoTokenPriceFromContract.Sign() > 0 {
+			// getting lendToken price from contract first
+			// otherwise, getting from tomox lendToken/TOMO
+			log.Debug("Getting TOMO/token from contract", "price", tomoTokenPriceFromContract)
+			tokenDecimal, err := l.tomox.GetTokenDecimal(chain, statedb, token)
+			log.Debug("GetTokenDecimal", "token", token.Hex(), "err", err)
+			if err != nil || tokenDecimal == nil || tokenDecimal.Sign() == 0 {
+				return nil, err
+			}
+			tokenTomoPrice := new(big.Int).Mul(tradingstate.BasePrice, tokenDecimal)
+			tokenTomoPrice = new(big.Int).Div(tokenTomoPrice, tomoTokenPriceFromContract)
+			return tokenTomoPrice, nil
+		}
+		tokenTOMOPrice, err := l.GetMediumTradePriceBeforeEpoch(chain, statedb, tradingStateDb, token, common.HexToAddress(tradingstate.TomoNativeAddress))
+		if err != nil {
+			return nil, err
+		}
+		if tokenTOMOPrice != nil && tokenTOMOPrice.Sign() > 0 {
+			log.Debug("Getting token/TOMO from tomox", "price", tokenTOMOPrice, "err", err)
+			return tokenTOMOPrice, nil
+		}
+	}
+	log.Debug("Can't getting tokenTOMOPrice ", "token", token.Hex())
+	return nil, nil
+}
+
+func (l *Lending) AutoTopUp(statedb *state.StateDB, tradingState *tradingstate.TradingStateDB, lendingState *lendingstate.LendingStateDB, lendingBook, lendingTradeId common.Hash, currentPrice *big.Int) (*lendingstate.LendingTrade, error) {
+	lendingTrade := lendingState.GetLendingTrade(lendingBook, lendingTradeId)
+	if lendingTrade == lendingstate.EmptyLendingTrade {
+		return nil, fmt.Errorf("process deposit for emptyLendingTrade is not allowed. lendingTradeId: %v", lendingTradeId.Hex())
+	}
+	if currentPrice.Cmp(lendingTrade.LiquidationPrice) >= 0 {
+		return nil, fmt.Errorf("CurrentPrice is still higher than or equal to LiquidationPrice. current price: %v  , liquidation price : %v  ", currentPrice, lendingTrade.LiquidationPrice)
+	}
+	// newLiquidationPrice = currentPrice * 90%
+	newLiquidationPrice := new(big.Int).Mul(currentPrice, lendingstate.RateTopUp)
+	newLiquidationPrice = new(big.Int).Div(newLiquidationPrice, lendingstate.BaseTopUp)
+	// newLockedAmount = CollateralLockedAmount *  LiquidationPrice / newLiquidationPrice
+	newLockedAmount := new(big.Int).Mul(lendingTrade.CollateralLockedAmount, lendingTrade.LiquidationPrice)
+	newLockedAmount = new(big.Int).Div(newLockedAmount, newLiquidationPrice)
+
+	requiredDepositAmount := new(big.Int).Sub(newLockedAmount, lendingTrade.CollateralLockedAmount)
+	tokenBalance := lendingstate.GetTokenBalance(lendingTrade.Borrower, lendingTrade.CollateralToken, statedb)
+	if tokenBalance.Cmp(requiredDepositAmount) < 0 {
+		return nil, fmt.Errorf("not enough balance to AutoTopUp. requiredDepositAmount: %v . tokenBalance: %v . Token: %s", requiredDepositAmount, tokenBalance, lendingTrade.CollateralToken.Hex())
+	}
+	err, _, newTrade := l.ProcessTopUpLendingTrade(lendingState, statedb, tradingState, lendingTradeId, lendingBook, requiredDepositAmount)
+	return newTrade, err
+}
+
+func (l *Lending) ProcessTopUpLendingTrade(lendingStateDB *lendingstate.LendingStateDB, statedb *state.StateDB, tradingStateDb *tradingstate.TradingStateDB, lendingTradeId common.Hash, lendingBook common.Hash, quantity *big.Int) (error, bool, *lendingstate.LendingTrade) {
+	lendingTrade := lendingStateDB.GetLendingTrade(lendingBook, lendingTradeId)
+	if lendingTrade == lendingstate.EmptyLendingTrade {
+		return fmt.Errorf("process deposit for emptyLendingTrade is not allowed. lendingTradeId: %v", lendingTradeId.Hex()), true, nil
+	}
+	tokenBalance := lendingstate.GetTokenBalance(lendingTrade.Borrower, lendingTrade.CollateralToken, statedb)
+	if tokenBalance.Cmp(quantity) < 0 {
+		log.Debug("not enough balance deposit", "Quantity", quantity, "tokenBalance", tokenBalance)
+		return fmt.Errorf("not enough balance deposit. lendingTradeId: %v , Quantity : %v , tokenBalance : %v", lendingTradeId.Hex(), quantity, tokenBalance), true, nil
+	}
+	err := tradingStateDb.RemoveLiquidationPrice(tradingstate.GetTradingOrderBookHash(lendingTrade.CollateralToken, lendingTrade.LendingToken), lendingTrade.LiquidationPrice, lendingBook, lendingTrade.TradeId)
+	if err != nil {
+		return err, true, nil
+	}
+	lendingstate.SubTokenBalance(lendingTrade.Borrower, quantity, lendingTrade.CollateralToken, statedb)
+	lendingstate.AddTokenBalance(common.HexToAddress(lendingstate.LendingLockAddress), quantity, lendingTrade.CollateralToken, statedb)
+	oldLockedAmount := lendingTrade.CollateralLockedAmount
+	newLockedAmount := new(big.Int).Add(quantity, oldLockedAmount)
+	newLiquidationPrice := new(big.Int).Mul(lendingTrade.LiquidationPrice, oldLockedAmount)
+	newLiquidationPrice = new(big.Int).Div(newLiquidationPrice, newLockedAmount)
+	lendingStateDB.UpdateLiquidationPrice(lendingBook, lendingTrade.TradeId, newLiquidationPrice)
+	lendingStateDB.UpdateCollateralLockedAmount(lendingBook, lendingTrade.TradeId, newLockedAmount)
+	tradingStateDb.InsertLiquidationPrice(tradingstate.GetTradingOrderBookHash(lendingTrade.CollateralToken, lendingTrade.LendingToken), newLiquidationPrice, lendingBook, lendingTrade.TradeId)
+	newLendingTrade := lendingTrade
+	newLendingTrade.LiquidationPrice = newLiquidationPrice
+	newLendingTrade.CollateralLockedAmount = newLockedAmount
+	log.Debug("ProcessTopUp successfully", "price", newLiquidationPrice, "lockAmount", newLockedAmount)
+	return nil, false, &newLendingTrade
+}
+
+func (l *Lending) ProcessRepayLendingTrade(header *types.Header, chain tradingstate.ChainContext, lendingStateDB *lendingstate.LendingStateDB, statedb *state.StateDB, tradingstateDB *tradingstate.TradingStateDB, lendingBook common.Hash, lendingTradeId uint64) (trade *lendingstate.LendingTrade, err error) {
+	lendingTradeIdHash := params.Uint64ToHash(lendingTradeId)
+	lendingTrade := lendingStateDB.GetLendingTrade(lendingBook, lendingTradeIdHash)
+	if lendingTrade == lendingstate.EmptyLendingTrade {
+		return nil, fmt.Errorf("ProcessRepayLendingTrade for emptyLendingTrade is not allowed. lendingTradeId: %v", lendingTradeId)
+	}
+	time := header.Time
+	tokenBalance := lendingstate.GetTokenBalance(lendingTrade.Borrower, lendingTrade.LendingToken, statedb)
+	paymentBalance := lendingstate.CalculateTotalRepayValue(time, lendingTrade.LiquidationTime, lendingTrade.Term, lendingTrade.Interest, lendingTrade.Amount)
+	log.Debug("ProcessRepay", "totalInterest", new(big.Int).Sub(paymentBalance, lendingTrade.Amount), "totalRepayValue", paymentBalance, "token", lendingTrade.LendingToken.Hex())
+
+	if tokenBalance.Cmp(paymentBalance) < 0 {
+		if lendingTrade.LiquidationTime > time {
+			return nil, fmt.Errorf("Not enough balance need : %s , have : %s ", paymentBalance, tokenBalance)
+		}
+		newLendingTrade := &lendingstate.LendingTrade{}
+		var err error
+		if chain.Config().IsTIPTomoXLending(header.Number) {
+			newLendingTrade, err = l.LiquidationExpiredTrade(header, chain, lendingStateDB, statedb, tradingstateDB, lendingBook, lendingTradeId)
+		} else {
+			newLendingTrade, err = l.LiquidationTrade(lendingStateDB, statedb, tradingstateDB, lendingBook, lendingTradeId)
+			liquidationData := lendingstate.LiquidationData{
+				RecallAmount:      common.Big0,
+				LiquidationAmount: lendingTrade.CollateralLockedAmount,
+				CollateralPrice:   common.Big0,
+				Reason:            lendingstate.LiquidatedByTime,
+			}
+			extraData, _ := json.Marshal(liquidationData)
+			if newLendingTrade != nil {
+				newLendingTrade.ExtraData = string(extraData)
+			}
+		}
+		if err != nil {
+			return nil, err
+		}
+		if newLendingTrade != nil {
+			newLendingTrade.Status = lendingstate.TradeStatusLiquidated
+		}
+		return newLendingTrade, err
+	} else {
+		lendingstate.SubTokenBalance(lendingTrade.Borrower, paymentBalance, lendingTrade.LendingToken, statedb)
+		lendingstate.AddTokenBalance(lendingTrade.Investor, paymentBalance, lendingTrade.LendingToken, statedb)
+
+		lendingstate.SubTokenBalance(common.HexToAddress(lendingstate.LendingLockAddress), lendingTrade.CollateralLockedAmount, lendingTrade.CollateralToken, statedb)
+		lendingstate.AddTokenBalance(lendingTrade.Borrower, lendingTrade.CollateralLockedAmount, lendingTrade.CollateralToken, statedb)
+
+		err = lendingStateDB.RemoveLiquidationTime(lendingBook, lendingTradeId, lendingTrade.LiquidationTime)
+		if err != nil {
+			log.Debug("ProcessRepay RemoveLiquidationTime", "err", err, "lendingHash", lendingTrade.Hash, "trade", lendingstate.ToJSON(lendingTrade))
+			return nil, err
+		}
+		err = tradingstateDB.RemoveLiquidationPrice(tradingstate.GetTradingOrderBookHash(lendingTrade.CollateralToken, lendingTrade.LendingToken), lendingTrade.LiquidationPrice, lendingBook, lendingTradeId)
+		if err != nil {
+			log.Debug("ProcessRepay RemoveLiquidationPrice", "err", err)
+			return nil, err
+		}
+		err = lendingStateDB.CancelLendingTrade(lendingBook, lendingTradeId)
+		if err != nil {
+			log.Debug("ProcessRepay CancelLendingTrade", "err", err)
+			return nil, err
+		}
+		lendingTrade.Status = lendingstate.TradeStatusClosed
+		extraData, _ := json.Marshal(struct {
+			Profit *big.Int
+		}{
+			Profit: new(big.Int).Sub(paymentBalance, lendingTrade.Amount),
+		})
+		lendingTrade.ExtraData = string(extraData)
+	}
+	return &lendingTrade, nil
+}
+
+func (l *Lending) ProcessRecallLendingTrade(lendingStateDB *lendingstate.LendingStateDB, statedb *state.StateDB, tradingStateDb *tradingstate.TradingStateDB, lendingBook common.Hash, lendingTradeId common.Hash, newLiquidationPrice *big.Int) (error, bool, *lendingstate.LendingTrade) {
+	log.Debug("ProcessRecallLendingTrade", "lendingTradeId", lendingTradeId.Hex(), "lendingBook", lendingBook.Hex(), "newLiquidationPrice", newLiquidationPrice)
+	lendingTrade := lendingStateDB.GetLendingTrade(lendingBook, lendingTradeId)
+	if lendingTrade == lendingstate.EmptyLendingTrade {
+		return fmt.Errorf("process recall for emptyLendingTrade is not allowed. lendingTradeId: %v", lendingTradeId.Hex()), true, nil
+	}
+	if newLiquidationPrice.Cmp(lendingTrade.LiquidationPrice) <= 0 {
+		return fmt.Errorf("New liquidation price must higher than  old liquidation price. current liquidation price: %v  , new liquidation price : %v  ", lendingTrade.LiquidationPrice, newLiquidationPrice), true, nil
+	}
+	newLockedAmount := new(big.Int).Mul(lendingTrade.CollateralLockedAmount, lendingTrade.LiquidationPrice)
+	newLockedAmount = new(big.Int).Div(newLockedAmount, newLiquidationPrice)
+	recallAmount := new(big.Int).Sub(lendingTrade.CollateralLockedAmount, newLockedAmount)
+	log.Debug("ProcessRecallLendingTrade", "newLockedAmount", newLockedAmount, "recallAmount", recallAmount, "oldLiquidationPrice", lendingTrade.LiquidationPrice, "newLiquidationPrice", newLiquidationPrice)
+	err := tradingStateDb.RemoveLiquidationPrice(tradingstate.GetTradingOrderBookHash(lendingTrade.CollateralToken, lendingTrade.LendingToken), lendingTrade.LiquidationPrice, lendingBook, lendingTrade.TradeId)
+	if err != nil {
+		return err, true, nil
+	}
+	lendingstate.AddTokenBalance(lendingTrade.Borrower, recallAmount, lendingTrade.CollateralToken, statedb)
+	lendingstate.SubTokenBalance(common.HexToAddress(lendingstate.LendingLockAddress), recallAmount, lendingTrade.CollateralToken, statedb)
+
+	lendingStateDB.UpdateLiquidationPrice(lendingBook, lendingTrade.TradeId, newLiquidationPrice)
+	lendingStateDB.UpdateCollateralLockedAmount(lendingBook, lendingTrade.TradeId, newLockedAmount)
+	tradingStateDb.InsertLiquidationPrice(tradingstate.GetTradingOrderBookHash(lendingTrade.CollateralToken, lendingTrade.LendingToken), newLiquidationPrice, lendingBook, lendingTrade.TradeId)
+	newLendingTrade := lendingTrade
+	newLendingTrade.LiquidationPrice = newLiquidationPrice
+	newLendingTrade.CollateralLockedAmount = newLockedAmount
+	log.Debug("ProcessRecall", "price", newLiquidationPrice, "lockAmount", newLockedAmount, "recall amount", recallAmount)
+	return nil, false, &newLendingTrade
+}

--- a/legacy/tomoxlending/tomoxlending.go
+++ b/legacy/tomoxlending/tomoxlending.go
@@ -1,0 +1,242 @@
+package tomoxlending
+
+import (
+	"encoding/json"
+	"errors"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/prque"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/legacy/tomox"
+	"github.com/ethereum/go-ethereum/legacy/tomox/tradingstate"
+	"github.com/ethereum/go-ethereum/legacy/tomoxlending/lendingstate"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+const (
+	ProtocolName       = "tomoxlending"
+	ProtocolVersion    = uint64(1)
+	ProtocolVersionStr = "1.0"
+)
+
+var (
+	ErrNonceTooHigh = errors.New("nonce too high")
+	ErrNonceTooLow  = errors.New("nonce too low")
+)
+
+type Lending struct {
+	db                ethdb.Database
+	lendingStateCache lendingstate.Database
+	trieCacheLimit    int
+	triegc            *prque.Prque
+	tomox             *tomox.TomoX
+
+	// config is needed to derive the correct transaction signer (EIP155 vs Homestead)
+	// when extracting the lending state root from the 0x92 system transaction.
+	config *params.ChainConfig
+}
+
+// New creates a Lending engine.
+// db is the ethdb passed directly - legacy/tomox.TomoX does not expose its DB.
+// tomox is required for token decimal lookups and price conversions.
+// config is the chain configuration, required for correct EIP155 signer derivation.
+func New(db ethdb.Database, tomox *tomox.TomoX, config *params.ChainConfig) *Lending {
+	return &Lending{
+		db:                db,
+		lendingStateCache: lendingstate.NewDatabase(db),
+		trieCacheLimit:    100,
+		triegc:            prque.New(nil),
+		tomox:             tomox,
+		config:            config,
+	}
+}
+
+// Version returns the Lending sub-protocols version number.
+func (l *Lending) Version() uint64 {
+	return ProtocolVersion
+}
+
+func (l *Lending) GetLendingState(block *types.Block, author common.Address) (*lendingstate.LendingStateDB, error) {
+	root, err := l.GetLendingStateRoot(block, author)
+	if err != nil {
+		return nil, err
+	}
+	if l.lendingStateCache == nil {
+		return nil, errors.New("Not initialized tomox")
+	}
+	state, err := lendingstate.New(root, l.lendingStateCache)
+	if err != nil {
+		log.Info("Not found lending state when GetLendingState", "block", block.Number(), "lendingRoot", root.Hex())
+	}
+	return state, err
+}
+
+func (l *Lending) GetLendingStateRoot(block *types.Block, author common.Address) (common.Hash, error) {
+	// The 0x92 system tx is signed by the block coinbase using EIP155 (ChainId is set on mainnet
+	// since block 3). Using HomesteadSigner would fail to recover the sender for any post-EIP155 tx.
+	signer := types.MakeSigner(l.config, block.Number())
+	for _, tx := range block.Transactions() {
+		if tx.To() == nil || tx.To().Hex() != tradingstate.TradingStateAddr {
+			continue
+		}
+		from, err := types.Sender(signer, tx)
+		if err != nil || from != author {
+			continue
+		}
+		if len(tx.Data()) >= 64 {
+			return common.BytesToHash(tx.Data()[32:]), nil
+		}
+	}
+	return lendingstate.EmptyRoot, nil
+}
+
+func (l *Lending) HasLendingState(block *types.Block, author common.Address) bool {
+	root, err := l.GetLendingStateRoot(block, author)
+	if err != nil {
+		return false
+	}
+	_, err = l.lendingStateCache.OpenTrie(root)
+	if err != nil {
+		return false
+	}
+	return true
+}
+
+func (l *Lending) GetStateCache() lendingstate.Database {
+	return l.lendingStateCache
+}
+
+func (l *Lending) GetTriegc() *prque.Prque {
+	return l.triegc
+}
+
+func (l *Lending) ProcessLiquidationData(header *types.Header, chain tradingstate.ChainContext, statedb *state.StateDB, tradingState *tradingstate.TradingStateDB, lendingState *lendingstate.LendingStateDB) (updatedTrades map[common.Hash]*lendingstate.LendingTrade, liquidatedTrades, autoRepayTrades, autoTopUpTrades, autoRecallTrades []*lendingstate.LendingTrade, err error) {
+	blockTime := new(big.Int).SetUint64(header.Time)
+	updatedTrades = map[common.Hash]*lendingstate.LendingTrade{} // sum of liquidatedTrades, autoRepayTrades, autoTopUpTrades, autoRecallTrades
+	liquidatedTrades = []*lendingstate.LendingTrade{}
+	autoRepayTrades = []*lendingstate.LendingTrade{}
+	autoTopUpTrades = []*lendingstate.LendingTrade{}
+	autoRecallTrades = []*lendingstate.LendingTrade{}
+
+	allPairs, err := lendingstate.GetAllLendingPairs(statedb)
+	if err != nil {
+		log.Debug("Not found all trading pairs", "error", err)
+		return updatedTrades, liquidatedTrades, autoRepayTrades, autoTopUpTrades, autoRecallTrades, nil
+	}
+	allLendingBooks, err := lendingstate.GetAllLendingBooks(statedb)
+	if err != nil {
+		log.Debug("Not found all lending books", "error", err)
+		return updatedTrades, liquidatedTrades, autoRepayTrades, autoTopUpTrades, autoRecallTrades, nil
+	}
+
+	// liquidate trades by time
+	for lendingBook := range allLendingBooks {
+		lowestTime, tradingIds := lendingState.GetLowestLiquidationTime(lendingBook, blockTime)
+		log.Debug("ProcessLiquidationData time", "tradeIds", len(tradingIds))
+		for lowestTime.Sign() > 0 && lowestTime.Cmp(blockTime) < 0 {
+			for _, tradingId := range tradingIds {
+				log.Debug("ProcessRepay", "lowestTime", lowestTime, "time", blockTime, "lendingBook", lendingBook.Hex(), "tradingId", tradingId.Hex())
+				trade, err := l.ProcessRepayLendingTrade(header, chain, lendingState, statedb, tradingState, lendingBook, tradingId.Big().Uint64())
+				if err != nil {
+					log.Error("Fail when process payment ", "time", blockTime, "lendingBook", lendingBook.Hex(), "tradingId", tradingId, "error", err)
+					return updatedTrades, liquidatedTrades, autoRepayTrades, autoTopUpTrades, autoRecallTrades, err
+				}
+				if trade != nil && trade.Hash != (common.Hash{}) {
+					updatedTrades[trade.Hash] = trade
+					switch trade.Status {
+					case lendingstate.TradeStatusLiquidated:
+						liquidatedTrades = append(liquidatedTrades, trade)
+					case lendingstate.TradeStatusClosed:
+						autoRepayTrades = append(autoRepayTrades, trade)
+					}
+				}
+			}
+			lowestTime, tradingIds = lendingState.GetLowestLiquidationTime(lendingBook, blockTime)
+		}
+	}
+
+	for _, lendingPair := range allPairs {
+		orderbook := tradingstate.GetTradingOrderBookHash(lendingPair.CollateralToken, lendingPair.LendingToken)
+		_, collateralPrice, err := l.GetCollateralPrices(header, chain, statedb, tradingState, lendingPair.CollateralToken, lendingPair.LendingToken)
+		if err != nil || collateralPrice == nil || collateralPrice.Sign() == 0 {
+			log.Error("Fail when get price collateral/lending ", "CollateralToken", lendingPair.CollateralToken.Hex(), "LendingToken", lendingPair.LendingToken.Hex(), "error", err)
+			// ignore this pair, do not throw error
+			continue
+		}
+		// liquidate trades
+		highestLiquidatePrice, liquidationData := tradingState.GetHighestLiquidationPriceData(orderbook, collateralPrice)
+		for highestLiquidatePrice.Sign() > 0 && collateralPrice.Cmp(highestLiquidatePrice) < 0 {
+			for lendingBook, tradingIds := range liquidationData {
+				for _, tradingIdHash := range tradingIds {
+					trade := lendingState.GetLendingTrade(lendingBook, tradingIdHash)
+					if trade.AutoTopUp {
+						if newTrade, err := l.AutoTopUp(statedb, tradingState, lendingState, lendingBook, tradingIdHash, collateralPrice); err == nil {
+							// if this action complete successfully, do not liquidate this trade in this epoch
+							log.Debug("AutoTopUp", "borrower", trade.Borrower.Hex(), "collateral", newTrade.CollateralToken.Hex(), "tradingIdHash", tradingIdHash.Hex(), "newLockedAmount", newTrade.CollateralLockedAmount)
+							autoTopUpTrades = append(autoTopUpTrades, newTrade)
+							updatedTrades[newTrade.Hash] = newTrade
+							continue
+						}
+					}
+					log.Debug("LiquidationTrade", "highestLiquidatePrice", highestLiquidatePrice, "lendingBook", lendingBook.Hex(), "tradingIdHash", tradingIdHash.Hex())
+					newTrade, err := l.LiquidationTrade(lendingState, statedb, tradingState, lendingBook, tradingIdHash.Big().Uint64())
+					if err != nil {
+						log.Error("Fail when remove liquidation newTrade", "time", blockTime, "lendingBook", lendingBook.Hex(), "tradingIdHash", tradingIdHash.Hex(), "error", err)
+						return updatedTrades, liquidatedTrades, autoRepayTrades, autoTopUpTrades, autoRecallTrades, err
+					}
+					if newTrade != nil && newTrade.Hash != (common.Hash{}) {
+						newTrade.Status = lendingstate.TradeStatusLiquidated
+						liquidationData := lendingstate.LiquidationData{
+							RecallAmount:      common.Big0,
+							LiquidationAmount: newTrade.CollateralLockedAmount,
+							CollateralPrice:   collateralPrice,
+							Reason:            lendingstate.LiquidatedByPrice,
+						}
+						extraData, _ := json.Marshal(liquidationData)
+						newTrade.ExtraData = string(extraData)
+						liquidatedTrades = append(liquidatedTrades, newTrade)
+						updatedTrades[newTrade.Hash] = newTrade
+					}
+				}
+			}
+			highestLiquidatePrice, liquidationData = tradingState.GetHighestLiquidationPriceData(orderbook, collateralPrice)
+		}
+		// recall trades
+		depositRate, liquidationRate, recallRate := lendingstate.GetCollateralDetail(statedb, lendingPair.CollateralToken)
+		recalLiquidatePrice := new(big.Int).Mul(collateralPrice, lendingstate.BaseRecall)
+		recalLiquidatePrice = new(big.Int).Div(recalLiquidatePrice, recallRate)
+		newLiquidatePrice := new(big.Int).Mul(collateralPrice, liquidationRate)
+		newLiquidatePrice = new(big.Int).Div(newLiquidatePrice, depositRate)
+		allLowertLiquidationData := tradingState.GetAllLowerLiquidationPriceData(orderbook, recalLiquidatePrice)
+		log.Debug("ProcessLiquidationData", "orderbook", orderbook.Hex(), "collateralPrice", collateralPrice, "recallRate", recallRate, "recalLiquidatePrice", recalLiquidatePrice, "newLiquidatePrice", newLiquidatePrice, "allLowertLiquidationData", len(allLowertLiquidationData))
+		for price, liquidationData := range allLowertLiquidationData {
+			if price.Sign() > 0 && recalLiquidatePrice.Cmp(price) > 0 {
+				for lendingBook, tradingIds := range liquidationData {
+					for _, tradingIdHash := range tradingIds {
+						log.Debug("Process Recall", "price", price, "lendingBook", lendingBook, "tradingIdHash", tradingIdHash.Hex())
+						trade := lendingState.GetLendingTrade(lendingBook, tradingIdHash)
+						log.Debug("TestRecall", "borrower", trade.Borrower.Hex(), "lendingToken", trade.LendingToken.Hex(), "collateral", trade.CollateralToken.Hex(), "price", price, "tradingIdHash", tradingIdHash.Hex())
+						if trade.AutoTopUp {
+							err, _, newTrade := l.ProcessRecallLendingTrade(lendingState, statedb, tradingState, lendingBook, tradingIdHash, newLiquidatePrice)
+							if err != nil {
+								log.Error("ProcessRecallLendingTrade", "lendingBook", lendingBook.Hex(), "tradingIdHash", tradingIdHash.Hex(), "newLiquidatePrice", newLiquidatePrice, "err", err)
+								return updatedTrades, liquidatedTrades, autoRepayTrades, autoTopUpTrades, autoRecallTrades, err
+							}
+							// if this action complete successfully, do not liquidate this trade in this epoch
+							log.Debug("AutoRecall", "borrower", trade.Borrower.Hex(), "collateral", newTrade.CollateralToken.Hex(), "lendingBook", lendingBook.Hex(), "tradingIdHash", tradingIdHash.Hex(), "newLockedAmount", newTrade.CollateralLockedAmount)
+							autoRecallTrades = append(autoRecallTrades, newTrade)
+							updatedTrades[newTrade.Hash] = newTrade
+						}
+					}
+				}
+			}
+		}
+	}
+
+	log.Debug("ProcessLiquidationData", "updatedTrades", len(updatedTrades), "liquidated", len(liquidatedTrades), "autoRepay", len(autoRepayTrades), "autoTopUp", len(autoTopUpTrades), "autoRecall", len(autoRecallTrades))
+	return updatedTrades, liquidatedTrades, autoRepayTrades, autoTopUpTrades, autoRecallTrades, nil
+}

--- a/params/viction_specs/viction.json
+++ b/params/viction_specs/viction.json
@@ -45,6 +45,7 @@
       "validatorMinBlockPerEpochCount": 1,
       "validatorSignInterval": 15,
       "vrc25Contract": "0x8c0faeb5C6bEd2129b8674F262Fd45c4e9468bee",
-      "vrc25GasPrice": "250000000"
+      "vrc25GasPrice": "250000000",
+      "lendingLiquidateTradeBlock": 100
     }
   }


### PR DESCRIPTION
# Port TomoZ Lending (TIPTomoXLending) for Historical Sync

## Summary

This PR ports the TomoZ lending engine (`TIPTomoXLending`, activation block 21,430,200) into
`vic-geth` so that the node can replay all historical blocks from the lending fork activation up
to the Atlas hardfork without state root mismatches. The scope is **sync-path only** — block
production is out of scope. TomoZ is fully gated off at Atlas.

---

## Changes by file

### New files (all additive, no upstream modification)

| File | Purpose |
|---|---|
| `core/lending_engine.go` | `LendingEngine` interface definition, isolated here to avoid import cycles between `core` and `legacy/tomoxlending` |
| `legacy/tomoxlending/tomoxlending.go` | Concrete `Lending` engine: wraps `LendingStateDB`, holds `*tomox.TomoX` reference for price lookups, implements the `LendingEngine` interface |
| `legacy/tomoxlending/order_processor.go` | Order matching logic: `CommitOrder`, `ProcessLiquidationData`, auto-repay/top-up/recall, balance settlement |
| `legacy/tomoxlending/lendingstate/` | Full lending state trie (17 files, ~3,800 lines): `LendingStateDB`, journal, item/trade/book state objects, relayer info, liquidation time index |

### `core/state_processor_viction.go` — hook changes

- Added `lendingStateDB *lendingstate.LendingStateDB` field to `victionProcessorState`
- `beforeProcess`: opens `LendingStateDB` from parent block when `IsTIPTomoXLending && !IsAtlas && tradingStateDB != nil`
- `applyVictionTransaction`: routes `0x93` (lending batch) to `applyLendingTx` and `0x94` (finalized trade) to `applyEmptyTransaction`, both gated on `!IsAtlas`
- Added `applyLendingTx`: decodes `TxLendingBatch`, iterates orders, calls `lendingEngine.CommitOrder` per order
- `afterProcess`: added lending state root verification — extracts expected root from the `0x92` tx payload bytes `[32:64]`, compares with `lendingStateDB.IntermediateRoot()`
- Added `GetLendingStateRoot` extractor (mirrors `GetTradingStateRoot`, reads bytes `[32:64]` of the `0x92` tx)
- Added `SetLendingEngine` setter on `StateProcessor`
- Null-guards added to `TIPSigningBlock` and hardfork branches so they are safe when `Viction` config is nil

### `core/blockchain_viction.go` — wiring changes

- Added `SetLendingEngine` method on `BlockChain` (mirrors existing `SetTradingEngine`)
- Added `beforeProcessViction`: epoch-gated hook that calls `ProcessLiquidationData` before the tx loop; active only when `IsTIPTomoXLending && !IsAtlas && block % Epoch == LendingLiquidateTradeBlock`
- Fixed typo `contracrAddress` → `contractAddress` in `UpdateM1`

### `core/blockchain.go` — upstream file (minimal touch)

```diff
+   if err := bc.beforeProcessViction(block, statedb); err != nil {
+       bc.reportBlock(block, nil, err)
+       ...
+       return it.index, err
+   }
    receipts, logs, usedGas, err := bc.processor.Process(block, statedb, bc.vmConfig)
```

The liquidation hook must fire **before** `Process` so that collateral state mutations are
visible to transactions in the same block. This is the only change to an upstream file.

### `core/state_processor.go` — upstream file (minimal touch)

- Added `lendingEngine LendingEngine` field to `StateProcessor` struct
- Improved error wrapping in `Process`: `applyVictionTransaction` and `applyTransaction` errors
  now include tx index and hash via `fmt.Errorf("could not apply tx %d [%v]: %w", ...)`

### `eth/backend_viction.go` — wiring

- Removed the now-dead `PosvSetTomoxTradingEngine` method
- `setupPosvBackend`: opens a `tomoxlending` LevelDB, constructs `tomoxlending.New(lendingDb, tomoxEngine, config)`, and calls `blockchain.SetLendingEngine`. The lending engine shares the same `tomoxEngine` instance so price lookups use the same trading state
- `tomox.NewWithDB` signature updated to accept `*params.ChainConfig` (needed for correct EIP155 signer when extracting state roots)

### `legacy/tomox/tomox.go` — config propagation

- `NewWithDB` now accepts `*params.ChainConfig`
- `GetTradingStateRoot` replaced hardcoded `HomesteadSigner{}` with `types.MakeSigner(config, block.Number())` — required for correct sender recovery on EIP155 blocks

### `params/viction_specs/viction.json` — config

- Added `lendingLiquidateTradeBlock: 100` (the within-epoch offset at which liquidation runs)

---

## `legacy/tomoxlending/lendingstate/` — file-by-file breakdown

| File | Lines | Role |
|---|---|---|
| `common.go` | ~180 | Package-level constants (`EmptyRoot`, `LendingLockAddress`), shared types (`LiquidationData`), fee variables (`RelayerLendingFee`, `RelayerLendingCancelFee`), interest/rate constants |
| `lendingitem.go` | ~130 | `LendingItem` struct with all order fields (Quantity, Interest, Side, Type, LendingToken, CollateralToken, AutoTopUp, Term, etc.); order type/status constants (Investing/Borrowing/TopUp/Repay/Recall/Market/Limit); `VerifyLendingItem` validation |
| `statedb.go` | ~500 | `LendingStateDB`: trie-backed state with journal, snapshot, and revert — mirrors `tradingstate.TradingStateDB`; `OpenLendingStateDB`, `Commit`, `IntermediateRoot` |
| `state_lendingbook.go` | ~350 | Per-book state: investing tree, borrowing tree, liquidation time index, lending item list, trade list; dirty tracking and trie encoding |
| `state_itemList.go` | ~200 | `itemListState` — order list state objects backing each side of a book |
| `state_lendingitem.go` | ~150 | Individual lending item (order) state object: encode/decode, dirty flag |
| `state_lendingtrade.go` | ~150 | Individual lending trade state object: encode/decode, dirty flag |
| `state_liquidationtime.go` | ~214 | Liquidation time index: maps epoch timestamp → set of trade IDs due for liquidation |
| `database.go` | ~60 | `Database` interface (trie cache, open/commit trie); used by `LendingStateDB` |
| `tomox_trie.go` | ~80 | Thin trie wrapper implementing the internal `Trie` interface over `trie.Trie` |
| `journal.go` | ~120 | Undo journal for snapshot/revert; one entry type per mutable object (book, item, trade, time index) |
| `managed_state.go` | ~60 | Per-address nonce management layered on top of `LendingStateDB` |
| `relayer.go` | ~70 | Reads relayer fee and info from the main `statedb.StateDB` via the relayer contract storage layout |
| `settle_balance.go` | ~120 | `GetSettleBalance`/`LendingSettleBalance`: computes token transfers for matched trades; `DefaultFeeRate = 100`; errors `ErrQuantityTradeTooSmall`, `ErrInvalidCollateralPrice` |
| `lendingcontract.go` | ~50 | Contract address constants and storage slot helpers for the lending registrar |
| `trade.go` | ~59 | `LendingTrade` struct: tracks live matched trades (collateral amount, liquidation price, term, interest, etc.) |
| `dump.go` | ~40 | Debug `Dump` helpers for inspecting trie state in tests and logging |

---

## `legacy/tomoxlending/order_processor.go` — function index

| Function | Signature | Purpose |
|---|---|---|
| `CommitOrder` | `(header, coinbase, chain, statedb, tradingStateDB, lendingStateDB, lendingItem) → (trades, rejects, err)` | Snapshot + revert wrapper around `ApplyOrder`; rolls back on error |
| `ApplyOrder` | same args | Nonce check; dispatches to TopUp / Repay / Cancel / Market / Limit handler |
| `processMarketOrder` | `(..., lendingItem) → (trades, rejects, err)` | Executes market order against best available counterparty |
| `processLimitOrder` | `(..., lendingItem) → (trades, rejects, err)` | Executes limit order; inserts remainder into book |
| `processOrderList` | `(..., side, orderList) → (trades, rejects, err)` | Inner matching loop: iterates counterparty order list, calls `DoSettleBalance` per match |
| `getLendQuantity` | `(...) → (investQuantity, borrowQuantity, err)` | Collateral math for a single match (unexported) |
| `GetLendQuantity` | same (exported) | Public wrapper used in tests |
| `DoSettleBalance` | `(statedb, lendingStateDB, lendingItem, trade) → err` | Token transfer settlement: moves collateral and principal between accounts |
| `ProcessCancelOrder` | `(..., lendingItem) → (rejects, err)` | Validates and removes an existing order from the book |
| `ProcessTopUp` | `(..., lendingItem) → (rejects, err)` | Increases collateral on an existing trade |
| `ProcessRepay` | `(..., lendingItem) → (rejects, err)` | Closes a trade early by repaying principal + interest |
| `LiquidationExpiredTrade` | `(..., trade) → err` | Liquidates a trade whose term has expired |
| `LiquidationTrade` | `(..., trade) → err` | Liquidates a trade whose collateral has fallen below threshold |
| `getCancelFeeV1` | `(...) → fee` | Legacy cancel fee formula (pre-TIPTomoXLending) |
| `getCancelFee` | `(...) → fee` | Current cancel fee formula |
| `GetMediumTradePriceBeforeEpoch` | `(chain, config, header, baseToken, quoteToken) → (price, err)` | Looks up the medium trade price in `TradingStateDB` for collateral valuation |
| `GetCollateralPrices` | `(chain, config, header, collateralToken, lendingToken) → (price, liquidationPrice, err)` | Returns current and liquidation price for a collateral/lending token pair |
| `GetTOMOBasePrices` | `(chain, config, header, baseToken) → (price, err)` | Returns VIC-denominated price for any token via trading state |
| `AutoTopUp` | `(statedb, tradingStateDB, lendingStateDB, chain, config, header, epoch) → err` | Scans due-for-liquidation trades and auto-tops-up if the borrower has enabled it |
| `ProcessTopUpLendingTrade` | `(..., trade) → err` | Executes a single auto-top-up on a trade |
| `ProcessRepayLendingTrade` | `(..., trade) → err` | Executes auto-repay on a trade |
| `ProcessRecallLendingTrade` | `(..., trade) → err` | Executes auto-recall (investor recalls principal) |
| `ProcessLiquidationData` | `(statedb, tradingStateDB, lendingStateDB, chain, config, header, epoch) → (5 slices, err)` | Epoch liquidation entry point called from `beforeProcessViction`; iterates the liquidation time index, liquidates or auto-manages each trade |

---

## Architecture notes

### Why two separate tries

TomoX and TomoZ each maintain their own Merkle trie parallel to the main state trie:

- `TradingStateDB` — order books for the DEX
- `LendingStateDB` — lending books, active trades, liquidation time index

Both roots are committed in the single `0x92` system transaction per block:
`data[0:32]` = trading root, `data[32:64]` = lending root.
`afterProcess` verifies both roots after the tx loop completes.

### Atlas gating

Every lending/TomoX code path is guarded by `!IsAtlas(header.Number)`. Atlas disabled both
engines on mainnet. Any block at or after Atlas simply skips all lending hooks and state opens.

### Liquidation epoch hook

`beforeProcessViction` fires once per epoch at the configured `LendingLiquidateTradeBlock`
offset. It opens the **parent** block's trading and lending states (not the current block's),
runs `ProcessLiquidationData`, and discards the five return slices — only the state mutations
matter for sync correctness.

### Sync vs production

`CommitOrder` returns `(trades, rejects, err)`. During sync:
- `trades` is discarded (`_`) — trade records are output data needed only for block production
- `rejects` is logged at `Debug` level for observability
- `err` causes hard block rejection

---