### PR TITLE
fix:  conflict database between versions

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -146,6 +146,9 @@ func makeConfigNode(ctx *cli.Context) (*node.Node, gethConfig) {
 	}
 	utils.SetShhConfig(ctx, stack)
 
+	// Set TomoX data directory from --tomox.datadir (if provided).
+	utils.SetTomoXConfig(ctx, &cfg.Eth)
+
 	return stack, cfg
 }
 

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -161,6 +161,7 @@ var (
 		utils.GpoMaxGasPriceFlag,
 		utils.EWASMInterpreterFlag,
 		utils.EVMInterpreterFlag,
+		utils.TomoXDataDirFlag,
 		configFileFlag,
 	}
 

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -46,7 +46,7 @@ import (
 )
 
 const (
-	clientIdentifier = "geth" // Client identifier to advertise over the network
+	clientIdentifier = "tomo" // Client identifier to advertise over the network
 )
 
 var (

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -46,7 +46,7 @@ import (
 )
 
 const (
-	clientIdentifier = "tomo" // Client identifier to advertise over the network
+	clientIdentifier = "viction" // Client identifier to advertise over the network
 )
 
 var (

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -738,6 +738,13 @@ var (
 		Usage: "External EVM configuration (default = built-in interpreter)",
 		Value: "",
 	}
+
+	// TomoX data directory
+	TomoXDataDirFlag = DirectoryFlag{
+		Name:  "tomox.datadir",
+		Usage: "Data directory for the TomoX databases",
+		Value: DirectoryString(filepath.Join(DataDirFlag.Value.String(), "tomox")),
+	}
 )
 
 // MakeDataDir retrieves the currently requested data directory, terminating
@@ -1707,6 +1714,16 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 		if cfg.NetworkId == 1 {
 			SetDNSDiscoveryDefaults(cfg, params.MainnetGenesisHash)
 		}
+	}
+}
+
+// SetTomoXConfig sets the TomoX data directory on the eth config from the
+// --tomox.datadir CLI flag.
+// If the flag is not set, cfg.TomoXDataDir is left empty and the node will
+// use its instance directory (stack.ResolvePath("tomox")).
+func SetTomoXConfig(ctx *cli.Context, cfg *eth.Config) {
+	if ctx.GlobalIsSet(TomoXDataDirFlag.Name) {
+		cfg.TomoXDataDir = ctx.GlobalString(TomoXDataDirFlag.Name)
 	}
 }
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -743,7 +743,7 @@ var (
 	TomoXDataDirFlag = DirectoryFlag{
 		Name:  "tomox.datadir",
 		Usage: "Data directory for the TomoX databases",
-		Value: DirectoryString(filepath.Join(DataDirFlag.Value.String(), "tomox")),
+		Value: "",
 	}
 )
 

--- a/eth/backend_viction.go
+++ b/eth/backend_viction.go
@@ -292,25 +292,18 @@ func (eth *Ethereum) setupPosvBackend(chainConfig *params.ChainConfig, stack *no
 		}
 	}
 
-	// Initialize legacy TomoX trading engine for historical block replay.
-	// Required to sync pre-Atlas blocks containing TomoX order matching transactions (0x91).
-	tradingDb, err := stack.OpenDatabase("tomox", 256, 256, "eth/db/tomox/")
+	// Initialize legacy TomoX/TomoZ engines for historical block replay.
+	// Both share a single LevelDB ("tomox") since TradingStateDB and LendingStateDB
+	// use independent trie roots and their key-spaces never collide.
+	tomoxDb, err := stack.OpenDatabase("tomox", 256, 256, "eth/db/tomox/")
 	if err != nil {
-		log.Error("Failed to open TomoX trading database", "err", err)
+		log.Error("Failed to open TomoX database", "err", err)
 		return nil
 	}
-	tomoxEngine := tomox.NewWithDB(tradingDb, eth.blockchain.Config())
+	tomoxEngine := tomox.NewWithDB(tomoxDb, eth.blockchain.Config())
 	eth.blockchain.SetTradingEngine(tomoxEngine)
 
-	// Initialize legacy TomoZ lending engine for historical block replay.
-	// Required to sync pre-Atlas blocks containing TomoZ lending order transactions (0x93).
-	// Must share the same tomoxEngine instance so lending price lookups hit the same trading state.
-	lendingDb, err := stack.OpenDatabase("tomoxlending", 256, 256, "eth/db/tomoxlending/")
-	if err != nil {
-		log.Error("Failed to open TomoZ lending database", "err", err)
-		return nil
-	}
-	lendingEngine := tomoxlending.New(lendingDb, tomoxEngine, eth.blockchain.Config())
+	lendingEngine := tomoxlending.New(tomoxDb, tomoxEngine, eth.blockchain.Config())
 	eth.blockchain.SetLendingEngine(lendingEngine)
 
 	return nil

--- a/eth/backend_viction.go
+++ b/eth/backend_viction.go
@@ -13,6 +13,8 @@ import (
 	"github.com/ethereum/go-ethereum/eth/viction"
 	"github.com/ethereum/go-ethereum/legacy/tomox"
 	"github.com/ethereum/go-ethereum/legacy/tomoxlending"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/params"
@@ -272,6 +274,17 @@ func (s *Ethereum) PosvGetValidators(vicConfig *params.VictionConfig, header *ty
 
 // setupPosvBackend wires the POSV engine backend and the legacy TomoX/TomoZ engines
 // for historical block replay (pre-Atlas sync).
+// openTomoXDatabase opens the TomoX LevelDB.
+//   - If --tomox.datadir is set, that explicit path is used directly.
+//   - Otherwise the database is created at {datadir}/{instance}/tomox.
+func openTomoXDatabase(cfg *Config, stack *node.Node) (ethdb.Database, error) {
+	if cfg.TomoXDataDir != "" {
+		log.Info("Opening TomoX database at custom path", "path", cfg.TomoXDataDir)
+		return rawdb.NewLevelDBDatabase(cfg.TomoXDataDir, 256, 256, "eth/db/tomox/")
+	}
+	return stack.OpenDatabase("tomox", 256, 256, "eth/db/tomox/")
+}
+
 func (eth *Ethereum) setupPosvBackend(chainConfig *params.ChainConfig, stack *node.Node) error {
 	if chainConfig.Posv == nil {
 		return nil
@@ -295,7 +308,7 @@ func (eth *Ethereum) setupPosvBackend(chainConfig *params.ChainConfig, stack *no
 	// Initialize legacy TomoX/TomoZ engines for historical block replay.
 	// Both share a single LevelDB ("tomox") since TradingStateDB and LendingStateDB
 	// use independent trie roots and their key-spaces never collide.
-	tomoxDb, err := stack.OpenDatabase("tomox", 256, 256, "eth/db/tomox/")
+	tomoxDb, err := openTomoXDatabase(eth.config, stack)
 	if err != nil {
 		log.Error("Failed to open TomoX database", "err", err)
 		return nil

--- a/eth/config.go
+++ b/eth/config.go
@@ -187,4 +187,8 @@ type Config struct {
 
 	// CheckpointOracle is the configuration for checkpoint oracle.
 	CheckpointOracle *params.CheckpointOracleConfig `toml:",omitempty"`
+
+	// TomoXDataDir is the directory for the TomoX/TomoZ LevelDB.
+	// If empty, defaults to {DataDir}/{instance}/tomox (set by node.ResolvePath).
+	TomoXDataDir string `toml:",omitempty"`
 }

--- a/eth/gen_config.go
+++ b/eth/gen_config.go
@@ -56,6 +56,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		RPCTxFeeCap             float64                        `toml:",omitempty"`
 		Checkpoint              *params.TrustedCheckpoint      `toml:",omitempty"`
 		CheckpointOracle        *params.CheckpointOracleConfig `toml:",omitempty"`
+		TomoXDataDir            string                         `toml:",omitempty"`
 	}
 	var enc Config
 	enc.Genesis = c.Genesis
@@ -97,6 +98,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.RPCTxFeeCap = c.RPCTxFeeCap
 	enc.Checkpoint = c.Checkpoint
 	enc.CheckpointOracle = c.CheckpointOracle
+	enc.TomoXDataDir = c.TomoXDataDir
 	return &enc, nil
 }
 
@@ -142,6 +144,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		RPCTxFeeCap             *float64                       `toml:",omitempty"`
 		Checkpoint              *params.TrustedCheckpoint      `toml:",omitempty"`
 		CheckpointOracle        *params.CheckpointOracleConfig `toml:",omitempty"`
+		TomoXDataDir            *string                        `toml:",omitempty"`
 	}
 	var dec Config
 	if err := unmarshal(&dec); err != nil {
@@ -263,6 +266,9 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.CheckpointOracle != nil {
 		c.CheckpointOracle = dec.CheckpointOracle
+	}
+	if dec.TomoXDataDir != nil {
+		c.TomoXDataDir = *dec.TomoXDataDir
 	}
 	return nil
 }

--- a/node/datadir_migrate.go
+++ b/node/datadir_migrate.go
@@ -17,46 +17,40 @@ import (
 // Order matters: newer names are tried first.
 var legacyInstanceNames = []string{"tomo", "geth"}
 
-// prepareInstanceDirectory resolves {dataDir}/{targetName} for the running node.
-// When a legacy directory (tomo, geth) must be renamed to the target name, the
-// legacy LOCK is acquired before os.Rename so a concurrent node still using the
-// legacy path prevents the rename (and returns ErrDatadirUsed).
-func prepareInstanceDirectory(dataDir, targetName string) (instdir string, release fileutil.Releaser, err error) {
+// migrateLegacyInstanceDir renames a legacy instance directory (tomo, geth) to
+// the current instance name (e.g. viction) when the target does not exist yet.
+func migrateLegacyInstanceDir(dataDir, targetName string) (fileutil.Releaser, error) {
 	if dataDir == "" || targetName == "" {
-		return "", nil, nil
+		return nil, nil
 	}
 	target := filepath.Join(dataDir, targetName)
-
-	if !instanceDirHasData(target) {
-		for _, legacy := range legacyInstanceNames {
-			if legacy == targetName {
-				continue
-			}
-			src := filepath.Join(dataDir, legacy)
-			if !instanceDirHasData(src) {
-				continue
-			}
-			if common.FileExist(target) {
-				return "", nil, fmt.Errorf("cannot migrate instance datadir from %q to %q: destination path already exists; remove or rename %q, then restart",src, target, target)
-			}
-			release, _, err := fileutil.Flock(filepath.Join(src, "LOCK"))
-			if err != nil {
-				return "", nil, err
-			}
-			log.Info("Migrating instance datadir", "from", src, "to", target)
-			if err := os.Rename(src, target); err != nil {
-				release.Release()
-				return "", nil, err
-			}
-			return target, release, nil
-		}
-		if err := os.MkdirAll(target, 0700); err != nil {
-			return "", nil, err
-		}
+	if instanceDirHasData(target) {
+		return nil, nil
 	}
+	for _, legacy := range legacyInstanceNames {
+		if legacy == targetName {
+			continue
+		}
+		src := filepath.Join(dataDir, legacy)
+		if !instanceDirHasData(src) {
+			continue
+		}
+		if common.FileExist(target) {
+			return nil, fmt.Errorf("cannot migrate instance datadir from %q to %q: destination path already exists; remove or rename %q, then restart", src, target, target)
+		}
+		release, _, err := fileutil.Flock(filepath.Join(src, "LOCK"))
+		if err != nil {
+			return nil, err
+		}
 
-	release, _, err = fileutil.Flock(filepath.Join(target, "LOCK"))
-	return target, release, err
+		log.Info("Migrating instance datadir", "from", src, "to", target)
+		if err := os.Rename(src, target); err != nil {
+			release.Release()
+			return nil, err
+		}
+		return release, nil
+	}
+	return nil, nil
 }
 
 func instanceDirHasData(dir string) bool {

--- a/node/datadir_migrate.go
+++ b/node/datadir_migrate.go
@@ -45,7 +45,6 @@ func migrateLegacyInstanceDir(dataDir, targetName string) (fileutil.Releaser, er
 
 		log.Info("Migrating instance datadir", "from", src, "to", target)
 		if err := os.Rename(src, target); err != nil {
-			release.Release()
 			return nil, err
 		}
 		return release, nil

--- a/node/datadir_migrate.go
+++ b/node/datadir_migrate.go
@@ -13,43 +13,50 @@ import (
 	"github.com/prometheus/tsdb/fileutil"
 )
 
-// legacyInstanceNames lists historical instance directory names under DataDir.
-// Order matters: newer names are tried first.
-var legacyInstanceNames = []string{"tomo", "geth"}
+// legacyInstanceDir is the historical instance directory name that may need
+// to be migrated to the current instance name (e.g. "viction").
+const legacyInstanceDir = "tomo"
 
-// migrateLegacyInstanceDir renames a legacy instance directory (tomo, geth) to
-// the current instance name (e.g. viction) when the target does not exist yet.
-func migrateLegacyInstanceDir(dataDir, targetName string) (fileutil.Releaser, error) {
-	if dataDir == "" || targetName == "" {
-		return nil, nil
-	}
-	target := filepath.Join(dataDir, targetName)
-	if instanceDirHasData(target) {
-		return nil, nil
-	}
-	for _, legacy := range legacyInstanceNames {
-		if legacy == targetName {
-			continue
-		}
-		src := filepath.Join(dataDir, legacy)
-		if !instanceDirHasData(src) {
-			continue
-		}
-		if common.FileExist(target) {
-			return nil, fmt.Errorf("cannot migrate instance datadir from %q to %q: destination path already exists; remove or rename %q, then restart", src, target, target)
-		}
-		release, _, err := fileutil.Flock(filepath.Join(src, "LOCK"))
-		if err != nil {
-			return nil, err
-		}
+// migrateLegacyInstanceDir resolves the instance directory path and migrates
+// the legacy "tomo" directory to targetName when needed.
+//
+// Returns:
+//   - instdir: the resolved instance directory path (always set when no error)
+//   - release: non-nil only when migration happened; holds the lock on the
+//     moved LOCK file and must be assigned to n.dirLock by the caller
+//   - err: non-nil if migration was attempted but failed
+func migrateLegacyInstanceDir(dataDir, targetName string) (instdir string, release fileutil.Releaser, err error) {
+	instdir = filepath.Join(dataDir, targetName)
 
-		log.Info("Migrating instance datadir", "from", src, "to", target)
-		if err := os.Rename(src, target); err != nil {
-			return nil, err
-		}
-		return release, nil
+	// Skip migration if the target already has node data or if the target
+	// name is the legacy name itself.
+	if instanceDirHasData(instdir) || targetName == legacyInstanceDir {
+		return instdir, nil, nil
 	}
-	return nil, nil
+
+	src := filepath.Join(dataDir, legacyInstanceDir)
+	if !instanceDirHasData(src) {
+		return instdir, nil, nil
+	}
+
+	// Guard against renaming over an existing (but empty) target directory.
+	if common.FileExist(instdir) {
+		return "", nil, fmt.Errorf(
+			"cannot migrate instance datadir from %q to %q: destination already exists; remove or rename %q, then restart",
+			src, instdir, instdir,
+		)
+	}
+
+	release, _, err = fileutil.Flock(filepath.Join(src, "LOCK"))
+	if err != nil {
+		return "", nil, err
+	}
+
+	log.Info("Migrating instance datadir", "from", src, "to", instdir)
+	if err = os.Rename(src, instdir); err != nil {
+		return "", nil, err
+	}
+	return instdir, release, nil
 }
 
 func instanceDirHasData(dir string) bool {

--- a/node/datadir_migrate.go
+++ b/node/datadir_migrate.go
@@ -1,0 +1,61 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+
+package node
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// legacyInstanceNames lists historical instance directory names under DataDir.
+// Order matters: newer names are tried first.
+var legacyInstanceNames = []string{"tomo", "geth"}
+
+// migrateLegacyInstanceDir renames a legacy instance directory (tomo, geth) to
+// the current instance name (e.g. viction) when the target does not exist yet.
+func migrateLegacyInstanceDir(dataDir, targetName string) error {
+	if dataDir == "" || targetName == "" {
+		return nil
+	}
+	target := filepath.Join(dataDir, targetName)
+	if instanceDirHasData(target) {
+		return nil
+	}
+	for _, legacy := range legacyInstanceNames {
+		if legacy == targetName {
+			continue
+		}
+		src := filepath.Join(dataDir, legacy)
+		if !instanceDirHasData(src) {
+			continue
+		}
+		if common.FileExist(target) {
+			return fmt.Errorf("legacy datadir %q exists but %q is already present; migrate or remove %q manually", src, target, target)
+		}
+		log.Info("Migrating instance datadir", "from", src, "to", target)
+		return os.Rename(src, target)
+	}
+	return nil
+}
+
+func instanceDirHasData(dir string) bool {
+	for _, name := range []string{"chaindata", "LOCK", datadirPrivateKey} {
+		if common.FileExist(filepath.Join(dir, name)) {
+			return true
+		}
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		return false
+	}
+	if !info.IsDir() {
+		return false
+	}
+	entries, err := os.ReadDir(dir)
+	return err == nil && len(entries) > 0
+}

--- a/node/datadir_migrate.go
+++ b/node/datadir_migrate.go
@@ -10,37 +10,53 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/prometheus/tsdb/fileutil"
 )
 
 // legacyInstanceNames lists historical instance directory names under DataDir.
 // Order matters: newer names are tried first.
 var legacyInstanceNames = []string{"tomo", "geth"}
 
-// migrateLegacyInstanceDir renames a legacy instance directory (tomo, geth) to
-// the current instance name (e.g. viction) when the target does not exist yet.
-func migrateLegacyInstanceDir(dataDir, targetName string) error {
+// prepareInstanceDirectory resolves {dataDir}/{targetName} for the running node.
+// When a legacy directory (tomo, geth) must be renamed to the target name, the
+// legacy LOCK is acquired before os.Rename so a concurrent node still using the
+// legacy path prevents the rename (and returns ErrDatadirUsed).
+func prepareInstanceDirectory(dataDir, targetName string) (instdir string, release fileutil.Releaser, err error) {
 	if dataDir == "" || targetName == "" {
-		return nil
+		return "", nil, nil
 	}
 	target := filepath.Join(dataDir, targetName)
-	if instanceDirHasData(target) {
-		return nil
+
+	if !instanceDirHasData(target) {
+		for _, legacy := range legacyInstanceNames {
+			if legacy == targetName {
+				continue
+			}
+			src := filepath.Join(dataDir, legacy)
+			if !instanceDirHasData(src) {
+				continue
+			}
+			if common.FileExist(target) {
+				return "", nil, fmt.Errorf("cannot migrate instance datadir from %q to %q: destination path already exists; remove or rename %q, then restart",src, target, target)
+			}
+			release, _, err := fileutil.Flock(filepath.Join(src, "LOCK"))
+			if err != nil {
+				return "", nil, err
+			}
+			log.Info("Migrating instance datadir", "from", src, "to", target)
+			if err := os.Rename(src, target); err != nil {
+				release.Release()
+				return "", nil, err
+			}
+			return target, release, nil
+		}
+		if err := os.MkdirAll(target, 0700); err != nil {
+			return "", nil, err
+		}
 	}
-	for _, legacy := range legacyInstanceNames {
-		if legacy == targetName {
-			continue
-		}
-		src := filepath.Join(dataDir, legacy)
-		if !instanceDirHasData(src) {
-			continue
-		}
-		if common.FileExist(target) {
-			return fmt.Errorf("legacy datadir %q exists but %q is already present; migrate or remove %q manually", src, target, target)
-		}
-		log.Info("Migrating instance datadir", "from", src, "to", target)
-		return os.Rename(src, target)
-	}
-	return nil
+
+	release, _, err = fileutil.Flock(filepath.Join(target, "LOCK"))
+	return target, release, err
 }
 
 func instanceDirHasData(dir string) bool {

--- a/node/node.go
+++ b/node/node.go
@@ -298,6 +298,10 @@ func (n *Node) openDataDir() error {
 		return nil // ephemeral
 	}
 
+	if err := migrateLegacyInstanceDir(n.config.DataDir, n.config.name()); err != nil {
+		return err
+	}
+
 	instdir := filepath.Join(n.config.DataDir, n.config.name())
 	if err := os.MkdirAll(instdir, 0700); err != nil {
 		return err

--- a/node/node.go
+++ b/node/node.go
@@ -298,15 +298,22 @@ func (n *Node) openDataDir() error {
 		return nil // ephemeral
 	}
 
-	instdir, release, err := prepareInstanceDirectory(n.config.DataDir, n.config.name())
+	release, err := migrateLegacyInstanceDir(n.config.DataDir, n.config.name())
 	if err != nil {
 		return convertFileLockError(err)
 	}
-	n.dirLock = release
-	if instdir != "" {
-		n.log.Info("Using instance directory", "instdir", instdir)
+
+	instdir := filepath.Join(n.config.DataDir, n.config.name())
+	if err := os.MkdirAll(instdir, 0700); err != nil {
+		return err
 	}
-	return nil
+
+	if release != nil {
+		n.dirLock = release
+		return nil
+	}
+	n.dirLock, _, err = fileutil.Flock(filepath.Join(instdir, "LOCK"))
+	return convertFileLockError(err)
 }
 
 func (n *Node) closeDataDir() {

--- a/node/node.go
+++ b/node/node.go
@@ -298,21 +298,14 @@ func (n *Node) openDataDir() error {
 		return nil // ephemeral
 	}
 
-	if err := migrateLegacyInstanceDir(n.config.DataDir, n.config.name()); err != nil {
-		return err
-	}
-
-	instdir := filepath.Join(n.config.DataDir, n.config.name())
-	if err := os.MkdirAll(instdir, 0700); err != nil {
-		return err
-	}
-	// Lock the instance directory to prevent concurrent use by another instance as well as
-	// accidental use of the instance directory as a database.
-	release, _, err := fileutil.Flock(filepath.Join(instdir, "LOCK"))
+	instdir, release, err := prepareInstanceDirectory(n.config.DataDir, n.config.name())
 	if err != nil {
 		return convertFileLockError(err)
 	}
 	n.dirLock = release
+	if instdir != "" {
+		n.log.Info("Using instance directory", "instdir", instdir)
+	}
 	return nil
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -298,20 +298,25 @@ func (n *Node) openDataDir() error {
 		return nil // ephemeral
 	}
 
-	release, err := migrateLegacyInstanceDir(n.config.DataDir, n.config.name())
+	instdir, release, err := migrateLegacyInstanceDir(n.config.DataDir, n.config.name())
 	if err != nil {
 		return convertFileLockError(err)
 	}
 
-	instdir := filepath.Join(n.config.DataDir, n.config.name())
-	if err := os.MkdirAll(instdir, 0700); err != nil {
-		return err
-	}
-
+	// check if migration happened and if so, no need to acquire lock
 	if release != nil {
+		// Migration happened: lock was acquired on the source LOCK file,
+		// which moved with the directory — no need to Flock again.
 		n.dirLock = release
 		return nil
 	}
+
+	// create instance directory if it doesn't exist
+	if err := os.MkdirAll(instdir, 0700); err != nil {
+		return convertFileLockError(err)
+	}
+
+	// No migration: acquire an exclusive lock to prevent concurrent use.
 	n.dirLock, _, err = fileutil.Flock(filepath.Join(instdir, "LOCK"))
 	return convertFileLockError(err)
 }


### PR DESCRIPTION
## Summary

Changed the client identifier from `"geth"` / `"tomo"` to `"viction"` in `cmd/geth/main.go` to properly brand the node and ensure consistent default data directories across the Viction network stack.

Added support for a new `--tomox.datadir` flag to allow customization of the TomoX data directory.

## Root Cause

The `clientIdentifier` constant was still inherited from the upstream `go-ethereum` and older `victionchain` codebases (set to `"geth"` or `"tomo"`). This identifier is used to determine default data paths and the node name advertised on the p2p network.

As a result:
- Upgrading nodes caused the new binary to use a different default data directory, leading to creation of a new database folder.
- This resulted in apparent data loss and connection/sync issues for users.
- There was no way to customize the TomoX data directory, increasing the risk of data loss during migration.

## Changes

- Updated `clientIdentifier` to `"viction"` in `cmd/geth/main.go`.
- Added new CLI flag `--tomox.datadir` to specify a custom path for TomoX data.

## Migration Guide

### 1. Starting a new node
- No need to set `--tomox.datadir`
- Example :
```bash
geth --datadir ~/tomochain-chain \
  --viction \
  --identity my-full-node \
  --gasprice 250000000 \
  --rpc --rpcaddr 0.0.0.0 --rpcport 8545 --rpcvhosts "*" --rpccorsdomain "*" \
  --rpcapi "eth,debug,net,personal,web3" \
  --ws --wsaddr 0.0.0.0 --wsport 8546 --wsorigins "*" \
  --port 30303 \
  --syncmode full --gcmode full \
  --verbosity 3
```
### 2. Migrating from victionchain / old vic-geth
- Set the value of `tomox.datadir` to be similar to the current datadir
- Example: 
```bash
geth --datadir ~/tomochain-chain \
  --viction \
  --tomox.datadir path/to/current/tomox/data
  --identity my-full-node \
  --gasprice 250000000 \
  --rpc --rpcaddr 0.0.0.0 --rpcport 8545 --rpcvhosts "*" --rpccorsdomain "*" \
  --rpcapi "eth,debug,net,personal,web3" \
  --ws --wsaddr 0.0.0.0 --wsport 8546 --wsorigins "*" \
  --port 30303 \
  --syncmode full --gcmode full \
  --verbosity 3
```

**Changes made:**
- Replaced `/path/to/current/tomox/data` with  real current tomox datadir