### PR TITLE
params: remove viction case from KnownDNSNetwork

### DIFF
--- a/params/bootnodes.go
+++ b/params/bootnodes.go
@@ -98,8 +98,6 @@ func KnownDNSNetwork(genesis common.Hash, protocol string) string {
 		net = "rinkeby"
 	case GoerliGenesisHash:
 		net = "goerli"
-	case VictionGenesisHash:
-		net = "viction"
 	default:
 		return ""
 	}


### PR DESCRIPTION
Remove the viction case from `KnownDNSNetwork` as it is unused.