### PR TITLE
Fix VRC25 stale fee capacity reads causing state root mismatch

### DIFF
--- a/core/state_processor_viction.go
+++ b/core/state_processor_viction.go
@@ -173,6 +173,9 @@ func (p *StateProcessor) beforeProcess(block *types.Block, statedb *state.StateD
 	if !p.config.IsAtlas(header.Number) &&
 		p.config.Viction != nil && p.config.Viction.VRC25Contract != (common.Address{}) {
 		p.victionState.feeBalance = vrc25.GetAllFeeCapacities(statedb, p.config.Viction.VRC25Contract)
+		activeFeeBalance = p.victionState.feeBalance
+	} else {
+		activeFeeBalance = nil
 	}
 
 	// Open TomoX and TomoZ tries from the parent block.
@@ -240,6 +243,10 @@ func (p *StateProcessor) beforeProcess(block *types.Block, statedb *state.StateD
 // transaction embedded in the block. Called once after all transactions have
 // been applied.
 func (p *StateProcessor) afterProcess(block *types.Block, statedb *state.StateDB) error {
+	// Clear the package-level feeBalance pointer; it is only valid during
+	// block processing and must not leak to the next block.
+	activeFeeBalance = nil
+
 	// Pre-Atlas: flush accumulated VRC25 fee updates to state.
 	if p.victionState != nil && !p.config.IsAtlas(block.Number()) &&
 		p.config.Viction != nil && p.config.Viction.VRC25Contract != (common.Address{}) &&

--- a/core/state_transition_viction.go
+++ b/core/state_transition_viction.go
@@ -9,6 +9,11 @@ import (
 	"github.com/ethereum/go-ethereum/core/vrc25"
 )
 
+// activeFeeBalance holds the per-block running VRC25 fee capacity map for
+// the block currently being processed.  It is set by beforeProcess (via
+// victionProcessorState) and read by vrc25BuyGas during each transaction.
+var activeFeeBalance map[common.Address]*big.Int
+
 // vrc25BuyGas checks VRC25 sponsorship eligibility and adjusts payer/gasPrice.
 func (st *StateTransition) vrc25BuyGas() error {
 	st.payer = st.msg.From()
@@ -17,18 +22,20 @@ func (st *StateTransition) vrc25BuyGas() error {
 	if victionConfig == nil || victionConfig.VRC25Contract == (common.Address{}) {
 		return nil
 	}
-	
-	feeCap := vrc25.GetFeeCapacity(st.state, victionConfig.VRC25Contract, st.msg.To())
-	if feeCap == nil || feeCap.Sign() == 0 {
-		return nil
-	}
 
 	blockNum := st.evm.Context.BlockNumber
 
 	if !st.evm.ChainConfig().IsAtlas(blockNum) {
-		// Pre-Atlas: token must be in the tokens[] array to be eligible.
-		// A token can have non-zero tokensState capacity but NOT be in the array
-		if !vrc25.IsTokenInArray(st.state, victionConfig.VRC25Contract, *st.msg.To()) {
+		// Pre-Atlas path: use the running activeFeeBalance map for eligibility.
+		// This map is loaded from state at block start (beforeProcess) and
+		// decremented after each VRC25 tx (afterApplyTransaction), ensuring
+		// correct capacity tracking across multiple txs to the same token.
+		if st.msg.To() == nil || activeFeeBalance == nil {
+			return nil
+		}
+		feeCap, ok := activeFeeBalance[*st.msg.To()]
+		if !ok || feeCap == nil {
+			// Token not in the registered list — treat as regular VIC tx.
 			return nil
 		}
 
@@ -41,12 +48,23 @@ func (st *StateTransition) vrc25BuyGas() error {
 
 		mgval := new(big.Int).Mul(new(big.Int).SetUint64(st.msg.Gas()), effectiveGasPrice)
 		if feeCap.Cmp(mgval) < 0 {
+			// Token is registered but capacity is insufficient — fall through
+			// to regular VIC path.  buyGas will then check the sender's VIC
+			// balance at the original gasPrice (which for VRC25 txs is
+			// typically 0, so this effectively rejects the tx with
+			// ErrInsufficientFunds
 			return nil
 		}
 		// Set payer = VRC25Contract so isVRC25Transaction() returns true.
 		// buyGas will skip the balance check and SubBalance for pre-Atlas sponsored txs.
 		st.gasPrice = effectiveGasPrice
 		st.payer = victionConfig.VRC25Contract
+		return nil
+	}
+
+	// Post-Atlas: read capacity from statedb (each tx writes back via vrc25RefundGas).
+	feeCap := vrc25.GetFeeCapacity(st.state, victionConfig.VRC25Contract, st.msg.To())
+	if feeCap == nil || feeCap.Sign() == 0 {
 		return nil
 	}
 

--- a/core/vrc25/vrc25.go
+++ b/core/vrc25/vrc25.go
@@ -128,26 +128,6 @@ func GetAllFeeCapacities(statedb vm.StateDB, vrc25Contract common.Address) map[c
 	return result
 }
 
-// IsTokenInArray reports whether addr appears in the VRC25 issuer contract's
-// tokens[] dynamic array (slot 1). Pre-Atlas, only tokens present in this
-// array are eligible for VRC25 sponsorship
-func IsTokenInArray(statedb vm.StateDB, vrc25Contract common.Address, addr common.Address) bool {
-	tokensSlot := state.StorageLocationFromSlot(SlotVRC25Contract["tokens"])
-	tokenCount := statedb.GetState(vrc25Contract, tokensSlot.Hash()).Big().Uint64()
-	for i := uint64(0); i < tokenCount; i++ {
-		elemKey := state.StorageLocationOfDynamicArrayElement(tokensSlot, i, 1)
-		tokenHash := statedb.GetState(vrc25Contract, elemKey.Hash())
-		if tokenHash == (common.Hash{}) {
-			continue
-		}
-		token := common.BytesToAddress(tokenHash.Bytes())
-		if token == addr {
-			return true
-		}
-	}
-	return false
-}
-
 // we use vm.StateDB interface instead of *StateDB
 func GetFeeCapacity(statedb vm.StateDB, vrc25Contract common.Address, addr *common.Address) *big.Int {
 	if addr == nil {


### PR DESCRIPTION
## Problem :
Block processing fails at block `92,188,801` with `invalid merkle root` (BAD BLOCK) due to incorrect VRC25 fee capacity tracking across multiple transactions within the same block.

In the pre-Atlas VRC25 path, `vrc25BuyGas()` read fee capacity directly from `statedb` on every transaction. However, the `statedb` capacity is only flushed once at end-of-block in `afterProcess`. When multiple transactions target the same VRC25 token within a single block, the 2nd and 3rd transactions see the original (stale) capacity instead of the decremented value .
Block 92,188,801 has 3 transactions to VRC25 token `0x2BA295918a155D08BD9592313bCb75960aB2FD61` at tx indices 3, 10, and 11, triggering this bug.

## Root Cause :
- `core/state_transition_viction.go` (broken): `vrc25BuyGas()` called `vrc25.GetFeeCapacity()` from `statedb` each time. Since `statedb` writes are deferred to `afterProcess`, every tx in the block saw identical capacity.

## Fix : 
- Added `activeFeeBalance` package-level variable in `state_transition_viction.go` -> holds the per-block running VRC25 capacity map (safe because block processing is single-threaded).
- `beforeProcess` sets `activeFeeBalance` from the snapshot loaded into `victionProcessorState.feeBalance`.
- `afterProcess` clears `activeFeeBalance` to prevent leaking to the next block.
- Rewrote the pre-Atlas path in `vrc25BuyGas()` to read from `activeFeeBalance` instead of `statedb`. The `afterApplyTransaction` hook already decrements this map after each tx, so subsequent txs to the same token see the correctly reduced capacity.
- Post-Atlas path unchanged (reads from `statedb`, which is correct since `vrc25RefundGas` writes back per-tx).
- Removed unused `IsTokenInArray()` from `core/vrc25/vrc25.go` : no longer needed since `activeFeeBalance` (loaded via `GetAllFeeCapacities` ) already contains only tokens present in the `tokens[]` array.

## File changes : 
- `core/state_transition_viction.go` : Added `activeFeeBalance` var; rewrote pre-Atlas `vrc25BuyGas()` to use running map.
- `core/state_processor_viction.go`: Set/clear `activeFeeBalance` in `beforeProcess`/`afterProcess`.
- `core/vrc25/vrc25.go`: Removed unused `IsTokenInArray()`. 
