### PR TITLE
Fix post-Atlas state root mismatch at block 97,705,094 (Atlas hardfork)

### DIFF
--- a/core/state_processor_viction.go
+++ b/core/state_processor_viction.go
@@ -18,6 +18,11 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
+// activeFeeBalance holds the per-block running VRC25 fee capacity map for
+// the block currently being processed.  It is set by beforeProcess (via
+// victionProcessorState) and read by vrc25BuyGas during each transaction.
+var activeFeeBalance map[common.Address]*big.Int
+
 // TradingEngine is the interface the TomoX engine must satisfy.
 // Defined here to avoid an import cycle between core and legacy/tomox.
 type TradingEngine interface {

--- a/core/state_processor_viction.go
+++ b/core/state_processor_viction.go
@@ -444,12 +444,27 @@ func (p *StateProcessor) afterApplyTransaction(tx *types.Transaction, msg types.
 
 	blockNum := p.victionState.currentBlockNumber
 
-	if p.config.IsAtlas(blockNum) || tx.To() == nil {
+	if tx.To() == nil {
 		return nil
 	}
 
 	token := *tx.To()
 	vicCfg := p.config.Viction
+
+	if p.config.IsAtlas(blockNum) {
+		// Post-Atlas: charge VRC25 token fee for failed sponsored txs.
+		if receipt.Status == types.ReceiptStatusFailed && vicCfg != nil && vicCfg.VRC25GasPrice != nil {
+			feeCap := vrc25.GetFeeCapacity(statedb, vicCfg.VRC25Contract, tx.To())
+			fee := new(big.Int).Mul(
+				new(big.Int).SetUint64(usedGas),
+				(*big.Int)(vicCfg.VRC25GasPrice),
+			)
+			if feeCap != nil && feeCap.Cmp(fee) > 0 {
+				vrc25.PayFeeWithVRC25(statedb, msg.From(), token)
+			}
+		}
+		return nil
+	}
 
 	// Pre-Atlas: accumulate VRC25 fee deductions into feeUpdated; flushed in afterProcess.
 	if p.victionState.feeBalance != nil {

--- a/core/state_processor_viction.go
+++ b/core/state_processor_viction.go
@@ -173,6 +173,9 @@ func (p *StateProcessor) beforeProcess(block *types.Block, statedb *state.StateD
 	if !p.config.IsAtlas(header.Number) &&
 		p.config.Viction != nil && p.config.Viction.VRC25Contract != (common.Address{}) {
 		p.victionState.feeBalance = vrc25.GetAllFeeCapacities(statedb, p.config.Viction.VRC25Contract)
+		activeFeeBalance = p.victionState.feeBalance
+	} else {
+		activeFeeBalance = nil
 	}
 
 	// Open TomoX and TomoZ tries from the parent block.
@@ -240,6 +243,10 @@ func (p *StateProcessor) beforeProcess(block *types.Block, statedb *state.StateD
 // transaction embedded in the block. Called once after all transactions have
 // been applied.
 func (p *StateProcessor) afterProcess(block *types.Block, statedb *state.StateDB) error {
+	// Clear the package-level feeBalance pointer; it is only valid during
+	// block processing and must not leak to the next block.
+	activeFeeBalance = nil
+
 	// Pre-Atlas: flush accumulated VRC25 fee updates to state.
 	if p.victionState != nil && !p.config.IsAtlas(block.Number()) &&
 		p.config.Viction != nil && p.config.Viction.VRC25Contract != (common.Address{}) &&

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -305,7 +305,7 @@ func (st *StateTransition) refundGas() {
 		// If normal transaction, fallback to basic ETH refunding
 		st.state.AddBalance(st.msg.From(), remaining)
 	}
-	
+
 	// Also return remaining gas to the block gas counter so it is
 	// available for the next transaction.
 	st.gp.AddGas(st.gas)

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -296,16 +296,15 @@ func (st *StateTransition) refundGas() {
 	// Return ETH for remaining gas, exchanged at the original rate.
 	remaining := new(big.Int).Mul(new(big.Int).SetUint64(st.gas), st.gasPrice)
 
-	// VRC25, Atlas gas, ...
-	isCustomGasRefunding := st.isVRC25Transaction() || st.evm.ChainConfig().IsAtlas(st.evm.Context.BlockNumber)
-
-	if isCustomGasRefunding {
+	if st.isVRC25Transaction() {
+		// VRC25-sponsored: delegate refund to the Viction hook.
 		st.vrc25RefundGas(remaining)
-	} else {
-		// If normal transaction, fallback to basic ETH refunding
+	} else if !st.evm.ChainConfig().IsAtlas(st.evm.Context.BlockNumber) {
+		// Pre-Atlas regular tx: refund remaining gas to sender.
 		st.state.AddBalance(st.msg.From(), remaining)
 	}
-
+	// Post-Atlas regular tx: no refund - remaining gas is burned.
+	
 	// Also return remaining gas to the block gas counter so it is
 	// available for the next transaction.
 	st.gp.AddGas(st.gas)

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -296,14 +296,15 @@ func (st *StateTransition) refundGas() {
 	// Return ETH for remaining gas, exchanged at the original rate.
 	remaining := new(big.Int).Mul(new(big.Int).SetUint64(st.gas), st.gasPrice)
 
-	if st.isVRC25Transaction() {
-		// VRC25-sponsored: delegate refund to the Viction hook.
+	// VRC25, Atlas gas, ...
+	isCustomGasRefunding := st.isVRC25Transaction() || st.evm.ChainConfig().IsAtlas(st.evm.Context.BlockNumber)
+
+	if isCustomGasRefunding {
 		st.vrc25RefundGas(remaining)
-	} else if !st.evm.ChainConfig().IsAtlas(st.evm.Context.BlockNumber) {
-		// Pre-Atlas regular tx: refund remaining gas to sender.
+	} else {
+		// If normal transaction, fallback to basic ETH refunding
 		st.state.AddBalance(st.msg.From(), remaining)
 	}
-	// Post-Atlas regular tx: no refund - remaining gas is burned.
 	
 	// Also return remaining gas to the block gas counter so it is
 	// available for the next transaction.

--- a/core/state_transition_viction.go
+++ b/core/state_transition_viction.go
@@ -9,11 +9,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/vrc25"
 )
 
-// activeFeeBalance holds the per-block running VRC25 fee capacity map for
-// the block currently being processed.  It is set by beforeProcess (via
-// victionProcessorState) and read by vrc25BuyGas during each transaction.
-var activeFeeBalance map[common.Address]*big.Int
-
 // vrc25BuyGas checks VRC25 sponsorship eligibility and adjusts payer/gasPrice.
 func (st *StateTransition) vrc25BuyGas() error {
 	st.payer = st.msg.From()

--- a/core/state_transition_viction.go
+++ b/core/state_transition_viction.go
@@ -9,6 +9,11 @@ import (
 	"github.com/ethereum/go-ethereum/core/vrc25"
 )
 
+// activeFeeBalance holds the per-block running VRC25 fee capacity map for
+// the block currently being processed.  It is set by beforeProcess (via
+// victionProcessorState) and read by vrc25BuyGas during each transaction.
+var activeFeeBalance map[common.Address]*big.Int
+
 // vrc25BuyGas checks VRC25 sponsorship eligibility and adjusts payer/gasPrice.
 func (st *StateTransition) vrc25BuyGas() error {
 	st.payer = st.msg.From()
@@ -17,18 +22,20 @@ func (st *StateTransition) vrc25BuyGas() error {
 	if victionConfig == nil || victionConfig.VRC25Contract == (common.Address{}) {
 		return nil
 	}
-	
-	feeCap := vrc25.GetFeeCapacity(st.state, victionConfig.VRC25Contract, st.msg.To())
-	if feeCap == nil || feeCap.Sign() == 0 {
-		return nil
-	}
 
 	blockNum := st.evm.Context.BlockNumber
 
 	if !st.evm.ChainConfig().IsAtlas(blockNum) {
-		// Pre-Atlas: token must be in the tokens[] array to be eligible.
-		// A token can have non-zero tokensState capacity but NOT be in the array
-		if !vrc25.IsTokenInArray(st.state, victionConfig.VRC25Contract, *st.msg.To()) {
+		// Pre-Atlas path: use the running activeFeeBalance map for eligibility.
+		// This map is loaded from state at block start (beforeProcess) and
+		// decremented after each VRC25 tx (afterApplyTransaction), ensuring
+		// correct capacity tracking across multiple txs to the same token.
+		if st.msg.To() == nil || activeFeeBalance == nil {
+			return nil
+		}
+		feeCap, ok := activeFeeBalance[*st.msg.To()]
+		if !ok || feeCap == nil {
+			// Token not in the registered list — treat as regular VIC tx.
 			return nil
 		}
 
@@ -41,12 +48,23 @@ func (st *StateTransition) vrc25BuyGas() error {
 
 		mgval := new(big.Int).Mul(new(big.Int).SetUint64(st.msg.Gas()), effectiveGasPrice)
 		if feeCap.Cmp(mgval) < 0 {
+			// Token is registered but capacity is insufficient — fall through
+			// to regular VIC path.  buyGas will then check the sender's VIC
+			// balance at the original gasPrice (which for VRC25 txs is
+			// typically 0, so this effectively rejects the tx with
+			// ErrInsufficientFunds
 			return nil
 		}
 		// Set payer = VRC25Contract so isVRC25Transaction() returns true.
 		// buyGas will skip the balance check and SubBalance for pre-Atlas sponsored txs.
 		st.gasPrice = effectiveGasPrice
 		st.payer = victionConfig.VRC25Contract
+		return nil
+	}
+
+	// Post-Atlas: read capacity from statedb (each tx writes back via vrc25RefundGas).
+	feeCap := vrc25.GetFeeCapacity(st.state, victionConfig.VRC25Contract, st.msg.To())
+	if feeCap == nil || feeCap.Sign() == 0 {
 		return nil
 	}
 

--- a/core/state_transition_viction.go
+++ b/core/state_transition_viction.go
@@ -83,29 +83,31 @@ func (st *StateTransition) isVRC25Transaction() bool {
 	return st.payer != st.msg.From()
 }
 
-// vrc25RefundGas handles gas refund for VRC25-sponsored transactions.
-// The caller (refundGas) guarantees this is only called when isVRC25Transaction() is true.
+// vrc25RefundGas handles gas refund for sponsored transactions.
 func (st *StateTransition) vrc25RefundGas(remaining *big.Int) {
-	blockNum := st.evm.Context.BlockNumber
-	if !st.evm.ChainConfig().IsAtlas(blockNum) {
-		// Pre-Atlas VRC25: buyGas was skipped entirely, nothing to refund.
-		return
-	}
+	if st.isVRC25Transaction() {
+		blockNum := st.evm.Context.BlockNumber
+		if !st.evm.ChainConfig().IsAtlas(blockNum) {
+			// Pre-Atlas VRC25: buyGas was skipped entirely, nothing to refund.
+			return
+		}
 
-	// Post-Atlas VRC25: deduct exactly gasUsed * price from the token's storage slot.
-	addr := st.msg.To()
-	victionConfig := st.evm.ChainConfig().Viction
-	vrc25Contract := victionConfig.VRC25Contract
-	feeCap := vrc25.GetFeeCapacity(st.state, vrc25Contract, addr)
-	if feeCap != nil {
-		gasUsedFee := new(big.Int).Mul(
-			new(big.Int).SetUint64(st.gasUsed()),
-			(*big.Int)(victionConfig.VRC25GasPrice),
-		)
-		vrc25.SetFeeCapacity(st.state, vrc25Contract, *addr, new(big.Int).Sub(feeCap, gasUsedFee))
+		// Post-Atlas VRC25: deduct exactly gasUsed * price from the token's storage slot.
+		addr := st.msg.To()
+		victionConfig := st.evm.ChainConfig().Viction
+		vrc25Contract := victionConfig.VRC25Contract
+		feeCap := vrc25.GetFeeCapacity(st.state, vrc25Contract, addr)
+		if feeCap != nil {
+			gasUsedFee := new(big.Int).Mul(
+				new(big.Int).SetUint64(st.gasUsed()),
+				(*big.Int)(victionConfig.VRC25GasPrice),
+			)
+			vrc25.SetFeeCapacity(st.state, vrc25Contract, *addr, new(big.Int).Sub(feeCap, gasUsedFee))
+		}
+		// Refund remaining native balance to the VRC25 issuer contract.
+		st.state.AddBalance(st.payer, remaining)
 	}
-	// Refund remaining native balance to the VRC25 issuer contract.
-	st.state.AddBalance(st.payer, remaining)
+	// Post-Atlas non-VRC25: no refund - remaining gas is burned.
 }
 
 // applyTransactionFee distributes the transaction fee to the correct recipient.

--- a/core/state_transition_viction.go
+++ b/core/state_transition_viction.go
@@ -83,28 +83,28 @@ func (st *StateTransition) isVRC25Transaction() bool {
 	return st.payer != st.msg.From()
 }
 
-// vrc25RefundGas handles gas refund for sponsored transactions.
+// vrc25RefundGas handles gas refund for VRC25-sponsored transactions.
+// The caller (refundGas) guarantees this is only called when isVRC25Transaction() is true.
 func (st *StateTransition) vrc25RefundGas(remaining *big.Int) {
-	if st.isVRC25Transaction() {
-		blockNum := st.evm.Context.BlockNumber
-		if !st.evm.ChainConfig().IsAtlas(blockNum) {
-			// Pre-Atlas: nothing
-			return
-		}
-
-		// Post-Atlas: deduct exactly gasUsed×price from the token's storage slot once.
-		addr := st.msg.To()
-		victionConfig := st.evm.ChainConfig().Viction
-		vrc25Contract := victionConfig.VRC25Contract
-		feeCap := vrc25.GetFeeCapacity(st.state, vrc25Contract, addr)
-		if feeCap != nil {
-			gasUsedFee := new(big.Int).Mul(
-				new(big.Int).SetUint64(st.gasUsed()),
-				(*big.Int)(victionConfig.VRC25GasPrice),
-			)
-			vrc25.SetFeeCapacity(st.state, vrc25Contract, *addr, new(big.Int).Sub(feeCap, gasUsedFee))
-		}
+	blockNum := st.evm.Context.BlockNumber
+	if !st.evm.ChainConfig().IsAtlas(blockNum) {
+		// Pre-Atlas VRC25: buyGas was skipped entirely, nothing to refund.
+		return
 	}
+
+	// Post-Atlas VRC25: deduct exactly gasUsed * price from the token's storage slot.
+	addr := st.msg.To()
+	victionConfig := st.evm.ChainConfig().Viction
+	vrc25Contract := victionConfig.VRC25Contract
+	feeCap := vrc25.GetFeeCapacity(st.state, vrc25Contract, addr)
+	if feeCap != nil {
+		gasUsedFee := new(big.Int).Mul(
+			new(big.Int).SetUint64(st.gasUsed()),
+			(*big.Int)(victionConfig.VRC25GasPrice),
+		)
+		vrc25.SetFeeCapacity(st.state, vrc25Contract, *addr, new(big.Int).Sub(feeCap, gasUsedFee))
+	}
+	// Refund remaining native balance to the VRC25 issuer contract.
 	st.state.AddBalance(st.payer, remaining)
 }
 

--- a/core/vrc25/vrc25.go
+++ b/core/vrc25/vrc25.go
@@ -128,26 +128,6 @@ func GetAllFeeCapacities(statedb vm.StateDB, vrc25Contract common.Address) map[c
 	return result
 }
 
-// IsTokenInArray reports whether addr appears in the VRC25 issuer contract's
-// tokens[] dynamic array (slot 1). Pre-Atlas, only tokens present in this
-// array are eligible for VRC25 sponsorship
-func IsTokenInArray(statedb vm.StateDB, vrc25Contract common.Address, addr common.Address) bool {
-	tokensSlot := state.StorageLocationFromSlot(SlotVRC25Contract["tokens"])
-	tokenCount := statedb.GetState(vrc25Contract, tokensSlot.Hash()).Big().Uint64()
-	for i := uint64(0); i < tokenCount; i++ {
-		elemKey := state.StorageLocationOfDynamicArrayElement(tokensSlot, i, 1)
-		tokenHash := statedb.GetState(vrc25Contract, elemKey.Hash())
-		if tokenHash == (common.Hash{}) {
-			continue
-		}
-		token := common.BytesToAddress(tokenHash.Bytes())
-		if token == addr {
-			return true
-		}
-	}
-	return false
-}
-
 // we use vm.StateDB interface instead of *StateDB
 func GetFeeCapacity(statedb vm.StateDB, vrc25Contract common.Address, addr *common.Address) *big.Int {
 	if addr == nil {

--- a/params/viction_specs/viction.json
+++ b/params/viction_specs/viction.json
@@ -49,6 +49,7 @@
       "validatorSignInterval": 15,
       "vrc25Contract": "0x8c0faeb5C6bEd2129b8674F262Fd45c4e9468bee",
       "vrc25GasPrice": "250000000",
+      "atlasVRC25MinCap": "1",
       "lendingLiquidateTradeBlock": 100,
       "saigonFundAddress": "0xeDC9f7873a33763c84b82157B034988728445a0E",
       "saigonFundAmount": "0x108b2a2c28029094000000",


### PR DESCRIPTION
## Overview
This PR is cumulative and includes all changes from #84. Merging this will effectively apply #84; I'm keeping it open to preserve its documentation.

## Problem
Syncing to block 97,705,094 (Atlas activation block) fails with:
`invalid merkle root (remote: 77513e1a...45ba local: 18a64a80...59e)`

Two bugs were causing the local state to diverge from mainnet.

## Root Cause
- _**Bug 1: Gas refund for non-VRC25 transactions post-Atlas :**_
In `victionchain`, post-Atlas regular (non-VRC25) transactions do **not** get remaining gas refunded - unused gas is burned. In `vic-geth`, `vrc25RefundGas()` unconditionally called `AddBalance(st.payer, remaining)` for all post-Atlas transactions, incorrectly refunding unused gas to senders of regular transactions.
- _**Bug 2: Missing `atlasVRC25MinCap` in chain config :**_
At the exact Atlas activation block, `victionchain` writes `minCap = 1 wei` to the VRC25 issuer contract's storage slot 0. In `vic-geth`, this write is gated by `config.AtlasVRC25MinCap != nil`, but the value was missing from all chain spec JSON files, silently skipping the state mutation.
- _**Bug 3 : PayFeeWithTRC21TxFail charges the token's minFee from the sender's token balance to the issuer - even post-Atlas :**_
In `vic-geth`, afterApplyTransaction was returning early for all post-Atlas blocks, skipping this state change entirely.
`victionchain` instead : 
`victionchain/core/state_processor.go#L488-491 :`

```
if balanceFee != nil && balanceFee.Cmp(fee) == 1 && failed {
		// No need to care about old blocks because tx with invalid will be dropped
		state.PayFeeWithTRC21TxFail(statedb, msg.From(), *tx.To())
}
```
This deducts minFee from the sender's token balance and credits it to the token issuer. `vic-geth` skips this entirely post-Atlas.
## Changes
1.  `core/state_transition_viction.go `: Fixed `vrc25RefundGas()` so that `AddBalance(st.payer, remaining)` only executes inside the `isVRC25Transaction()` branch. Post-Atlas non-VRC25 transactions now correctly burn remaining gas with no refund. 
2. `params/viction_specs/viction.json`:  Added `"atlasVRC25MinCap": "1"`.

3. ` vic-geth/core/state_processor_viction.go:454-470` : added a post-Atlas branch in `afterApplyTransaction` that calls `vrc25.PayFeeWithVRC25` when a VRC25-sponsored tx fails, matching victionchain's behavior.

> Note : 
> - Post-Atlas: reads fee capacity from state, checks sufficiency, calls PayFeeWithVRC25 on failure
> - Pre-Atlas: tracks running fee balance in-memory, accumulates deductions, calls PayFeeWithVRC25 on failure

4. Cleanup (from #84): Moved `activeFeeBalance` from `state_transition_viction.go` to `state_processor_viction.go` for better consistency with the current project structure. No logic changes involved.

## Verification
Compared the full transaction flow (`buyGas` → EVM execution → `refundGas` → fee distribution) between `victionchain` and `vic-geth` for all pre/post-Atlas × VRC25/regular combinations. Storage slot computation, contract addresses, gas prices, and fee distribution logic all match after these fixes.