### PR TITLE
fix: don't drop peer for blocks without attestor signature (phase 1)

### DIFF
--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -759,7 +759,7 @@ func (f *BlockFetcher) importHeaders(peer string, header *types.Header) {
 			return
 		}
 		// Validate the header and if something went wrong, drop the peer
-		if err := f.verifyHeader(header); err != nil && err != consensus.ErrFutureBlock {
+		if err := f.verifyHeader(header); err != nil && err != consensus.ErrFutureBlock && err != consensus.ErrNoValidatorSignature {
 			log.Debug("Propagated header verification failed", "peer", peer, "number", header.Number, "hash", hash, "err", err)
 			f.dropPeer(peer)
 			return
@@ -797,6 +797,13 @@ func (f *BlockFetcher) importBlocks(peer string, block *types.Block) {
 		switch err := f.verifyHeader(block.Header()); err {
 		case nil:
 			// All ok, quickly propagate to our peers
+			blockBroadcastOutTimer.UpdateSince(block.ReceivedAt)
+			go f.broadcastBlock(block, true)
+
+		case consensus.ErrNoValidatorSignature:
+			// Block from phase 1 without attestor signature, propagate to network
+			// so attesters can receive and sign it. Don't drop the peer.
+			log.Debug("Propagated block without attestor (phase 1)", "peer", peer, "number", block.Number(), "hash", hash)
 			blockBroadcastOutTimer.UpdateSince(block.ReceivedAt)
 			go f.broadcastBlock(block, true)
 

--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -803,9 +803,11 @@ func (f *BlockFetcher) importBlocks(peer string, block *types.Block) {
 		case consensus.ErrNoValidatorSignature:
 			// Block from phase 1 without attestor signature, propagate to network
 			// so attesters can receive and sign it. Don't drop the peer.
+			// Don't insert into local chain — wait for the attested version.
 			log.Debug("Propagated block without attestor (phase 1)", "peer", peer, "number", block.Number(), "hash", hash)
 			blockBroadcastOutTimer.UpdateSince(block.ReceivedAt)
 			go f.broadcastBlock(block, true)
+			return
 
 		case consensus.ErrFutureBlock:
 			// Weird future block, don't fail, but neither propagate


### PR DESCRIPTION
## Summary

- Stop dropping peers when receiving blocks without attestor signatures, which is normal in Viction consensus phase 1
- Rebroadcast such blocks to the network so attesters can receive and sign them
- Fixes the issue where nodes continuously drop and reconnect to peers after syncing to latest, because propagated phase-1 blocks fail verification with "no validator in header"

## Context

In Viction's PoSV consensus, validators broadcast blocks **without** attestor signatures in phase 1. Attesters then receive the block, sign it, and rebroadcast. The block fetcher was treating this as a malicious peer and dropping the connection, causing a reconnect loop.