### PR TITLE
fix: ignore signerCheck at checkpoint block 14458500 due to incorrect snapshot at gap 14458495

### DIFF
--- a/consensus/posv/verifier.go
+++ b/consensus/posv/verifier.go
@@ -168,6 +168,11 @@ func (c *Posv) verifyValidators(chain consensus.ChainReader, header *types.Heade
 	number := header.Number.Uint64()
 	log.Debug("Verifying checkpoint validators", "number", number, "hash", header.Hash().Hex())
 
+	// ignore signerCheck at checkpoint block 14458500 due to wrong snapshot at gap 14458495
+	if number == chain.Config().TIPFixSignerCheckBlock.Uint64() {
+		return nil
+	}
+
 	// Load snapshot at the gap block (checkpoint - Gap), where UpdateMasternodes
 	// stored the updated snapshot. Resolve the gap block hash from DB first,
 	// then fall back to the in-batch parents slice.


### PR DESCRIPTION
## Summary

- **Temporarily disable signer validation at checkpoint block 14458500** to bypass a consensus failure caused by an incorrect snapshot at block gap `14458495`.

## Root Cause

At checkpoint block `14458500`, the consensus verification (`verifySeal`) fails due to an invalid validator snapshot generated earlier at block `14458495`.

The corrupted snapshot leads to incorrect signer validation, causing the node to reject an otherwise valid checkpoint block.

## Fix

Introduce a conditional bypass in `verifySeal` to skip the `signerCheck` logic specifically at the affected checkpoint block:

```go
// ignore signerCheck at checkpoint block 14458500 due to wrong snapshot at gap 14458495
if number == chain.Config().TIPFixSignerCheckBlock.Uint64() {
    return nil
}