### PR TITLE
refactor: update reward calculation structure in POSV

### DIFF
--- a/consensus/posv/posv_extend.go
+++ b/consensus/posv/posv_extend.go
@@ -38,8 +38,9 @@ const (
 // EpochReward stores number of sign made by each validator and rewards for
 // all stakeholders (validators and voters) in an epoch.
 type EpochReward struct {
-	ValidatorRewards  map[common.Address]*ValidatorReward `json:"signers"`
-	StakholderRewards map[common.Address]*big.Int         `json:"rewards"`
+	Rewards           map[common.Address]map[common.Address]*big.Int `json:"rewards"`
+	ValidatorRewards  map[common.Address]*ValidatorReward            `json:"signers"`
+	StakholderRewards map[common.Address]*big.Int                    `json:"-"`
 }
 
 type ValidatorReward struct {

--- a/consensus/posv/posv_extend.go
+++ b/consensus/posv/posv_extend.go
@@ -40,7 +40,7 @@ const (
 type EpochReward struct {
 	Rewards           map[common.Address]map[common.Address]*big.Int `json:"rewards"`
 	ValidatorRewards  map[common.Address]*ValidatorReward            `json:"signers"`
-	StakholderRewards map[common.Address]*big.Int                    `json:"-"`
+	StakeholderRewards map[common.Address]*big.Int                    `json:"-"`
 }
 
 type ValidatorReward struct {

--- a/eth/backend_viction.go
+++ b/eth/backend_viction.go
@@ -172,7 +172,7 @@ func (s *Ethereum) PosvGetEpochReward(c *posv.Posv, config *params.ChainConfig, 
 	if err != nil {
 		return nil, err
 	}
-	epochRewards.StakholderRewards = stakeholderRewards
+	epochRewards.StakeholderRewards = stakeholderRewards
 	epochRewards.Rewards = nestedRewards
 
 	return epochRewards, nil
@@ -195,7 +195,7 @@ func (s *Ethereum) PosvDistributeEpochRewards(header *types.Header, state *state
 	totalRewardDistributed := big.NewInt(0)
 	rewardCount := 0
 
-	for addr, amount := range epochReward.StakholderRewards {
+	for addr, amount := range epochReward.StakeholderRewards {
 		if amount == nil || amount.Sign() <= 0 {
 			continue
 		}

--- a/eth/backend_viction.go
+++ b/eth/backend_viction.go
@@ -168,11 +168,12 @@ func (s *Ethereum) PosvGetEpochReward(c *posv.Posv, config *params.ChainConfig, 
 		rewardState = statedb
 	}
 
-	stakeholderRewards, err := viction.CalcRewardsForStakeholders(c, config, posvConfig, vicConfig, header, validatorRewards, rewardState, logger)
+	stakeholderRewards, nestedRewards, err := viction.CalcRewardsForStakeholders(c, config, posvConfig, vicConfig, header, validatorRewards, rewardState, logger)
 	if err != nil {
 		return nil, err
 	}
 	epochRewards.StakholderRewards = stakeholderRewards
+	epochRewards.Rewards = nestedRewards
 
 	return epochRewards, nil
 }

--- a/eth/viction/reward.go
+++ b/eth/viction/reward.go
@@ -133,8 +133,9 @@ func CalcRewardsForValidators(
 
 func CalcRewardsForStakeholders(c *posv.Posv, config *params.ChainConfig, posvConfig *params.PosvConfig, vicConfig *params.VictionConfig,
 	header *types.Header, validatorRewards map[common.Address]*posv.ValidatorReward, statedb *state.StateDB, logger log.Logger,
-) (map[common.Address]*big.Int, error) {
+) (map[common.Address]*big.Int, map[common.Address]map[common.Address]*big.Int, error) {
 	stakeholderRewards := make(map[common.Address]*big.Int)
+	nestedRewards := make(map[common.Address]map[common.Address]*big.Int)
 	blockNumber := header.Number.Uint64()
 	rewardValidatorPercent := vicConfig.RewardValidatorPercent
 	rewardVoterPercent := vicConfig.RewardVoterPercent
@@ -155,11 +156,13 @@ func CalcRewardsForStakeholders(c *posv.Posv, config *params.ChainConfig, posvCo
 
 		// 		validatorRewardTotal := new(big.Int).Set(vr.Reward)
 		distributedTotal := new(big.Int)
+		validatorNested := make(map[common.Address]*big.Int)
 
 		owner, _ := statedb.VicGetValidatorInfo(vicConfig.ValidatorContract, validator)
 		rewardForOwner := new(big.Int).Mul(vr.Reward, new(big.Int).SetUint64(rewardValidatorPercent))
 		rewardForOwner.Div(rewardForOwner, common.Big100)
 		addBalance(stakeholderRewards, owner, rewardForOwner)
+		addBalance(validatorNested, owner, new(big.Int).Set(rewardForOwner))
 		distributedTotal.Add(distributedTotal, rewardForOwner)
 
 		voters := statedb.VicGetValidatorVoters(vicConfig.ValidatorContract, validator)
@@ -188,6 +191,7 @@ func CalcRewardsForStakeholders(c *posv.Posv, config *params.ChainConfig, posvCo
 					rcap := new(big.Int).Mul(totalVoterReward, voteCap)
 					rcap.Div(rcap, totalCap)
 					addBalance(stakeholderRewards, addr, rcap)
+					addBalance(validatorNested, addr, new(big.Int).Set(rcap))
 					voterRewardDistributed.Add(voterRewardDistributed, rcap)
 				}
 			}
@@ -198,6 +202,7 @@ func CalcRewardsForStakeholders(c *posv.Posv, config *params.ChainConfig, posvCo
 			rewardForFoundation := new(big.Int).Mul(vr.Reward, new(big.Int).SetUint64(rewardFoundationPercent))
 			rewardForFoundation.Div(rewardForFoundation, common.Big100)
 			addBalance(stakeholderRewards, vicConfig.RewardFoundationAddress, rewardForFoundation)
+			addBalance(validatorNested, vicConfig.RewardFoundationAddress, new(big.Int).Set(rewardForFoundation))
 			distributedTotal.Add(distributedTotal, rewardForFoundation)
 		}
 
@@ -207,7 +212,8 @@ func CalcRewardsForStakeholders(c *posv.Posv, config *params.ChainConfig, posvCo
 		// 		logger.Warn("CalcRewardsForStakeholders: significant reward distribution mismatch", "validator", validator.Hex(), "totalReward", validatorRewardTotal.String(), "distributed", distributedTotal.String(), "missing", missing.String())
 		// 	}
 		// }
+		nestedRewards[validator] = validatorNested
 	}
 
-	return stakeholderRewards, nil
+	return stakeholderRewards, nestedRewards, nil
 }


### PR DESCRIPTION
## Summary
- Changes the JSON response format of the epoch reward RPC methods to return a **per-validator** stakeholder breakdown instead of a flat address-to-amount map.

**Affected RPC methods:**
- `eth_getRewardByHash`
- `eth_getRewardByNumber`
- `eth_getRewardByHashOrNumber`

**Unchanged:**
- `signers` — per-validator sign count and total reward for the epoch
- On-chain reward distribution logic (balances are still applied from aggregated totals)

## Reason
- Almost all existing frontends rely on the epoch reward JSON format exposed by the current Victionchain node. vic-geth returned stakeholder rewards as a flat `address → amount` map, which does not match that format. This mismatch increases maintenance cost and makes it harder to migrate clients from Victionchain to vic-geth without custom adapters.

## Changes

## Response format change
### Before
`rewards` was a flat map: **stakeholder address → total reward amount** (summed across all validators).

```json
{
  "signers": {
    "0xValidatorA...": {
      "sign": 42,
      "reward": "1000000000000000000"
    },
    "0xValidatorB...": {
      "sign": 38,
      "reward": "900000000000000000"
    }
  },
  "rewards": {
    "0xOwnerA...": "400000000000000000",
    "0xVoter1...": "300000000000000000",
    "0xVoter2...": "200000000000000000",
    "0xFoundation...": "100000000000000000"
  }
}
```

### After
```json
{
  "signers": {
    "0xValidatorA...": {
      "sign": 42,
      "reward": "1000000000000000000"
    },
    "0xValidatorB...": {
      "sign": 38,
      "reward": "900000000000000000"
    }
  },
  "rewards": {
    "0xValidatorA...": {
      "0xOwnerA...": "400000000000000000",
      "0xVoter1...": "300000000000000000",
      "0xFoundation...": "100000000000000000"
    },
    "0xValidatorB...": {
      "0xOwnerB...": "360000000000000000",
      "0xVoter2...": "200000000000000000",
      "0xFoundation...": "900000000000000000"
    }
  }
}
