### PR TITLE
Add skip order execution entirely at epoch block .

### DIFF
--- a/core/state_processor_viction.go
+++ b/core/state_processor_viction.go
@@ -371,6 +371,9 @@ func (p *StateProcessor) SetLendingEngine(engine LendingEngine) {
 }
 
 // applyTomoXTx decodes and replays a TomoX order-matching batch (0x91 transaction).
+//
+// On epoch-boundary blocks (block % Epoch == 0) skips order execution
+// entirely and only runs UpdateMediumPriceBeforeEpoch (called in beforeProcess).
 func (p *StateProcessor) applyTomoXTx(statedb *state.StateDB, tx *types.Transaction, header *types.Header, usedGas *uint64) (bool, *types.Receipt, uint64, error, *big.Int) {
 	var root []byte
 	if p.config.IsByzantium(header.Number) {
@@ -379,7 +382,9 @@ func (p *StateProcessor) applyTomoXTx(statedb *state.StateDB, tx *types.Transact
 		root = statedb.IntermediateRoot(p.config.IsEIP158(header.Number)).Bytes()
 	}
 
-	if len(tx.Data()) > 0 && p.victionState != nil && p.victionState.tradingStateDB != nil && p.tradingEngine != nil {
+	isEpochBlock := p.config.Posv != nil && header.Number.Uint64()%p.config.Posv.Epoch == 0
+
+	if !isEpochBlock && len(tx.Data()) > 0 && p.victionState != nil && p.victionState.tradingStateDB != nil && p.tradingEngine != nil {
 		txMatchBatch, err := tradingstate.DecodeTxMatchesBatch(tx.Data())
 		if err != nil {
 			return true, nil, 0, fmt.Errorf("TomoX: failed to decode TxMatchBatch tx=%s: %w", tx.Hash().Hex(), err), nil
@@ -423,6 +428,9 @@ func (p *StateProcessor) applyTomoXTx(statedb *state.StateDB, tx *types.Transact
 }
 
 // applyLendingTx decodes and replays a TomoZ lending order-matching batch (0x93 transaction).
+//
+// Mirrors the epoch-skip rule from applyTomoXTx: on epoch-boundary blocks
+// skips all order execution; only UpdateMediumPriceBeforeEpoch runs that block.
 func (p *StateProcessor) applyLendingTx(statedb *state.StateDB, tx *types.Transaction, header *types.Header, usedGas *uint64) (bool, *types.Receipt, uint64, error, *big.Int) {
 	var root []byte
 	if p.config.IsByzantium(header.Number) {
@@ -431,7 +439,10 @@ func (p *StateProcessor) applyLendingTx(statedb *state.StateDB, tx *types.Transa
 		root = statedb.IntermediateRoot(p.config.IsEIP158(header.Number)).Bytes()
 	}
 
-	if len(tx.Data()) > 0 &&
+	isEpochBlock := p.config.Posv != nil && header.Number.Uint64()%p.config.Posv.Epoch == 0
+
+	if !isEpochBlock &&
+		len(tx.Data()) > 0 &&
 		p.victionState != nil &&
 		p.victionState.lendingStateDB != nil &&
 		p.victionState.tradingStateDB != nil &&


### PR DESCRIPTION

## Bug fix: epoch-block order execution skipped (trading state root mismatch)

### Symptom

```
BAD BLOCK
Number: 20582100
Error: TomoX: trading state root mismatch at block 20582100:
  got      0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421
  expected 0x2d1ffaa87ce729855d1a7f153393ff81fe52bb5ad49fe5c716da68df081a0944
```

Block 20582100 is the first epoch boundary after `TIPTomoX` activation
(`20582100 % 900 == 0`).

### Root cause

`victionchain` applies a strict **epoch-block vs non-epoch-block split** in its
block-insertion loop:

```go
if block % Epoch == 0 {
    UpdateMediumPriceBeforeEpoch(...)   // only this; no order replay
} else {
    ValidateTradingOrder(...)
    ValidateLendingOrder(...)
    ProcessLiquidationData(...)         // only at offset 100
}
```

On epoch blocks no 0x91 (TomoX) or 0x93 (lending) orders are ever applied to the
trie. `vic-geth`'s `applyTomoXTx` and `applyLendingTx` were calling `CommitOrder`
unconditionally, mutating the trading state trie with matches that `victionchain`
never applied.

`UpdateMediumPriceBeforeEpoch` (called in `beforeProcess` when `% Epoch == 0`)
already ran correctly and wrote its medium-price updates. The mismatch arose because
order-matching mutations were layered on top of those writes.

### Fix

Added `isEpochBlock` guard in both `applyTomoXTx` and `applyLendingTx`
(`core/state_processor_viction.go`):

```go
isEpochBlock := p.config.Posv != nil && header.Number.Uint64()%p.config.Posv.Epoch == 0

if !isEpochBlock && len(tx.Data()) > 0 && ... {
    // CommitOrder loop
}
```

Both functions still emit the correct receipt for the tx — only the state-mutating
`CommitOrder` call is skipped, exactly matching `victionchain`'s behaviour.
