### PR TITLE
feat: implement migration for legacy TomoX database directory

### DIFF
--- a/node/datadir_migrate.go
+++ b/node/datadir_migrate.go
@@ -21,10 +21,7 @@ const legacyInstanceDir = "tomo"
 const legacyTomoXDir = "tomox"
 
 // migrateLegacyInstanceDir resolves the instance directory path and migrates
-// the legacy "tomo" directory to targetName when needed. TomoX under
-// {datadir}/tomo/tomox is moved with the rename; root-level {datadir}/tomox is
-// moved by migrateLegacyTomoXDir after a successful instance migration.
-//
+// the legacy "tomo" directory to targetName when needed
 // Returns:
 //   - instdir: the resolved instance directory path (always set when no error)
 //   - release: non-nil only when migration happened; holds the lock on the

--- a/node/datadir_migrate.go
+++ b/node/datadir_migrate.go
@@ -58,6 +58,10 @@ func migrateLegacyInstanceDir(dataDir, targetName string) (instdir string, relea
 	if err = os.Rename(src, instdir); err != nil {
 		return "", nil, err
 	}
+
+	if err := migrateLegacyTomoXDir(dataDir, targetName); err != nil {
+		return "", nil, err
+	}
 	return instdir, release, nil
 }
 

--- a/node/datadir_migrate.go
+++ b/node/datadir_migrate.go
@@ -17,8 +17,13 @@ import (
 // to be migrated to the current instance name (e.g. "viction").
 const legacyInstanceDir = "tomo"
 
+// legacyTomoXDir is the TomoX LevelDB directory name.
+const legacyTomoXDir = "tomox"
+
 // migrateLegacyInstanceDir resolves the instance directory path and migrates
-// the legacy "tomo" directory to targetName when needed.
+// the legacy "tomo" directory to targetName when needed. TomoX under
+// {datadir}/tomo/tomox is moved with the rename; root-level {datadir}/tomox is
+// moved by migrateLegacyTomoXDir after a successful instance migration.
 //
 // Returns:
 //   - instdir: the resolved instance directory path (always set when no error)
@@ -57,6 +62,46 @@ func migrateLegacyInstanceDir(dataDir, targetName string) (instdir string, relea
 		return "", nil, err
 	}
 	return instdir, release, nil
+}
+
+// migrateLegacyTomoXDir moves a legacy root-level TomoX database
+// ({datadir}/tomox) into the instance directory. It is only called after a
+// successful tomo → targetName instance migration.
+func migrateLegacyTomoXDir(dataDir, targetName string) error {
+	dst := filepath.Join(dataDir, targetName, legacyTomoXDir)
+	if tomoxDirHasData(dst) {
+		return nil
+	}
+
+	src := filepath.Join(dataDir, legacyTomoXDir)
+	if !tomoxDirHasData(src) {
+		return nil
+	}
+	if common.FileExist(dst) {
+		return fmt.Errorf(
+			"cannot migrate TomoX datadir from %q to %q: destination already exists; remove or rename %q, then restart",
+			src, dst, dst,
+		)
+	}
+	log.Info("Migrating TomoX datadir", "from", src, "to", dst)
+	return os.Rename(src, dst)
+}
+
+func tomoxDirHasData(dir string) bool {
+	for _, name := range []string{"CURRENT", "LOCK"} {
+		if common.FileExist(filepath.Join(dir, name)) {
+			return true
+		}
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		return false
+	}
+	if !info.IsDir() {
+		return false
+	}
+	entries, err := os.ReadDir(dir)
+	return err == nil && len(entries) > 0
 }
 
 func instanceDirHasData(dir string) bool {

--- a/node/node.go
+++ b/node/node.go
@@ -305,9 +305,6 @@ func (n *Node) openDataDir() error {
 
 	// check if migration happened and if so, no need to acquire lock
 	if release != nil {
-		if err := migrateLegacyTomoXDir(n.config.DataDir, n.config.name()); err != nil {
-			return convertFileLockError(err)
-		}
 		// Migration happened: lock was acquired on the source LOCK file,
 		// which moved with the directory — no need to Flock again.
 		n.dirLock = release

--- a/node/node.go
+++ b/node/node.go
@@ -305,6 +305,9 @@ func (n *Node) openDataDir() error {
 
 	// check if migration happened and if so, no need to acquire lock
 	if release != nil {
+		if err := migrateLegacyTomoXDir(n.config.DataDir, n.config.name()); err != nil {
+			return convertFileLockError(err)
+		}
 		// Migration happened: lock was acquired on the source LOCK file,
 		// which moved with the directory — no need to Flock again.
 		n.dirLock = release


### PR DESCRIPTION
## Summary
- Move the TomoX data directory from `{datadir}` to `{datadir}/viction` during migration (`tomo` to `viction` )

## Root Cause
- In the current VictionChain codebase, the default TomoX data directory is `{datadir}`, which can be confusing and inconsistent with the new directory structure.

- In newer versions, the default TomoX data directory has been changed to `{datadir}/viction`. However, this change can cause issues when retrieving existing TomoX databases created with the legacy path.

## Changes
- Add a new function `migrateLegacyTomoXDir` to migrate the TomoX data directory from the legacy location (`{datadir}/tomo`) to the new location (`{datadir}/viction`) during the `tomo` → `viction` migration process.