### PR TITLE
core: reduce txpool max transaction size

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -48,7 +48,7 @@ const (
 	// non-trivial consequences: larger transactions are significantly harder and
 	// more expensive to propagate; larger transactions also take more resources
 	// to validate whether they fit into the pool or not.
-	txMaxSize = 4 * txSlotSize // 128KB
+	txMaxSize = 1 * txSlotSize // 32KB
 )
 
 var (


### PR DESCRIPTION
## Summary
- reduce txpool max transaction size from 128KB to 32KB

## Testing
- Not run per request.