### PR TITLE
fix: pad StorageLocationOfStructElement to 32 bytes to prevent wrong storage slot

### DIFF
--- a/core/state/storage_location.go
+++ b/core/state/storage_location.go
@@ -30,7 +30,8 @@ func StorageLocationOfMappingElement(mappingSlot StorageLocation, elementKey []b
 }
 
 func StorageLocationOfStructElement(structSlot StorageLocation, fieldIndex *big.Int) StorageLocation {
-	return StorageLocation(new(big.Int).Add(structSlot.Big(), fieldIndex).Bytes())
+	sum := new(big.Int).Add(structSlot.Big(), fieldIndex)
+	return StorageLocation(common.BigToHash(sum).Bytes())
 }
 
 func StorageLocationOfDynamicArrayElement(arraySlot StorageLocation, elementIndex uint64, elementSize uint64) StorageLocation {


### PR DESCRIPTION
## Summary

- **Fix incorrect reward calculation at checkpoint block 8505900+** caused by `StorageLocationOfStructElement` returning a `StorageLocation` shorter than 32 bytes when the underlying keccak256 hash had leading zero bytes.

## Root Cause

`StorageLocationOfStructElement` used `big.Int.Bytes()` which strips leading zero bytes. When this shorter-than-32-byte `StorageLocation` was passed as the `mappingSlot` to `StorageLocationOfMappingElement`, the `keccak256(elementKey, mappingSlot)` received 63 bytes of input instead of 64, producing a completely different hash.

This caused `VicGetValidatorVoterCap` to read from the wrong storage slot — returning 0 instead of the actual voter cap — for any validator whose `keccak256(validatorAddr.Hash(), slot(1))` happened to have a leading `0x00` byte (~1/256 probability).

## Fix

Use `common.BigToHash()` to left-pad the result to exactly 32 bytes, matching the original codebase behavior which always used `common.BigToHash()` when converting `big.Int` values to Solidity storage slot inputs.

```go
// Before (buggy):
return StorageLocation(new(big.Int).Add(structSlot.Big(), fieldIndex).Bytes())

// After (fixed):
sum := new(big.Int).Add(structSlot.Big(), fieldIndex)
return StorageLocation(common.BigToHash(sum).Bytes())
```

## Impact

Only `VicGetValidatorVoterCap` was affected — other storage reads (`VicGetValidatorInfo`, `VicGetValidatorVoters`) use `.Hash()` which pads to 32 bytes before calling `GetState`, so they were not impacted.