### PR TITLE
Fix VRC25 process 

### DIFF
--- a/core/state_processor_viction.go
+++ b/core/state_processor_viction.go
@@ -52,9 +52,9 @@ type victionProcessorState struct {
 	tradingStateDB *tradingstate.TradingStateDB
 
 	// Pre-Atlas VRC25 fee tracking.
-	FeeBalance map[common.Address]*big.Int // running snapshot: token -> remaining cap
-	FeeUpdated map[common.Address]*big.Int // tokens that had fees charged: token -> final cap
-	TotalFee   *big.Int                    // sum of all fees charged across the block
+	feeBalance map[common.Address]*big.Int // running snapshot: token -> remaining cap
+	feeUpdated map[common.Address]*big.Int // tokens that had fees charged: token -> final cap
+	totalFee   *big.Int                    // sum of all fees charged across the block
 }
 
 func (p *StateProcessor) beforeProcess(block *types.Block, statedb *state.StateDB) error {
@@ -63,8 +63,8 @@ func (p *StateProcessor) beforeProcess(block *types.Block, statedb *state.StateD
 	// Initialize victionState for this block.
 	p.victionState = &victionProcessorState{
 		currentBlockNumber: new(big.Int).Set(header.Number),
-		FeeUpdated:         map[common.Address]*big.Int{},
-		TotalFee:           new(big.Int),
+		feeUpdated:         map[common.Address]*big.Int{},
+		totalFee:           new(big.Int),
 	}
 
 	if p.config.TIPSigningBlock != nil && p.config.TIPSigningBlock.Cmp(header.Number) == 0 {
@@ -81,7 +81,7 @@ func (p *StateProcessor) beforeProcess(block *types.Block, statedb *state.StateD
 	// eligibility checks use the running map rather than live state reads.
 	if !p.config.IsAtlas(header.Number) &&
 		p.config.Viction != nil && p.config.Viction.VRC25Contract != (common.Address{}) {
-		p.victionState.FeeBalance = vrc25.GetAllFeeCapacities(statedb, p.config.Viction.VRC25Contract)
+		p.victionState.feeBalance = vrc25.GetAllFeeCapacities(statedb, p.config.Viction.VRC25Contract)
 	}
 
 	// --- TomoX TradingStateDB initialization ---
@@ -123,8 +123,8 @@ func (p *StateProcessor) afterProcess(block *types.Block, statedb *state.StateDB
 	// Pre-Atlas: flush accumulated VRC25 fee updates to state.
 	if p.victionState != nil && !p.config.IsAtlas(block.Number()) &&
 		p.config.Viction != nil && p.config.Viction.VRC25Contract != (common.Address{}) &&
-		len(p.victionState.FeeUpdated) > 0 {
-		vrc25.UpdateFeeCapacity(statedb, p.config.Viction.VRC25Contract, p.victionState.FeeUpdated, p.victionState.TotalFee)
+		len(p.victionState.feeUpdated) > 0 {
+		vrc25.UpdateFeeCapacity(statedb, p.config.Viction.VRC25Contract, p.victionState.feeUpdated, p.victionState.totalFee)
 	}
 
 	// --- TomoX trading root verification ---
@@ -289,8 +289,8 @@ func (p *StateProcessor) afterApplyTransaction(tx *types.Transaction, msg types.
 	vicCfg := p.config.Viction
 
 	// Pre-Atlas VRC25 fee accumulation.
-	if p.victionState.FeeBalance != nil {
-		runningCap, ok := p.victionState.FeeBalance[token]
+	if p.victionState.feeBalance != nil {
+		runningCap, ok := p.victionState.feeBalance[token]
 		if ok && runningCap != nil {
 			fee := new(big.Int).SetUint64(usedGas)
 			if p.config.TIPTRC21FeeBlock != nil && blockNum.Cmp(p.config.TIPTRC21FeeBlock) > 0 && vicCfg != nil && vicCfg.VRC25GasPrice != nil {
@@ -300,9 +300,9 @@ func (p *StateProcessor) afterApplyTransaction(tx *types.Transaction, msg types.
 			if runningCap.Cmp(fee) > 0 {
 				// Deduct from the running balance; record in updated map.
 				newCap := new(big.Int).Sub(runningCap, fee)
-				p.victionState.FeeBalance[token] = newCap
-				p.victionState.FeeUpdated[token] = newCap
-				p.victionState.TotalFee.Add(p.victionState.TotalFee, fee)
+				p.victionState.feeBalance[token] = newCap
+				p.victionState.feeUpdated[token] = newCap
+				p.victionState.totalFee.Add(p.victionState.totalFee, fee)
 
 				// Failed-tx minimum token fee
 				if receipt.Status == types.ReceiptStatusFailed {

--- a/core/state_processor_viction.go
+++ b/core/state_processor_viction.go
@@ -308,8 +308,8 @@ func (p *StateProcessor) afterApplyTransaction(tx *types.Transaction, msg types.
 			// Compute fee in the same units victionchain uses: raw gasUsed pre-TIPTRC21Fee,
 			// gasUsed × TRC21GasPrice post-TIPTRC21Fee (state_processor.go:139-142).
 			fee := new(big.Int).SetUint64(usedGas)
-			if p.config.IsTIPTRC21Fee(blockNum) && vicCfg != nil && vicCfg.TRC21GasPrice != nil {
-				fee = new(big.Int).Mul(fee, (*big.Int)(vicCfg.TRC21GasPrice))
+			if p.config.IsTIPTRC21Fee(blockNum) && vicCfg != nil && vicCfg.VRC25GasPrice != nil {
+				fee = new(big.Int).Mul(fee, (*big.Int)(vicCfg.VRC25GasPrice))
 			}
 			// tokenFeeUsed: running cap must be strictly greater than fee.
 			if runningCap.Cmp(fee) > 0 {

--- a/core/state_processor_viction.go
+++ b/core/state_processor_viction.go
@@ -51,15 +51,10 @@ type victionProcessorState struct {
 	// Only non-nil for pre-Atlas blocks where TomoX was active.
 	tradingStateDB *tradingstate.TradingStateDB
 
-	// Pre-Atlas VRC25 fee tracking. victionchain snapshots all registered token
-	// fee capacities before the tx loop and decrements them per sponsored tx
-	// (state_processor.go:98-151). The final updated balances and total fee are
-	// written to state once at afterProcess via UpdateTRC21Fee / UpdateFeeCapacity.
-	// Post-Atlas these writes happen inside the tx via vrc25BuyGas/vrc25RefundGas
-	// and this map is unused.
-	trc21FeeBalance map[common.Address]*big.Int // running snapshot: token → remaining cap
-	trc21FeeUpdated map[common.Address]*big.Int // tokens that had fees charged: token → final cap
-	trc21TotalFee   *big.Int                    // sum of all fees charged across the block
+	// Pre-Atlas VRC25 fee tracking.
+	FeeBalance map[common.Address]*big.Int // running snapshot: token -> remaining cap
+	FeeUpdated map[common.Address]*big.Int // tokens that had fees charged: token -> final cap
+	TotalFee   *big.Int                    // sum of all fees charged across the block
 }
 
 func (p *StateProcessor) beforeProcess(block *types.Block, statedb *state.StateDB) error {
@@ -68,8 +63,8 @@ func (p *StateProcessor) beforeProcess(block *types.Block, statedb *state.StateD
 	// Initialize victionState for this block.
 	p.victionState = &victionProcessorState{
 		currentBlockNumber: new(big.Int).Set(header.Number),
-		trc21FeeUpdated:    map[common.Address]*big.Int{},
-		trc21TotalFee:      new(big.Int),
+		FeeUpdated:         map[common.Address]*big.Int{},
+		TotalFee:           new(big.Int),
 	}
 
 	if p.config.TIPSigningBlock != nil && p.config.TIPSigningBlock.Cmp(header.Number) == 0 {
@@ -84,13 +79,9 @@ func (p *StateProcessor) beforeProcess(block *types.Block, statedb *state.StateD
 
 	// Pre-Atlas: snapshot all registered VRC25 token fee capacities so per-tx
 	// eligibility checks use the running map rather than live state reads.
-	// This matches victionchain's GetTRC21FeeCapacityFromStateWithCache call
-	// before the transaction loop (blockchain.go:1674-1676). Note: victionchain
-	// gates this only on !IsAtlas — there is no IsTIPTRC21Fee guard — so the
-	// snapshot runs for all pre-Atlas blocks, including pre-TIPTRC21Fee blocks.
 	if !p.config.IsAtlas(header.Number) &&
 		p.config.Viction != nil && p.config.Viction.VRC25Contract != (common.Address{}) {
-		p.victionState.trc21FeeBalance = vrc25.GetAllFeeCapacities(statedb, p.config.Viction.VRC25Contract)
+		p.victionState.FeeBalance = vrc25.GetAllFeeCapacities(statedb, p.config.Viction.VRC25Contract)
 	}
 
 	// --- TomoX TradingStateDB initialization ---
@@ -129,13 +120,11 @@ func (p *StateProcessor) beforeProcess(block *types.Block, statedb *state.StateD
 }
 
 func (p *StateProcessor) afterProcess(block *types.Block, statedb *state.StateDB) error {
-	// Pre-Atlas: flush accumulated VRC25 fee updates to state. victionchain calls
-	// UpdateTRC21Fee after the tx loop (state_processor.go:149-151) to write the
-	// final per-token storage slots and subtract totalFeeUsed from the issuer contract.
+	// Pre-Atlas: flush accumulated VRC25 fee updates to state.
 	if p.victionState != nil && !p.config.IsAtlas(block.Number()) &&
 		p.config.Viction != nil && p.config.Viction.VRC25Contract != (common.Address{}) &&
-		len(p.victionState.trc21FeeUpdated) > 0 {
-		vrc25.UpdateFeeCapacity(statedb, p.config.Viction.VRC25Contract, p.victionState.trc21FeeUpdated, p.victionState.trc21TotalFee)
+		len(p.victionState.FeeUpdated) > 0 {
+		vrc25.UpdateFeeCapacity(statedb, p.config.Viction.VRC25Contract, p.victionState.FeeUpdated, p.victionState.TotalFee)
 	}
 
 	// --- TomoX trading root verification ---
@@ -299,14 +288,10 @@ func (p *StateProcessor) afterApplyTransaction(tx *types.Transaction, msg types.
 	token := *tx.To()
 	vicCfg := p.config.Viction
 
-	// Pre-Atlas VRC25 fee accumulation. victionchain accumulates fee into balanceUpdated
-	// and totalFeeUsed after each sponsored tx (state_processor.go:138-146).
-	// tokenFeeUsed condition: balanceFee != nil && balanceFee.Cmp(fee) == 1 (strictly >).
-	if p.victionState.trc21FeeBalance != nil {
-		runningCap, ok := p.victionState.trc21FeeBalance[token]
+	// Pre-Atlas VRC25 fee accumulation.
+	if p.victionState.FeeBalance != nil {
+		runningCap, ok := p.victionState.FeeBalance[token]
 		if ok && runningCap != nil {
-			// Compute fee in the same units victionchain uses: raw gasUsed pre-TIPTRC21Fee,
-			// gasUsed × TRC21GasPrice post-TIPTRC21Fee (state_processor.go:139-142).
 			fee := new(big.Int).SetUint64(usedGas)
 			if p.config.IsTIPTRC21Fee(blockNum) && vicCfg != nil && vicCfg.VRC25GasPrice != nil {
 				fee = new(big.Int).Mul(fee, (*big.Int)(vicCfg.VRC25GasPrice))
@@ -315,12 +300,11 @@ func (p *StateProcessor) afterApplyTransaction(tx *types.Transaction, msg types.
 			if runningCap.Cmp(fee) > 0 {
 				// Deduct from the running balance; record in updated map.
 				newCap := new(big.Int).Sub(runningCap, fee)
-				p.victionState.trc21FeeBalance[token] = newCap
-				p.victionState.trc21FeeUpdated[token] = newCap
-				p.victionState.trc21TotalFee.Add(p.victionState.trc21TotalFee, fee)
+				p.victionState.FeeBalance[token] = newCap
+				p.victionState.FeeUpdated[token] = newCap
+				p.victionState.TotalFee.Add(p.victionState.TotalFee, fee)
 
-				// Failed-tx minimum token fee: victionchain charges even when EVM reverts
-				// to prevent free failed-tx abuse (state_processor.go:488-491).
+				// Failed-tx minimum token fee
 				if receipt.Status == types.ReceiptStatusFailed {
 					vrc25.PayFeeWithVRC25(statedb, msg.From(), token)
 				}

--- a/core/state_processor_viction.go
+++ b/core/state_processor_viction.go
@@ -50,6 +50,16 @@ type victionProcessorState struct {
 	// Initialized per block in beforeProcess from the parent block's trading root.
 	// Only non-nil for pre-Atlas blocks where TomoX was active.
 	tradingStateDB *tradingstate.TradingStateDB
+
+	// Pre-Atlas VRC25 fee tracking. victionchain snapshots all registered token
+	// fee capacities before the tx loop and decrements them per sponsored tx
+	// (state_processor.go:98-151). The final updated balances and total fee are
+	// written to state once at afterProcess via UpdateTRC21Fee / UpdateFeeCapacity.
+	// Post-Atlas these writes happen inside the tx via vrc25BuyGas/vrc25RefundGas
+	// and this map is unused.
+	trc21FeeBalance map[common.Address]*big.Int // running snapshot: token → remaining cap
+	trc21FeeUpdated map[common.Address]*big.Int // tokens that had fees charged: token → final cap
+	trc21TotalFee   *big.Int                    // sum of all fees charged across the block
 }
 
 func (p *StateProcessor) beforeProcess(block *types.Block, statedb *state.StateDB) error {
@@ -58,6 +68,8 @@ func (p *StateProcessor) beforeProcess(block *types.Block, statedb *state.StateD
 	// Initialize victionState for this block.
 	p.victionState = &victionProcessorState{
 		currentBlockNumber: new(big.Int).Set(header.Number),
+		trc21FeeUpdated:    map[common.Address]*big.Int{},
+		trc21TotalFee:      new(big.Int),
 	}
 
 	if p.config.TIPSigningBlock != nil && p.config.TIPSigningBlock.Cmp(header.Number) == 0 {
@@ -68,6 +80,15 @@ func (p *StateProcessor) beforeProcess(block *types.Block, statedb *state.StateD
 	}
 	if p.config.SaigonBlock != nil && p.config.SaigonBlock.Cmp(block.Number()) <= 0 {
 		misc.ApplySaigonHardFork(statedb, p.config.Viction, p.config.SaigonBlock, block.Number())
+	}
+
+	// Pre-Atlas: snapshot all registered VRC25 token fee capacities so per-tx
+	// eligibility checks use the running map rather than live state reads.
+	// This matches victionchain's GetTRC21FeeCapacityFromStateWithCache call
+	// before the transaction loop (state_processor.go:98).
+	if !p.config.IsAtlas(header.Number) && p.config.IsTIPTRC21Fee(header.Number) &&
+		p.config.Viction != nil && p.config.Viction.VRC25Contract != (common.Address{}) {
+		p.victionState.trc21FeeBalance = vrc25.GetAllFeeCapacities(statedb, p.config.Viction.VRC25Contract)
 	}
 
 	// --- TomoX TradingStateDB initialization ---
@@ -106,6 +127,15 @@ func (p *StateProcessor) beforeProcess(block *types.Block, statedb *state.StateD
 }
 
 func (p *StateProcessor) afterProcess(block *types.Block, statedb *state.StateDB) error {
+	// Pre-Atlas: flush accumulated VRC25 fee updates to state. victionchain calls
+	// UpdateTRC21Fee after the tx loop (state_processor.go:149-151) to write the
+	// final per-token storage slots and subtract totalFeeUsed from the issuer contract.
+	if p.victionState != nil && !p.config.IsAtlas(block.Number()) &&
+		p.config.Viction != nil && p.config.Viction.VRC25Contract != (common.Address{}) &&
+		len(p.victionState.trc21FeeUpdated) > 0 {
+		vrc25.UpdateFeeCapacity(statedb, p.config.Viction.VRC25Contract, p.victionState.trc21FeeUpdated, p.victionState.trc21TotalFee)
+	}
+
 	// --- TomoX trading root verification ---
 	// Consensus-critical: a mismatch means order matching produced different state
 	// than what the block author committed in the 0x92 tx.
@@ -260,17 +290,42 @@ func (p *StateProcessor) afterApplyTransaction(tx *types.Transaction, msg types.
 
 	blockNum := p.victionState.currentBlockNumber
 
-	// For failed VRC25-sponsored transactions the EVM reverts so no token transfer
-	// executes. Charge a minimum token fee to prevent free failed-tx abuse.
-	if !p.config.IsAtlas(blockNum) && tx.To() != nil &&
-		p.config.IsTIPTRC21Fee(blockNum) &&
-		receipt.Status == types.ReceiptStatusFailed {
+	if p.config.IsAtlas(blockNum) || tx.To() == nil {
+		return nil
+	}
 
-		feeCap := vrc25.GetFeeCapacity(statedb, p.config.Viction.VRC25Contract, tx.To())
-		if feeCap != nil && feeCap.Sign() > 0 {
-			vrc25.PayFeeWithVRC25(statedb, msg.From(), *tx.To())
+	token := *tx.To()
+	vicCfg := p.config.Viction
+
+	// Pre-Atlas VRC25 fee accumulation. victionchain accumulates fee into balanceUpdated
+	// and totalFeeUsed after each sponsored tx (state_processor.go:138-146).
+	// tokenFeeUsed condition: balanceFee != nil && balanceFee.Cmp(fee) == 1 (strictly >).
+	if p.victionState.trc21FeeBalance != nil {
+		runningCap, ok := p.victionState.trc21FeeBalance[token]
+		if ok && runningCap != nil {
+			// Compute fee in the same units victionchain uses: raw gasUsed pre-TIPTRC21Fee,
+			// gasUsed × TRC21GasPrice post-TIPTRC21Fee (state_processor.go:139-142).
+			fee := new(big.Int).SetUint64(usedGas)
+			if p.config.IsTIPTRC21Fee(blockNum) && vicCfg != nil && vicCfg.TRC21GasPrice != nil {
+				fee = new(big.Int).Mul(fee, (*big.Int)(vicCfg.TRC21GasPrice))
+			}
+			// tokenFeeUsed: running cap must be strictly greater than fee.
+			if runningCap.Cmp(fee) > 0 {
+				// Deduct from the running balance; record in updated map.
+				newCap := new(big.Int).Sub(runningCap, fee)
+				p.victionState.trc21FeeBalance[token] = newCap
+				p.victionState.trc21FeeUpdated[token] = newCap
+				p.victionState.trc21TotalFee.Add(p.victionState.trc21TotalFee, fee)
+
+				// Failed-tx minimum token fee: victionchain charges even when EVM reverts
+				// to prevent free failed-tx abuse (state_processor.go:488-491).
+				if receipt.Status == types.ReceiptStatusFailed {
+					vrc25.PayFeeWithVRC25(statedb, msg.From(), token)
+				}
+			}
 		}
 	}
+
 	return nil
 }
 

--- a/core/state_processor_viction.go
+++ b/core/state_processor_viction.go
@@ -293,7 +293,7 @@ func (p *StateProcessor) afterApplyTransaction(tx *types.Transaction, msg types.
 		runningCap, ok := p.victionState.FeeBalance[token]
 		if ok && runningCap != nil {
 			fee := new(big.Int).SetUint64(usedGas)
-			if p.config.IsTIPTRC21Fee(blockNum) && vicCfg != nil && vicCfg.VRC25GasPrice != nil {
+			if p.config.TIPTRC21FeeBlock != nil && blockNum.Cmp(p.config.TIPTRC21FeeBlock) > 0 && vicCfg != nil && vicCfg.VRC25GasPrice != nil {
 				fee = new(big.Int).Mul(fee, (*big.Int)(vicCfg.VRC25GasPrice))
 			}
 			// tokenFeeUsed: running cap must be strictly greater than fee.

--- a/core/state_processor_viction.go
+++ b/core/state_processor_viction.go
@@ -85,8 +85,10 @@ func (p *StateProcessor) beforeProcess(block *types.Block, statedb *state.StateD
 	// Pre-Atlas: snapshot all registered VRC25 token fee capacities so per-tx
 	// eligibility checks use the running map rather than live state reads.
 	// This matches victionchain's GetTRC21FeeCapacityFromStateWithCache call
-	// before the transaction loop (state_processor.go:98).
-	if !p.config.IsAtlas(header.Number) && p.config.IsTIPTRC21Fee(header.Number) &&
+	// before the transaction loop (blockchain.go:1674-1676). Note: victionchain
+	// gates this only on !IsAtlas — there is no IsTIPTRC21Fee guard — so the
+	// snapshot runs for all pre-Atlas blocks, including pre-TIPTRC21Fee blocks.
+	if !p.config.IsAtlas(header.Number) &&
 		p.config.Viction != nil && p.config.Viction.VRC25Contract != (common.Address{}) {
 		p.victionState.trc21FeeBalance = vrc25.GetAllFeeCapacities(statedb, p.config.Viction.VRC25Contract)
 	}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -181,16 +181,20 @@ func (st *StateTransition) buyGas() error {
 		return err
 	}
 
-	mgval := new(big.Int).Mul(new(big.Int).SetUint64(st.msg.Gas()), st.gasPrice)
-	if have, want := st.state.GetBalance(st.payer), mgval; have.Cmp(want) < 0 {
-		return fmt.Errorf("%w: address %v have %v want %v", ErrInsufficientFunds, st.payer.Hex(), have, want)
-	}
 	if err := st.gp.SubGas(st.msg.Gas()); err != nil {
 		return err
 	}
 	st.gas += st.msg.Gas()
 
 	st.initialGas = st.msg.Gas()
+	// Pre-Atlas sponsored tx
+	if st.isVRC25Transaction() && !st.evm.ChainConfig().IsAtlas(st.evm.Context.BlockNumber) {
+		return nil
+	}
+	mgval := new(big.Int).Mul(new(big.Int).SetUint64(st.msg.Gas()), st.gasPrice)
+	if have, want := st.state.GetBalance(st.payer), mgval; have.Cmp(want) < 0 {
+		return fmt.Errorf("%w: address %v have %v want %v", ErrInsufficientFunds, st.payer.Hex(), have, want)
+	}
 	st.state.SubBalance(st.payer, mgval)
 	return nil
 }

--- a/core/state_transition_viction.go
+++ b/core/state_transition_viction.go
@@ -80,13 +80,8 @@ func (st *StateTransition) vrc25RefundGas(remaining *big.Int) {
 			)
 			vrc25.SetFeeCapacity(st.state, vrc25Contract, *addr, new(big.Int).Sub(feeCap, gasUsedFee))
 		}
-		// Refund the remaining gas back to the payer (VRC25Contract) native balance.
-		st.state.AddBalance(st.payer, remaining)
-		return
 	}
-
-	// Non-VRC25 transaction: refund remaining gas to the sender.
-	st.state.AddBalance(st.msg.From(), remaining)
+	st.state.AddBalance(st.payer, remaining)
 }
 
 // applyTransactionFee distributes the transaction fee to the correct recipient.

--- a/core/state_transition_viction.go
+++ b/core/state_transition_viction.go
@@ -80,6 +80,8 @@ func (st *StateTransition) vrc25RefundGas(remaining *big.Int) {
 			)
 			vrc25.SetFeeCapacity(st.state, vrc25Contract, *addr, new(big.Int).Sub(feeCap, gasUsedFee))
 		}
+		// Refund the remaining gas back to the payer (VRC25Contract) native balance.
+		st.state.AddBalance(st.payer, remaining)
 		return
 	}
 

--- a/core/state_transition_viction.go
+++ b/core/state_transition_viction.go
@@ -11,16 +11,19 @@ import (
 
 // vrc25BuyGas checks VRC25 sponsorship eligibility and adjusts payer/gasPrice.
 //
-// Pre-Atlas: victionchain overrides msg.gasPrice in AsMessage (types/transaction.go:264-271)
-// to TRC21GasPriceBefore (2500) pre-TIPTRC21Fee, or TRC21GasPrice (250M) post-TIPTRC21Fee.
-// checkBalance then tests feeCap >= gasLimit × that overridden price. subtractBalance does
-// nothing when balanceFee != nil — no native balance or storage touched during the tx.
-// We replicate this by overriding st.gasPrice so eligibility and coinbase fee use the right
-// price, but we leave payer = sender so upstream SubBalance hits the sender (who has enough
-// balance because vrc25BuyGas pre-credits the sender to cover it).
+// Pre-Atlas: victionchain AsMessage overrides msg.gasPrice to TRC21GasPriceBefore (2500)
+// pre-TIPTRC21Fee or TRC21GasPrice (250M) post-TIPTRC21Fee (types/transaction.go:264-271).
+// checkBalance tests feeCap >= gasLimit × overridden price. subtractBalance does nothing
+// when balanceFee != nil — no native balance or storage touched during the tx.
+// refundGas also does nothing when balanceFee != nil.
+//
+// We set payer = VRC25Contract so isVRC25Transaction() returns true, which routes refundGas
+// through vrc25RefundGas (which returns immediately for pre-Atlas, issuing no refund).
+// We pre-credit VRC25Contract with mgval so the upstream SubBalance(payer=VRC25Contract, mgval)
+// nets to zero — the issuer's native balance is untouched during the tx, matching victionchain.
 //
 // Post-Atlas: feeCap must strictly exceed gasLimit × VRC25GasPrice. vrc25PayGas writes the
-// storage slot and SubBalance inside the same call, so we set payer = VRC25Contract and let
+// storage slot and SubBalance inside the same call; we set payer = VRC25Contract and let
 // upstream SubBalance handle the native deduction (no pre-credit needed).
 func (st *StateTransition) vrc25BuyGas() error {
 	st.payer = st.msg.From()
@@ -39,8 +42,6 @@ func (st *StateTransition) vrc25BuyGas() error {
 
 	if !st.evm.ChainConfig().IsAtlas(blockNum) {
 		// Pre-Atlas: eligibility uses the era-overridden gas price, not the user-submitted one.
-		// victionchain AsMessage sets gasPrice to TRC21GasPriceBefore (2500) pre-TIPTRC21Fee
-		// and TRC21GasPrice (250M) post-TIPTRC21Fee (types/transaction.go:264-271).
 		var effectiveGasPrice *big.Int
 		if st.evm.ChainConfig().IsTIPTRC21Fee(blockNum) {
 			effectiveGasPrice = (*big.Int)(victionConfig.VRC25GasPrice) // 250,000,000
@@ -49,16 +50,16 @@ func (st *StateTransition) vrc25BuyGas() error {
 		}
 
 		mgval := new(big.Int).Mul(new(big.Int).SetUint64(st.msg.Gas()), effectiveGasPrice)
-		// victionchain checkBalance pre-Atlas: balanceTokenFee.Cmp(mgval) < 0 → reject
-		// so sponsorship requires feeCap >= mgval.
 		if feeCap.Cmp(mgval) < 0 {
 			return nil
 		}
 
-		// Override gasPrice so coinbase fee and refund use the correct era price.
-		// Payer stays as sender; pre-credit sender so upstream SubBalance nets to zero.
+		// Set payer = VRC25Contract so isVRC25Transaction() returns true, routing refundGas
+		// through vrc25RefundGas which returns immediately for pre-Atlas (no refund issued).
+		// Pre-credit VRC25Contract so the upstream SubBalance(VRC25Contract, mgval) nets to zero.
 		st.gasPrice = effectiveGasPrice
-		st.state.AddBalance(st.msg.From(), mgval)
+		st.payer = victionConfig.VRC25Contract
+		st.state.AddBalance(victionConfig.VRC25Contract, mgval)
 		return nil
 	}
 

--- a/core/state_transition_viction.go
+++ b/core/state_transition_viction.go
@@ -27,7 +27,7 @@ func (st *StateTransition) vrc25BuyGas() error {
 
 	if !st.evm.ChainConfig().IsAtlas(blockNum) {
 		var effectiveGasPrice *big.Int
-		if st.evm.ChainConfig().IsTIPTRC21Fee(blockNum) {
+		if st.evm.ChainConfig().TIPTRC21FeeBlock != nil && blockNum.Cmp(st.evm.ChainConfig().TIPTRC21FeeBlock) > 0 {
 			effectiveGasPrice = (*big.Int)(victionConfig.VRC25GasPrice) // 250,000,000
 		} else {
 			effectiveGasPrice = (*big.Int)(victionConfig.TRC21GasPrice) // 2,500
@@ -118,7 +118,8 @@ func (st *StateTransition) applyTransactionFee() {
 	}
 
 	// Before TIPTRC21Fee fork: fee goes to the block coinbase.
-	if !st.evm.ChainConfig().IsTIPTRC21Fee(blockNum) {
+	chainCfg := st.evm.ChainConfig()
+	if chainCfg.TIPTRC21FeeBlock == nil || blockNum.Cmp(chainCfg.TIPTRC21FeeBlock) <= 0 {
 		st.state.AddBalance(st.evm.Context.Coinbase, txFee)
 		return
 	}

--- a/core/state_transition_viction.go
+++ b/core/state_transition_viction.go
@@ -10,21 +10,6 @@ import (
 )
 
 // vrc25BuyGas checks VRC25 sponsorship eligibility and adjusts payer/gasPrice.
-//
-// Pre-Atlas: victionchain AsMessage overrides msg.gasPrice to TRC21GasPriceBefore (2500)
-// pre-TIPTRC21Fee or TRC21GasPrice (250M) post-TIPTRC21Fee (types/transaction.go:264-271).
-// checkBalance tests feeCap >= gasLimit × overridden price. subtractBalance does nothing
-// when balanceFee != nil — no native balance or storage touched during the tx.
-// refundGas also does nothing when balanceFee != nil.
-//
-// We set payer = VRC25Contract so isVRC25Transaction() returns true, which routes refundGas
-// through vrc25RefundGas (which returns immediately for pre-Atlas, issuing no refund).
-// We pre-credit VRC25Contract with mgval so the upstream SubBalance(payer=VRC25Contract, mgval)
-// nets to zero — the issuer's native balance is untouched during the tx, matching victionchain.
-//
-// Post-Atlas: feeCap must strictly exceed gasLimit × VRC25GasPrice. vrc25PayGas writes the
-// storage slot and SubBalance inside the same call; we set payer = VRC25Contract and let
-// upstream SubBalance handle the native deduction (no pre-credit needed).
 func (st *StateTransition) vrc25BuyGas() error {
 	st.payer = st.msg.From()
 
@@ -41,7 +26,6 @@ func (st *StateTransition) vrc25BuyGas() error {
 	blockNum := st.evm.Context.BlockNumber
 
 	if !st.evm.ChainConfig().IsAtlas(blockNum) {
-		// Pre-Atlas: eligibility uses the era-overridden gas price, not the user-submitted one.
 		var effectiveGasPrice *big.Int
 		if st.evm.ChainConfig().IsTIPTRC21Fee(blockNum) {
 			effectiveGasPrice = (*big.Int)(victionConfig.VRC25GasPrice) // 250,000,000
@@ -53,25 +37,20 @@ func (st *StateTransition) vrc25BuyGas() error {
 		if feeCap.Cmp(mgval) < 0 {
 			return nil
 		}
-
-		// Set payer = VRC25Contract so isVRC25Transaction() returns true, routing refundGas
-		// through vrc25RefundGas which returns immediately for pre-Atlas (no refund issued).
-		// Pre-credit VRC25Contract so the upstream SubBalance(VRC25Contract, mgval) nets to zero.
+		// Set payer = VRC25Contract so isVRC25Transaction() returns true.
+		// buyGas will skip the balance check and SubBalance for pre-Atlas sponsored txs.
 		st.gasPrice = effectiveGasPrice
 		st.payer = victionConfig.VRC25Contract
-		st.state.AddBalance(victionConfig.VRC25Contract, mgval)
 		return nil
 	}
 
-	// Post-Atlas: victionchain checkBalance uses Cmp(vrc25val) <= 0 → not sponsored.
-	// Sponsorship requires feeCap > gasLimit × VRC25GasPrice (strictly greater).
 	vrc25GasPrice := (*big.Int)(victionConfig.VRC25GasPrice)
 	vrc25GasFee := new(big.Int).Mul(new(big.Int).SetUint64(st.msg.Gas()), vrc25GasPrice)
 	if feeCap.Cmp(vrc25GasFee) <= 0 {
 		return nil
 	}
 
-	// Deduct storage slot (vrc25PayGas equivalent for the pre-execution part).
+	// Deduct storage slot upfront (vrc25PayGas equivalent).
 	newFeeCap := new(big.Int).Sub(feeCap, vrc25GasFee)
 	vrc25.SetFeeCapacity(st.state, victionConfig.VRC25Contract, *st.msg.To(), newFeeCap)
 

--- a/core/state_transition_viction.go
+++ b/core/state_transition_viction.go
@@ -50,10 +50,6 @@ func (st *StateTransition) vrc25BuyGas() error {
 		return nil
 	}
 
-	// Deduct storage slot upfront (vrc25PayGas equivalent).
-	newFeeCap := new(big.Int).Sub(feeCap, vrc25GasFee)
-	vrc25.SetFeeCapacity(st.state, victionConfig.VRC25Contract, *st.msg.To(), newFeeCap)
-
 	st.gasPrice = vrc25GasPrice
 	st.payer = victionConfig.VRC25Contract
 	return nil
@@ -64,35 +60,26 @@ func (st *StateTransition) isVRC25Transaction() bool {
 }
 
 // vrc25RefundGas handles gas refund for sponsored transactions.
-//
-// Pre-Atlas sponsored: victionchain refundGas does nothing when balanceFee != nil
-// (state_transition.go:349-355). No native balance change, no storage restore.
-//
-// Post-Atlas sponsored: restore unused feeCap to the storage slot and credit native
-// balance back to the issuer contract (vrc25RefundGas, state_transition.go:384-395).
 func (st *StateTransition) vrc25RefundGas(remaining *big.Int) {
 	if st.isVRC25Transaction() {
 		blockNum := st.evm.Context.BlockNumber
 		if !st.evm.ChainConfig().IsAtlas(blockNum) {
-			// Pre-Atlas: nothing — victionchain does not touch any balance or storage
-			// on refund when balanceFee != nil (state_transition.go:349-355).
+			// Pre-Atlas: nothing
 			return
 		}
 
-		// Post-Atlas: restore unused feeCap to storage and native balance.
+		// Post-Atlas: deduct exactly gasUsed×price from the token's storage slot once.
 		addr := st.msg.To()
 		victionConfig := st.evm.ChainConfig().Viction
 		vrc25Contract := victionConfig.VRC25Contract
 		feeCap := vrc25.GetFeeCapacity(st.state, vrc25Contract, addr)
 		if feeCap != nil {
-			storageRemaining := new(big.Int).Mul(
-				new(big.Int).SetUint64(st.gas),
+			gasUsedFee := new(big.Int).Mul(
+				new(big.Int).SetUint64(st.gasUsed()),
 				(*big.Int)(victionConfig.VRC25GasPrice),
 			)
-			vrc25.SetFeeCapacity(st.state, vrc25Contract, *addr, new(big.Int).Add(feeCap, storageRemaining))
+			vrc25.SetFeeCapacity(st.state, vrc25Contract, *addr, new(big.Int).Sub(feeCap, gasUsedFee))
 		}
-		// Refund remaining gas value to the issuer contract (payer)
-		st.state.AddBalance(st.payer, remaining)
 		return
 	}
 

--- a/core/state_transition_viction.go
+++ b/core/state_transition_viction.go
@@ -9,39 +9,73 @@ import (
 	"github.com/ethereum/go-ethereum/core/vrc25"
 )
 
-var slotTokensState = vrc25.SlotVRC25Contract["tokensState"]
-
-// buyVRC25Gas checks sponsorship eligibility and deducts the gas fee from the sponsor's storage balance.
+// vrc25BuyGas checks VRC25 sponsorship eligibility and adjusts payer/gasPrice.
+//
+// Pre-Atlas: victionchain overrides msg.gasPrice in AsMessage (types/transaction.go:264-271)
+// to TRC21GasPriceBefore (2500) pre-TIPTRC21Fee, or TRC21GasPrice (250M) post-TIPTRC21Fee.
+// checkBalance then tests feeCap >= gasLimit × that overridden price. subtractBalance does
+// nothing when balanceFee != nil — no native balance or storage touched during the tx.
+// We replicate this by overriding st.gasPrice so eligibility and coinbase fee use the right
+// price, but we leave payer = sender so upstream SubBalance hits the sender (who has enough
+// balance because vrc25BuyGas pre-credits the sender to cover it).
+//
+// Post-Atlas: feeCap must strictly exceed gasLimit × VRC25GasPrice. vrc25PayGas writes the
+// storage slot and SubBalance inside the same call, so we set payer = VRC25Contract and let
+// upstream SubBalance handle the native deduction (no pre-credit needed).
 func (st *StateTransition) vrc25BuyGas() error {
-	// Default payer is the sender
 	st.payer = st.msg.From()
 
-	// 1. Check if contract is sponsored (has fee capacity)
-	feeCap := vrc25.GetFeeCapacity(st.state, st.evm.ChainConfig().Viction.VRC25Contract, st.msg.To())
-	if feeCap == nil {
-		return nil // Not sponsored, proceed with standard user payment
-	}
 	victionConfig := st.evm.ChainConfig().Viction
-
-	// 2. Calculate Gas Cost with VRC25 Gas Price
-	vrc25GasFee := new(big.Int).Mul(new(big.Int).SetUint64(st.msg.Gas()), (*big.Int)(victionConfig.VRC25GasPrice))
-
-	// 3. Check sufficiency
-	if feeCap.Cmp(vrc25GasFee) < 0 {
-		return nil // Insufficient sponsor balance, fallback to user payment
+	if victionConfig == nil || victionConfig.VRC25Contract == (common.Address{}) {
+		return nil
 	}
 
-	// 4. Deduct from Contract's Storage Balance
-	// Note: The native ETH deduction happens in state_transition.go via st.state.SubBalance(st.payer)
+	feeCap := vrc25.GetFeeCapacity(st.state, victionConfig.VRC25Contract, st.msg.To())
+	if feeCap == nil || feeCap.Sign() == 0 {
+		return nil
+	}
+
+	blockNum := st.evm.Context.BlockNumber
+
+	if !st.evm.ChainConfig().IsAtlas(blockNum) {
+		// Pre-Atlas: eligibility uses the era-overridden gas price, not the user-submitted one.
+		// victionchain AsMessage sets gasPrice to TRC21GasPriceBefore (2500) pre-TIPTRC21Fee
+		// and TRC21GasPrice (250M) post-TIPTRC21Fee (types/transaction.go:264-271).
+		var effectiveGasPrice *big.Int
+		if st.evm.ChainConfig().IsTIPTRC21Fee(blockNum) {
+			effectiveGasPrice = (*big.Int)(victionConfig.VRC25GasPrice) // 250,000,000
+		} else {
+			effectiveGasPrice = (*big.Int)(victionConfig.TRC21GasPrice) // 2,500
+		}
+
+		mgval := new(big.Int).Mul(new(big.Int).SetUint64(st.msg.Gas()), effectiveGasPrice)
+		// victionchain checkBalance pre-Atlas: balanceTokenFee.Cmp(mgval) < 0 → reject
+		// so sponsorship requires feeCap >= mgval.
+		if feeCap.Cmp(mgval) < 0 {
+			return nil
+		}
+
+		// Override gasPrice so coinbase fee and refund use the correct era price.
+		// Payer stays as sender; pre-credit sender so upstream SubBalance nets to zero.
+		st.gasPrice = effectiveGasPrice
+		st.state.AddBalance(st.msg.From(), mgval)
+		return nil
+	}
+
+	// Post-Atlas: victionchain checkBalance uses Cmp(vrc25val) <= 0 → not sponsored.
+	// Sponsorship requires feeCap > gasLimit × VRC25GasPrice (strictly greater).
+	vrc25GasPrice := (*big.Int)(victionConfig.VRC25GasPrice)
+	vrc25GasFee := new(big.Int).Mul(new(big.Int).SetUint64(st.msg.Gas()), vrc25GasPrice)
+	if feeCap.Cmp(vrc25GasFee) <= 0 {
+		return nil
+	}
+
+	// Deduct storage slot (vrc25PayGas equivalent for the pre-execution part).
 	newFeeCap := new(big.Int).Sub(feeCap, vrc25GasFee)
-	feeCapKey := state.StorageLocationOfMappingElement(state.StorageLocationFromSlot(slotTokensState), st.msg.To().Hash().Bytes())
-	st.state.SetState(victionConfig.VRC25Contract, feeCapKey.Hash(), common.BigToHash(newFeeCap))
+	vrc25.SetFeeCapacity(st.state, victionConfig.VRC25Contract, *st.msg.To(), newFeeCap)
 
-	// 5. Set Payer to System Contract
-	// This ensures buyGas() deducts native ETH from the system contract
-	st.gasPrice = (*big.Int)(victionConfig.VRC25GasPrice)
+	st.gasPrice = vrc25GasPrice
 	st.payer = victionConfig.VRC25Contract
-
 	return nil
 }
 
@@ -49,22 +83,36 @@ func (st *StateTransition) isVRC25Transaction() bool {
 	return st.payer != st.msg.From()
 }
 
-// vrc25RefundGas is called for VRC25-sponsored transactions and all Atlas-block transactions.
-// For sponsored transactions it also restores the unused portion to the fee capacity storage slot.
-// For non-sponsored Atlas transactions it only returns native ETH to the sender.
+// vrc25RefundGas handles gas refund for sponsored transactions.
+//
+// Pre-Atlas sponsored: victionchain refundGas does nothing when balanceFee != nil
+// (state_transition.go:349-355). No native balance change, no storage restore.
+//
+// Post-Atlas sponsored: restore unused feeCap to the storage slot and credit native
+// balance back to the issuer contract (vrc25RefundGas, state_transition.go:384-395).
 func (st *StateTransition) vrc25RefundGas(remaining *big.Int) {
 	if st.isVRC25Transaction() {
+		blockNum := st.evm.Context.BlockNumber
+		if !st.evm.ChainConfig().IsAtlas(blockNum) {
+			// Pre-Atlas: nothing — victionchain does not touch any balance or storage
+			// on refund when balanceFee != nil (state_transition.go:349-355).
+			return
+		}
+
+		// Post-Atlas: restore unused feeCap to storage and native balance.
 		addr := st.msg.To()
-		vrc25Contract := st.evm.ChainConfig().Viction.VRC25Contract
+		victionConfig := st.evm.ChainConfig().Viction
+		vrc25Contract := victionConfig.VRC25Contract
 		feeCap := vrc25.GetFeeCapacity(st.state, vrc25Contract, addr)
-		if feeCap != nil { // always non-nil for non-nil addr; guard defensively
-			newFeeCap := new(big.Int).Add(feeCap, remaining)
-			feeCapKey := state.StorageLocationOfMappingElement(state.StorageLocationFromSlot(slotTokensState), addr.Hash().Bytes())
-			st.state.SetState(vrc25Contract, feeCapKey.Hash(), common.BigToHash(newFeeCap))
+		if feeCap != nil {
+			storageRemaining := new(big.Int).Mul(
+				new(big.Int).SetUint64(st.gas),
+				(*big.Int)(victionConfig.VRC25GasPrice),
+			)
+			vrc25.SetFeeCapacity(st.state, vrc25Contract, *addr, new(big.Int).Add(feeCap, storageRemaining))
 		}
 	}
 
-	// Return native ETH to the payer (VRC25Contract for sponsored txs, sender otherwise).
 	st.state.AddBalance(st.payer, remaining)
 }
 

--- a/core/state_transition_viction.go
+++ b/core/state_transition_viction.go
@@ -112,9 +112,13 @@ func (st *StateTransition) vrc25RefundGas(remaining *big.Int) {
 			)
 			vrc25.SetFeeCapacity(st.state, vrc25Contract, *addr, new(big.Int).Add(feeCap, storageRemaining))
 		}
+		// Refund remaining gas value to the issuer contract (payer)
+		st.state.AddBalance(st.payer, remaining)
+		return
 	}
 
-	st.state.AddBalance(st.payer, remaining)
+	// Non-VRC25 transaction: refund remaining gas to the sender.
+	st.state.AddBalance(st.msg.From(), remaining)
 }
 
 // applyTransactionFee distributes the transaction fee to the correct recipient.

--- a/core/vrc25/vrc25.go
+++ b/core/vrc25/vrc25.go
@@ -95,6 +95,43 @@ func UpdateFeeCapacity(statedb vm.StateDB, vrc25Contract common.Address, newBala
 	statedb.SubBalance(vrc25Contract, totalFeeUsed)
 }
 
+// SetFeeCapacity writes a token's fee capacity into the VRC25 issuer contract's
+// tokensState mapping. Called during post-Atlas gas purchase to deduct the
+// pre-committed fee from the slot before EVM execution.
+func SetFeeCapacity(statedb vm.StateDB, vrc25Contract common.Address, token common.Address, value *big.Int) {
+	key := state.StorageLocationOfMappingElement(state.StorageLocationFromSlot(SlotVRC25Contract["tokensState"]), token.Hash().Bytes())
+	statedb.SetState(vrc25Contract, key.Hash(), common.BigToHash(value))
+}
+
+// GetAllFeeCapacities reads the entire tokensState mapping from the VRC25 issuer
+// contract and returns a snapshot of every registered token's fee capacity.
+// Used at the start of pre-Atlas block processing (beforeProcess) so that
+// per-transaction eligibility checks use the snapshotted map rather than
+// live state reads, matching victionchain's GetTRC21FeeCapacityFromStateWithCache
+// behaviour (trc21_reader.go:27-44).
+func GetAllFeeCapacities(statedb vm.StateDB, vrc25Contract common.Address) map[common.Address]*big.Int {
+	result := map[common.Address]*big.Int{}
+
+	// tokens is a dynamic array at slot 1; read its length first.
+	tokensSlot := state.StorageLocationFromSlot(SlotVRC25Contract["tokens"])
+	tokenCount := statedb.GetState(vrc25Contract, tokensSlot.Hash()).Big().Uint64()
+
+	slotTokensState := SlotVRC25Contract["tokensState"]
+	for i := uint64(0); i < tokenCount; i++ {
+		// Each element of the dynamic array is stored at keccak256(slot) + i.
+		elemKey := state.StorageLocationOfDynamicArrayElement(tokensSlot, i, 1)
+		tokenHash := statedb.GetState(vrc25Contract, elemKey.Hash())
+		if tokenHash == (common.Hash{}) {
+			continue
+		}
+		token := common.BytesToAddress(tokenHash.Bytes())
+		balanceKey := state.StorageLocationOfMappingElement(state.StorageLocationFromSlot(slotTokensState), token.Hash().Bytes())
+		cap := statedb.GetState(vrc25Contract, balanceKey.Hash()).Big()
+		result[token] = cap
+	}
+	return result
+}
+
 // we use vm.StateDB interface instead of *StateDB
 func GetFeeCapacity(statedb vm.StateDB, vrc25Contract common.Address, addr *common.Address) *big.Int {
 	if addr == nil {

--- a/core/vrc25/vrc25.go
+++ b/core/vrc25/vrc25.go
@@ -105,10 +105,6 @@ func SetFeeCapacity(statedb vm.StateDB, vrc25Contract common.Address, token comm
 
 // GetAllFeeCapacities reads the entire tokensState mapping from the VRC25 issuer
 // contract and returns a snapshot of every registered token's fee capacity.
-// Used at the start of pre-Atlas block processing (beforeProcess) so that
-// per-transaction eligibility checks use the snapshotted map rather than
-// live state reads, matching victionchain's GetTRC21FeeCapacityFromStateWithCache
-// behaviour (trc21_reader.go:27-44).
 func GetAllFeeCapacities(statedb vm.StateDB, vrc25Contract common.Address) map[common.Address]*big.Int {
 	result := map[common.Address]*big.Int{}
 


### PR DESCRIPTION
sumary : `vic-geth` produced a state root mismatch against `victionchain` on blocks via mismatch involving VRC25-sponsored transactions (gas paid via token fee instead of native VIC).

## 1. Root cause

### Bug 1 — Wrong payer / unnetted SubBalance during buyGas.
Fix :
`core/state_transition.go` — `buyGas`
Added pre-Atlas sponsored tx early return to skip balance check and `SubBalance`:
```go
// Pre-Atlas sponsored tx: payer = VRC25Contract but victionchain does not
// SubBalance from the issuer contract in the pre-Atlas path.
if st.isVRC25Transaction() && !st.evm.ChainConfig().IsAtlas(st.evm.Context.BlockNumber) {
    return nil
}
```
Also modifier `VRC25BuyGas` to match the check .
### Bug 2 — Missing end-of-block fee flush.
fix — `core/state_processor_viction.go` — `feeBalance`/`feeUpdated`/`totalFee` fields in `victionProcessorState`; snapshotted in `beforeProcess`; decremented per tx in `afterApplyTransaction`; flushed via `vrc25.UpdateFeeCapacity` in `afterProcess`.
### Bug 3 — Atlas eligibility off-by-one : 
fix — `core/state_transition_viction.go:vrc25BuyGas` — changed to `<= 0`.
### Bug 4 — Failed-tx minimum fee not applied pre-TIPTRC21Fee.
fix — `core/state_processor_viction.go:afterApplyTransaction` — era guard removed; fires inside the `feeBalance` eligibility check for any pre-Atlas failed sponsored tx.

### Bug 5 - Wrong gas price constant:
Fix:  `afterApplyTransaction `change to use vicCfg.VRC25GasPrice .