### PR TITLE
feat: add GetRewardByNumber and GetRewardByHashOrNumber methods and Exposed Viction APIs through IPC

### DIFF
--- a/eth/api_backend_viction.go
+++ b/eth/api_backend_viction.go
@@ -14,6 +14,8 @@ import (
 )
 
 // GetRewardByHash returns the epoch reward breakdown for the checkpoint block identified by hash.
+// GetRewardByNumber returns the epoch reward breakdown for the checkpoint block identified by number.
+// GetRewardByHashOrNumber returns the epoch reward breakdown for the checkpoint block identified by hash or number.
 //
 // Use this when you want to know how rewards were distributed at the end of a specific epoch.
 // The hash must be the hash of a checkpoint block (block number divisible by epoch size, e.g. 900,
@@ -33,20 +35,51 @@ func (s *EthAPIBackend) GetRewardByHash(ctx context.Context, hash common.Hash) (
 	if err != nil {
 		return nil, err
 	}
-	if header == nil || header.Number.Uint64()%s.eth.blockchain.Config().Posv.Epoch != 0 {
-		return nil, errors.New("header is not a checkpoint block")
-	}
-	engine := s.Engine().(*posv.Posv)
-	statedb, err := s.eth.blockchain.StateAt(header.Root)
+	return s.getEpochRewardByCheckpointHeader(header)
+}
+
+func (s *EthAPIBackend) GetRewardByNumber(ctx context.Context, number rpc.BlockNumber) (*posv.EpochReward, error) {
+	header, err := s.HeaderByNumber(ctx, number)
 	if err != nil {
-		log.Info("Failed to get state at", "hash", hash, "error", err)
 		return nil, err
 	}
+	return s.getEpochRewardByCheckpointHeader(header)
+}
+
+func (s *EthAPIBackend) GetRewardByHashOrNumber(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*posv.EpochReward, error) {
+	header, err := s.HeaderByNumberOrHash(ctx, blockNrOrHash)
+	if err != nil {
+		return nil, err
+	}
+	return s.getEpochRewardByCheckpointHeader(header)
+}
+
+func (s *EthAPIBackend) getEpochRewardByCheckpointHeader(header *types.Header) (*posv.EpochReward, error) {
+	if header == nil {
+		return nil, errors.New("header is not a checkpoint block")
+	}
+
+	cfg := s.eth.blockchain.Config()
+	if header.Number.Uint64()%cfg.Posv.Epoch != 0 {
+		return nil, errors.New("header is not a checkpoint block")
+	}
+
+	engine, ok := s.Engine().(*posv.Posv)
+	if !ok {
+		return nil, errors.New("engine is not a posv engine")
+	}
+
+	statedb, err := s.eth.blockchain.StateAt(header.Root)
+	if err != nil {
+		log.Info("Failed to get state at", "root", header.Root, "error", err)
+		return nil, err
+	}
+
 	epochReward, err := s.eth.PosvGetEpochReward(
 		engine,
-		s.eth.blockchain.Config(),
-		s.eth.blockchain.Config().Posv,
-		s.eth.blockchain.Config().Viction,
+		cfg,
+		cfg.Posv,
+		cfg.Viction,
 		header,
 		s.eth.blockchain,
 		statedb,
@@ -59,8 +92,8 @@ func (s *EthAPIBackend) GetRewardByHash(ctx context.Context, hash common.Hash) (
 		return nil, errors.New("epoch reward is nil")
 	}
 	return epochReward, nil
-
 }
+
 
 func (s *EthAPIBackend) GetAttestorsPairsByHash(ctx context.Context, hash common.Hash) (map[common.Address]common.Address, error) {
 	header, err := s.HeaderByHash(ctx, hash)

--- a/eth/api_backend_viction.go
+++ b/eth/api_backend_viction.go
@@ -14,22 +14,12 @@ import (
 )
 
 // GetRewardByHash returns the epoch reward breakdown for the checkpoint block identified by hash.
-// GetRewardByNumber returns the epoch reward breakdown for the checkpoint block identified by number.
-// GetRewardByHashOrNumber returns the epoch reward breakdown for the checkpoint block identified by hash or number.
-//
-// Use this when you want to know how rewards were distributed at the end of a specific epoch.
-// The hash must be the hash of a checkpoint block (block number divisible by epoch size, e.g. 900,
+// The hash must identify a checkpoint block (block number divisible by the epoch size, e.g. 900,
 // 1800, 2700 ...). Passing a non-checkpoint hash returns an error.
 //
 // Note: requires the state trie at that block to be available. On a pruning (full-sync) node,
-// state is only kept for the most recent ~128 blocks. Querying an older checkpoint will fail
-// with "missing trie node" unless the node is running in archive mode (--gcmode=archive).
-//
-// Example (JSON-RPC):
-//
-//	curl -X POST http://localhost:8545 \
-//	  -H "Content-Type: application/json" \
-//	  -d '{"jsonrpc":"2.0","method":"eth_getRewardByHash","params":["0x<checkpoint-block-hash>"],"id":1}'
+// state is only kept for the most recent ~128 blocks; querying an older checkpoint will fail
+// with "missing trie node" unless the node runs in archive mode (--gcmode=archive).
 func (s *EthAPIBackend) GetRewardByHash(ctx context.Context, hash common.Hash) (*posv.EpochReward, error) {
 	header, err := s.HeaderByHash(ctx, hash)
 	if err != nil {
@@ -38,6 +28,13 @@ func (s *EthAPIBackend) GetRewardByHash(ctx context.Context, hash common.Hash) (
 	return s.getEpochRewardByCheckpointHeader(header)
 }
 
+// GetRewardByNumber returns the epoch reward breakdown for the checkpoint block at the given number.
+// The block number must be divisible by the epoch size (e.g. 900, 1800, 2700 ...).
+// Passing a non-checkpoint number returns an error.
+//
+// Note: requires the state trie at that block to be available. On a pruning (full-sync) node,
+// state is only kept for the most recent ~128 blocks; querying an older checkpoint will fail
+// with "missing trie node" unless the node runs in archive mode (--gcmode=archive).
 func (s *EthAPIBackend) GetRewardByNumber(ctx context.Context, number rpc.BlockNumber) (*posv.EpochReward, error) {
 	header, err := s.HeaderByNumber(ctx, number)
 	if err != nil {
@@ -46,6 +43,13 @@ func (s *EthAPIBackend) GetRewardByNumber(ctx context.Context, number rpc.BlockN
 	return s.getEpochRewardByCheckpointHeader(header)
 }
 
+// GetRewardByHashOrNumber returns the epoch reward breakdown for the checkpoint block identified
+// by either a block hash or a block number. The resolved block must be a checkpoint block
+// (block number divisible by the epoch size). Passing a non-checkpoint identifier returns an error.
+//
+// Note: requires the state trie at that block to be available. On a pruning (full-sync) node,
+// state is only kept for the most recent ~128 blocks; querying an older checkpoint will fail
+// with "missing trie node" unless the node runs in archive mode (--gcmode=archive).
 func (s *EthAPIBackend) GetRewardByHashOrNumber(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*posv.EpochReward, error) {
 	header, err := s.HeaderByNumberOrHash(ctx, blockNrOrHash)
 	if err != nil {

--- a/eth/api_backend_viction.go
+++ b/eth/api_backend_viction.go
@@ -71,7 +71,7 @@ func (s *EthAPIBackend) getEpochRewardByCheckpointHeader(header *types.Header) (
 
 	statedb, err := s.eth.blockchain.StateAt(header.Root)
 	if err != nil {
-		log.Info("Failed to get state at", "root", header.Root, "error", err)
+		log.Info("Failed to get state at", "hash", header.Hash(), "error", err)
 		return nil, err
 	}
 

--- a/eth/api_backend_viction.go
+++ b/eth/api_backend_viction.go
@@ -56,7 +56,7 @@ func (s *EthAPIBackend) GetRewardByHashOrNumber(ctx context.Context, blockNrOrHa
 
 func (s *EthAPIBackend) getEpochRewardByCheckpointHeader(header *types.Header) (*posv.EpochReward, error) {
 	if header == nil {
-		return nil, errors.New("header is not a checkpoint block")
+		return nil, errors.New("header at block number or hash is not found")
 	}
 
 	cfg := s.eth.blockchain.Config()
@@ -93,7 +93,6 @@ func (s *EthAPIBackend) getEpochRewardByCheckpointHeader(header *types.Header) (
 	}
 	return epochReward, nil
 }
-
 
 func (s *EthAPIBackend) GetAttestorsPairsByHash(ctx context.Context, hash common.Hash) (map[common.Address]common.Address, error) {
 	header, err := s.HeaderByHash(ctx, hash)

--- a/internal/ethapi/api_viction.go
+++ b/internal/ethapi/api_viction.go
@@ -31,8 +31,12 @@ func (s *PublicVictionBlockChainAPI) GetRewardByHash(ctx context.Context, hash c
 	return s.b.GetRewardByHash(ctx, hash)
 }
 
-func (s *PublicVictionBlockChainAPI) GetBlockFinalityByHash(ctx context.Context, hash common.Hash) (uint, error) {
-	return s.b.GetBlockFinalityByHash(ctx, hash)
+func (s *PublicVictionBlockChainAPI) GetRewardByNumber(ctx context.Context, number rpc.BlockNumber) (*posv.EpochReward, error) {
+	return s.b.GetRewardByNumber(ctx, number)
+}
+
+func (s *PublicVictionBlockChainAPI) GetRewardByHashOrNumber(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*posv.EpochReward, error) {
+	return s.b.GetRewardByHashOrNumber(ctx, blockNrOrHash)
 }
 
 func (s *PublicVictionBlockChainAPI) GetBlockFinalityByNumber(ctx context.Context, number rpc.BlockNumber) (uint, error) {

--- a/internal/ethapi/api_viction.go
+++ b/internal/ethapi/api_viction.go
@@ -39,6 +39,10 @@ func (s *PublicVictionBlockChainAPI) GetRewardByHashOrNumber(ctx context.Context
 	return s.b.GetRewardByHashOrNumber(ctx, blockNrOrHash)
 }
 
+func (s *PublicVictionBlockChainAPI) GetBlockFinalityByHash(ctx context.Context, hash common.Hash) (uint, error) {
+	return s.b.GetBlockFinalityByHash(ctx, hash)
+}
+
 func (s *PublicVictionBlockChainAPI) GetBlockFinalityByNumber(ctx context.Context, number rpc.BlockNumber) (uint, error) {
 	return s.b.GetBlockFinalityByNumber(ctx, number)
 }

--- a/internal/ethapi/backend_viction.go
+++ b/internal/ethapi/backend_viction.go
@@ -15,6 +15,8 @@ import (
 type BackendViction interface {
 	Backend
 	GetRewardByHash(ctx context.Context, hash common.Hash) (*posv.EpochReward, error)
+	GetRewardByNumber(ctx context.Context, number rpc.BlockNumber) (*posv.EpochReward, error)
+	GetRewardByHashOrNumber(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*posv.EpochReward, error)
 	GetAttestorsPairsByHash(ctx context.Context, hash common.Hash) (map[common.Address]common.Address, error)
 	GetAttestorsPairsByNumber(ctx context.Context, number rpc.BlockNumber) (map[common.Address]common.Address, error)
 	GetBlockFinalityByHash(ctx context.Context, blockHash common.Hash) (uint, error)

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -23,10 +23,11 @@ var Modules = map[string]string{
 	"chequebook": ChequebookJs,
 	"clique":     CliqueJs,
 	"posv":       PosvJs,
-	"viction":    VictionJs,
 	"ethash":     EthashJs,
 	"debug":      DebugJs,
-	"eth":        EthJs,
+	// Load Viction helpers under the eth module so they're always available
+	// wherever eth is exposed by the node.
+	"eth":      EthJs + VictionJs,
 	"miner":      MinerJs,
 	"net":        NetJs,
 	"personal":   PersonalJs,
@@ -944,49 +945,62 @@ web3._extend({
 	]
 });
 `
+// VictionJs extends the eth namespace with Viction/PoSV-specific methods.
+//
+// All RPC calls use the eth_ prefix so they work over HTTP, WS and IPC without
+// needing a separate namespace.  A convenience sub-object eth.viction mirrors
+// every method for discoverability and to allow a clean cut-over in future.
 const VictionJs = `
 web3._extend({
 	property: 'eth',
 	methods: [
-			new web3._extend.Method({
-				name: 'getRewardByHash',
-				call: 'eth_getRewardByHash',
-				params: 1
-			}),
-			new web3._extend.Method({
-				name: 'getAttestorsPairsByHash',
-				call: 'eth_getAttestorsPairsByHash',
-				params: 1
-			}),
-			new web3._extend.Method({
-				name: 'getAttestorsPairsByNumber',
-				call: 'eth_getAttestorsPairsByNumber',
-				params: 1
-			}),
-			new web3._extend.Method({
-    			name: 'getBlockFinalityByHash',
-    			call: 'eth_getBlockFinalityByHash',
-    			params: 1
-			}),
-			new web3._extend.Method({
-    			name: 'getBlockFinalityByNumber',
-    			call: 'eth_getBlockFinalityByNumber',
-    			params: 1
-			}),
-	],
-	properties: [
-		new web3._extend.Property({
-			name: 'pendingTransactions',
-			getter: 'eth_pendingTransactions',
-			outputFormatter: function(txs) {
-				var formatted = [];
-				for (var i = 0; i < txs.length; i++) {
-					formatted.push(web3._extend.formatters.outputTransactionFormatter(txs[i]));
-					formatted[i].blockHash = null;
-				}
-				return formatted;
-			}
+		new web3._extend.Method({
+			name: 'getRewardByHash',
+			call: 'eth_getRewardByHash',
+			params: 1
+		}),
+		new web3._extend.Method({
+			name: 'getRewardByNumber',
+			call: 'eth_getRewardByNumber',
+			params: 1
+		}),
+		new web3._extend.Method({
+			name: 'getRewardByHashOrNumber',
+			call: 'eth_getRewardByHashOrNumber',
+			params: 1
+		}),
+		new web3._extend.Method({
+			name: 'getAttestorsPairsByHash',
+			call: 'eth_getAttestorsPairsByHash',
+			params: 1
+		}),
+		new web3._extend.Method({
+			name: 'getAttestorsPairsByNumber',
+			call: 'eth_getAttestorsPairsByNumber',
+			params: 1
+		}),
+		new web3._extend.Method({
+			name: 'getBlockFinalityByHash',
+			call: 'eth_getBlockFinalityByHash',
+			params: 1
+		}),
+		new web3._extend.Method({
+			name: 'getBlockFinalityByNumber',
+			call: 'eth_getBlockFinalityByNumber',
+			params: 1
 		}),
 	]
 });
+(function() {
+	var vic = {};
+	var methods = [
+		'getRewardByHash', 'getRewardByNumber', 'getRewardByHashOrNumber',
+		'getAttestorsPairsByHash', 'getAttestorsPairsByNumber',
+		'getBlockFinalityByHash', 'getBlockFinalityByNumber'
+	];
+	for (var i = 0; i < methods.length; i++) {
+		vic[methods[i]] = web3.eth[methods[i]];
+	}
+	web3.eth.viction = vic;
+})();
 `

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -948,7 +948,6 @@ web3._extend({
 // VictionJs extends the eth namespace with Viction/PoSV-specific methods.
 //
 // All RPC calls use the eth_ prefix so they work over HTTP, WS and IPC without
-// needing a separate namespace.  A convenience sub-object eth.viction mirrors
 // every method for discoverability and to allow a clean cut-over in future.
 const VictionJs = `
 web3._extend({

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -991,16 +991,4 @@ web3._extend({
 		}),
 	]
 });
-(function() {
-	var vic = {};
-	var methods = [
-		'getRewardByHash', 'getRewardByNumber', 'getRewardByHashOrNumber',
-		'getAttestorsPairsByHash', 'getAttestorsPairsByNumber',
-		'getBlockFinalityByHash', 'getBlockFinalityByNumber'
-	];
-	for (var i = 0; i < methods.length; i++) {
-		vic[methods[i]] = web3.eth[methods[i]];
-	}
-	web3.eth.viction = vic;
-})();
 `


### PR DESCRIPTION
## Summary

- Added two RPC APIs: `GetRewardByNumber` and `GetRewardByHashOrNumber`
- Exposed Viction APIs through IPC.

## Root cause :
- Vic-Geth was missing several PoSV-related RPC APIs, including APIs for retrieving rewards by block number and by block hash/number.
- Viction-specific APIs such as getRewardByHash and getRewardByNumber could not be accessed through IPC.

## Solution :
- Add missing API 
-  Refactored in `web3ext.go` to enable Viction APIs to be used through IPC.