### PR TITLE
Bug Fix: Replicate big.Int Pointer Mutation for VRC25 Fallback Fees

### DIFF
--- a/core/vrc25/vrc25.go
+++ b/core/vrc25/vrc25.go
@@ -64,12 +64,12 @@ func PayFeeWithVRC25(statedb vm.StateDB, from common.Address, token common.Addre
 		// 6. Determine the actual fee to charge (lesser of balance or minFee)
 		feeUsed := new(big.Int).Set(minFee)
 		if balance.Cmp(minFee) < 0 {
-			feeUsed.Set(balance)
+			feeUsed = balance
 		}
 
 		// 7. Deduct the fee from the user's balance and update state
-		newBalance := new(big.Int).Sub(balance, feeUsed)
-		statedb.SetState(token, balanceKey.Hash(), common.BigToHash(newBalance))
+		balance.Sub(balance, feeUsed)
+		statedb.SetState(token, balanceKey.Hash(), common.BigToHash(balance))
 
 		// 8. Add the fee to the issuer's balance and update state
 		issuerBalanceKey := state.StorageLocationOfMappingElement(balanceSlot, issuerAddr.Hash().Bytes())


### PR DESCRIPTION
### **Description:**
This PR resolves an "invalid merkle root" state divergence occurring on specific blocks (e.g., block 27931641) involving failed TRC21/VRC25 sponsored transactions.
### **Root Cause:**
In the legacy `victionchain` codebase, there is a subtle `big.Int` memory pointer bug within `PayFeeWithTRC21TxFail`. When a user's TRC21 token balance is less than the required `minFee`, the code executes:
`feeUsed = balance`
Because both `feeUsed` and `balance` now point to the exact same `big.Int` memory address, the subsequent deduction:
`balance.Sub(balance, feeUsed)` mathematically subtracts the value from itself, unintentionally mutating **both** `balance` and `feeUsed` to `0`. As a result, the user's balance correctly becomes `0`, but the amount added to the token issuer's balance is also incorrectly calculated as `0` (burning the remaining tokens instead of transferring them to the issuer).
## **Resolution:**
If `vic-geth` safely performs this math (e.g., using `new(big.Int).Sub(...)`), the issuer correctly receives the tokens, but our state root diverges from the historical `victionchain` state. To maintain strict consensus compatibility with historical blocks, we must intentionally replicate this exact `big.Int` pointer mutation bug in`vic-geth`'s `PayFeeWithVRC25` fallback logic.