### PR TITLE
Add saigon hardfork config parameters

### DIFF
--- a/params/viction_specs/viction.json
+++ b/params/viction_specs/viction.json
@@ -49,6 +49,11 @@
       "validatorSignInterval": 15,
       "vrc25Contract": "0x8c0faeb5C6bEd2129b8674F262Fd45c4e9468bee",
       "vrc25GasPrice": "250000000",
-      "lendingLiquidateTradeBlock": 100
+      "lendingLiquidateTradeBlock": 100,
+      "saigonFundAddress": "0xeDC9f7873a33763c84b82157B034988728445a0E",
+      "saigonFundAmount": "0x108b2a2c28029094000000",
+      "saigonFundInterval": 13800000,
+      "saigonFundRepeat": 4,
+      "saigonRewardPerEpoch": "0xd8d726b7177a80000"
     }
   }


### PR DESCRIPTION
## Summary

Fix merkle root mismatch (BAD BLOCK) at Saigon hardfork activation block 86,158,494.

## Root Cause

The Saigon hardfork code (`ApplySaigonHardFork`, `CalcSaigonRewardPerBlock`) was already correctly implemented in `vic-geth`. However, the 5 required configuration parameters were missing from `viction.json`, causing:

- `SaigonFundInterval == 0` → `ApplySaigonHardFork` returns immediately (`consensus/misc/forks_viction.go:14-16`)
- No 20M VIC minted to the ecosystem fund address at block 86,158,494
- State root diverges from canonical chain → BAD BLOCK error

## Changes

Added 5 missing Saigon parameters to `params/viction_specs/viction.json`, all verified against `victionchain/common/constants.go`:

| Parameter | Value | Source |
|---|---|---|
| `saigonFundAddress` | `0xeDC9...5a0E` | `SaigonEcoSystemFundAddress` (constants.go:60) |
| `saigonFundAmount` | `0x108b2a2c28029094000000` | 20,000,000 × 10^18 wei (constants.go:61) |
| `saigonFundInterval` | `13800000` | ~1 year in blocks (constants.go:62) |
| `saigonFundRepeat` | `4` | 4 annual mints = 80M VIC total (constants.go:63) |
| `saigonRewardPerEpoch` | `0xd8d726b7177a80000` | 250 × 10^18 wei (constants.go:59) |

**Note on wei conversion**: In `victionchain`, multiplication by 10^18 happens at call time. In `vic-geth`, values are used directly from config, so they are stored in wei. This is consistent with the existing `rewardPerEpoch` field.