### PR TITLE
Feature/add get candidates

### DIFF
--- a/consensus/posv/posv_extend.go
+++ b/consensus/posv/posv_extend.go
@@ -38,8 +38,9 @@ const (
 // EpochReward stores number of sign made by each validator and rewards for
 // all stakeholders (validators and voters) in an epoch.
 type EpochReward struct {
-	ValidatorRewards  map[common.Address]*ValidatorReward `json:"signers"`
-	StakholderRewards map[common.Address]*big.Int         `json:"rewards"`
+	Rewards           map[common.Address]map[common.Address]*big.Int `json:"rewards"`
+	ValidatorRewards  map[common.Address]*ValidatorReward            `json:"signers"`
+	StakholderRewards map[common.Address]*big.Int                    `json:"-"`
 }
 
 type ValidatorReward struct {

--- a/consensus/posv/posv_extend.go
+++ b/consensus/posv/posv_extend.go
@@ -40,7 +40,7 @@ const (
 type EpochReward struct {
 	Rewards           map[common.Address]map[common.Address]*big.Int `json:"rewards"`
 	ValidatorRewards  map[common.Address]*ValidatorReward            `json:"signers"`
-	StakholderRewards map[common.Address]*big.Int                    `json:"-"`
+	StakeholderRewards map[common.Address]*big.Int                    `json:"-"`
 }
 
 type ValidatorReward struct {

--- a/eth/api_backend_viction.go
+++ b/eth/api_backend_viction.go
@@ -503,6 +503,11 @@ func (s *EthAPIBackend) GetCandidates(ctx context.Context, epoch rpc.EpochNumber
 	}
 
 	vicConfig := s.eth.blockchain.Config().Viction
+	if vicConfig == nil {
+		log.Error("Undefined Viction config")
+		result[fieldSuccess] = false
+		return result, errors.New("undefined Viction config")
+	}
 	stateBlockNr := checkpointNumber
 	if epoch == rpc.LatestEpochNumber {
 		stateBlockNr = rpc.BlockNumber(s.eth.blockchain.CurrentBlock().Number().Uint64())
@@ -555,7 +560,7 @@ func (s *EthAPIBackend) GetCandidates(ctx context.Context, epoch rpc.EpochNumber
 	penalties = posv.DecodePenaltiesFromHeader(header.Penalties)
 
 	// check last 5 epochs to find penalize masternodes
-	for i:= uint64(0); i <= vicConfig.PenaltyEpochCount; i++ {
+	for i:= uint64(1); i <= vicConfig.PenaltyEpochCount; i++ {
 		if header.Number.Uint64() < epochConfig * i {
 			break
 		}

--- a/eth/api_backend_viction.go
+++ b/eth/api_backend_viction.go
@@ -5,12 +5,26 @@ import (
 	"context"
 	"errors"
 	"math/big"
+	"sort"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/posv"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/ethereum/go-ethereum/sortlgc"
+)
+
+const (
+	statusMasternode = "MASTERNODE"
+	statusProposed   = "PROPOSED"
+	statusSlashed    = "SLASHED"
+	fieldEpoch       = "epoch"
+	fieldSuccess     = "success"
+	fieldStatus      = "status"
+	fieldCapacity    = "capacity"
+	fieldCandidates  = "candidates"
 )
 
 // GetRewardByHash returns the epoch reward breakdown for the checkpoint block identified by hash.
@@ -459,4 +473,168 @@ func (s *EthAPIBackend) findNearestSignedBlock(ctx context.Context, b *types.Blo
 	}
 	return nil
 
+}
+
+func (s *EthAPIBackend) GetCandidates(ctx context.Context, epoch rpc.EpochNumber) (map[string]interface{}, error) {
+	result := map[string]interface{}{
+		fieldSuccess: true,
+	}
+
+	if _, ok := s.Engine().(*posv.Posv); !ok {
+		log.Error("Undefined POSV consensus engine")
+		result[fieldSuccess] = false
+		return result, errors.New("undefined POSV consensus engine")
+	}
+	epochConfig := s.eth.blockchain.Config().Posv.Epoch
+
+	checkpointNumber, epochNumber := s.GetPreviousCheckpointFromEpoch(ctx, epoch)
+	result[fieldEpoch] = epochNumber.Int64()
+
+	block, err := s.BlockByNumber(ctx, checkpointNumber)
+	if err != nil || block == nil {
+		result[fieldSuccess] = false
+		return result, err
+	}
+
+	header := block.Header()
+	if header == nil {
+		log.Error("Empty header at checkpoint", "num", checkpointNumber)
+		return result, errors.New("empty header at checkpoint")
+	}
+
+	vicConfig := s.eth.blockchain.Config().Viction
+	stateBlockNr := checkpointNumber
+	if epoch == rpc.LatestEpochNumber {
+		stateBlockNr = rpc.BlockNumber(s.eth.blockchain.CurrentBlock().Number().Uint64())
+	}
+	candidates, err := s.loadValidatorCandidates(ctx, vicConfig, stateBlockNr)
+	if err != nil {
+		log.Error("Failed to load validator candidates", "block", stateBlockNr, "error", err)
+		result[fieldSuccess] = false
+		return result, err
+	}
+
+	statusMap := make(map[string]map[string]interface{}, len(candidates))
+	for _, candidate := range candidates {
+		statusMap[candidate.Address.String()] = map[string]interface{}{
+			fieldStatus:   statusProposed,
+			fieldCapacity: candidate.Stake,
+		}
+	}
+
+	// First, Sort candidates by capacity
+	sortedCandidates := append([]posv.Masternode(nil), candidates...)
+	stateBlockNum := big.NewInt(int64(stateBlockNr))
+	if s.eth.blockchain.Config().IsAtlas(stateBlockNum) {
+		sort.SliceStable(sortedCandidates, func(i, j int) bool {
+			return sortedCandidates[i].Stake.Cmp(sortedCandidates[j].Stake) >= 0
+		})
+	} else {
+		sortlgc.Slice(sortedCandidates, func(i, j int) bool {
+			return sortedCandidates[i].Stake.Cmp(sortedCandidates[j].Stake) >= 0
+		})
+	}
+
+	// Second, Find candidates that have masternode status
+	var masternodes []common.Address
+	masternodes = posv.ExtractValidatorsFromCheckpointHeader(header)
+
+	if len(masternodes) == 0 {
+		log.Debug("Masternodes list cannot be found", "len(masternodes)", len(masternodes))
+		result[fieldSuccess] = false
+		return result, errors.New("masternodes list cannot be found")
+	}
+	for _, addr := range masternodes {
+		if statusMap[addr.String()] != nil {
+			statusMap[addr.String()][fieldStatus] = statusMasternode
+		}
+	}
+
+	// Third, Get penalties list
+	var penalties []common.Address
+	penalties = posv.DecodePenaltiesFromHeader(header.Penalties)
+
+	// check last 5 epochs to find penalize masternodes
+	for i:= uint64(0); i <= vicConfig.PenaltyEpochCount; i++ {
+		if header.Number.Uint64() < epochConfig * i {
+			break
+		}
+		prevCheckpointBlockNumber := header.Number.Uint64() - epochConfig * i
+		prevCheckpointHeader, err := s.HeaderByNumber(ctx, rpc.BlockNumber(prevCheckpointBlockNumber))
+		if prevCheckpointHeader == nil || err != nil {
+			log.Error("Failed to get previous checkpoint header", "error", err)
+			continue
+		}
+		prevPenalties := posv.DecodePenaltiesFromHeader(prevCheckpointHeader.Penalties)
+		if len(prevPenalties) > 0 {
+			penalties = append(penalties, prevPenalties...)
+		}
+	}
+
+	// map slashing status
+	if len(penalties) == 0 {
+		result[fieldCandidates] = statusMap
+		return result, nil
+	}
+
+	var topCandidates []posv.Masternode
+	if len(sortedCandidates) > int(vicConfig.ValidatorMaxCount) {
+		topCandidates = sortedCandidates[:vicConfig.ValidatorMaxCount]
+	} else {
+		topCandidates = sortedCandidates
+	}
+	// check penalties from checkpoint headers and modify status of a node to SLASHED if it's in top 150 candidates
+	// if it's SLASHED but it's out of top 150, the status should be still PROPOSED
+	for _, pen := range penalties {
+		for _, candidate := range topCandidates {
+			if candidate.Address == pen && statusMap[pen.String()] != nil {
+				statusMap[pen.String()][fieldStatus] = statusSlashed
+			}
+		}
+	}
+	// update result
+	result[fieldCandidates] = statusMap
+	return result, nil
+}
+
+func (s *EthAPIBackend) loadValidatorCandidates(ctx context.Context, vicConfig *params.VictionConfig, blockNr rpc.BlockNumber) ([]posv.Masternode, error) {
+	statedb, _, err := s.StateAndHeaderByNumber(ctx, blockNr)
+	if err != nil {
+		return nil, err
+	}
+
+	addresses := statedb.VicGetCandidates(vicConfig.ValidatorContract)
+	candidates := make([]posv.Masternode, 0, len(addresses))
+	for _, addr := range addresses {
+		if addr == (common.Address{}) {
+			continue
+		}
+		_, cap := statedb.VicGetValidatorInfo(vicConfig.ValidatorContract, addr)
+		candidates = append(candidates, posv.Masternode{Address: addr, Stake: cap})
+	}
+	if len(candidates) == 0 {
+		log.Debug("Candidates list cannot be found", "len(candidates)", len(candidates))
+		return nil, errors.New("candidates list cannot be found")
+	}
+	return candidates, nil
+}
+
+func (s *EthAPIBackend) GetPreviousCheckpointFromEpoch(ctx context.Context, epochNum rpc.EpochNumber) (rpc.BlockNumber, rpc.EpochNumber) {
+	var checkpointNumber uint64
+	epoch := s.eth.blockchain.Config().Posv.Epoch
+
+	if epochNum == rpc.LatestEpochNumber {
+		blockNumer := s.eth.blockchain.CurrentBlock().Number().Uint64()
+		diff := blockNumer % epoch
+		checkpointNumber = blockNumer - diff
+		epochNum = rpc.EpochNumber(checkpointNumber / epoch)
+		if diff > 0 {
+			epochNum += 1
+		}
+	} else if epochNum < 2 {
+		checkpointNumber = 0
+	} else {
+		checkpointNumber = epoch * (uint64(epochNum) - 1)
+	}
+	return rpc.BlockNumber(checkpointNumber), epochNum
 }

--- a/eth/backend_viction.go
+++ b/eth/backend_viction.go
@@ -172,7 +172,7 @@ func (s *Ethereum) PosvGetEpochReward(c *posv.Posv, config *params.ChainConfig, 
 	if err != nil {
 		return nil, err
 	}
-	epochRewards.StakholderRewards = stakeholderRewards
+	epochRewards.StakeholderRewards = stakeholderRewards
 	epochRewards.Rewards = nestedRewards
 
 	return epochRewards, nil
@@ -195,7 +195,7 @@ func (s *Ethereum) PosvDistributeEpochRewards(header *types.Header, state *state
 	totalRewardDistributed := big.NewInt(0)
 	rewardCount := 0
 
-	for addr, amount := range epochReward.StakholderRewards {
+	for addr, amount := range epochReward.StakeholderRewards {
 		if amount == nil || amount.Sign() <= 0 {
 			continue
 		}

--- a/eth/backend_viction.go
+++ b/eth/backend_viction.go
@@ -168,11 +168,12 @@ func (s *Ethereum) PosvGetEpochReward(c *posv.Posv, config *params.ChainConfig, 
 		rewardState = statedb
 	}
 
-	stakeholderRewards, err := viction.CalcRewardsForStakeholders(c, config, posvConfig, vicConfig, header, validatorRewards, rewardState, logger)
+	stakeholderRewards, nestedRewards, err := viction.CalcRewardsForStakeholders(c, config, posvConfig, vicConfig, header, validatorRewards, rewardState, logger)
 	if err != nil {
 		return nil, err
 	}
 	epochRewards.StakholderRewards = stakeholderRewards
+	epochRewards.Rewards = nestedRewards
 
 	return epochRewards, nil
 }

--- a/eth/viction/reward.go
+++ b/eth/viction/reward.go
@@ -133,8 +133,9 @@ func CalcRewardsForValidators(
 
 func CalcRewardsForStakeholders(c *posv.Posv, config *params.ChainConfig, posvConfig *params.PosvConfig, vicConfig *params.VictionConfig,
 	header *types.Header, validatorRewards map[common.Address]*posv.ValidatorReward, statedb *state.StateDB, logger log.Logger,
-) (map[common.Address]*big.Int, error) {
+) (map[common.Address]*big.Int, map[common.Address]map[common.Address]*big.Int, error) {
 	stakeholderRewards := make(map[common.Address]*big.Int)
+	nestedRewards := make(map[common.Address]map[common.Address]*big.Int)
 	blockNumber := header.Number.Uint64()
 	rewardValidatorPercent := vicConfig.RewardValidatorPercent
 	rewardVoterPercent := vicConfig.RewardVoterPercent
@@ -155,11 +156,13 @@ func CalcRewardsForStakeholders(c *posv.Posv, config *params.ChainConfig, posvCo
 
 		// 		validatorRewardTotal := new(big.Int).Set(vr.Reward)
 		distributedTotal := new(big.Int)
+		validatorNested := make(map[common.Address]*big.Int)
 
 		owner, _ := statedb.VicGetValidatorInfo(vicConfig.ValidatorContract, validator)
 		rewardForOwner := new(big.Int).Mul(vr.Reward, new(big.Int).SetUint64(rewardValidatorPercent))
 		rewardForOwner.Div(rewardForOwner, common.Big100)
 		addBalance(stakeholderRewards, owner, rewardForOwner)
+		addBalance(validatorNested, owner, new(big.Int).Set(rewardForOwner))
 		distributedTotal.Add(distributedTotal, rewardForOwner)
 
 		voters := statedb.VicGetValidatorVoters(vicConfig.ValidatorContract, validator)
@@ -188,6 +191,7 @@ func CalcRewardsForStakeholders(c *posv.Posv, config *params.ChainConfig, posvCo
 					rcap := new(big.Int).Mul(totalVoterReward, voteCap)
 					rcap.Div(rcap, totalCap)
 					addBalance(stakeholderRewards, addr, rcap)
+					addBalance(validatorNested, addr, new(big.Int).Set(rcap))
 					voterRewardDistributed.Add(voterRewardDistributed, rcap)
 				}
 			}
@@ -198,6 +202,7 @@ func CalcRewardsForStakeholders(c *posv.Posv, config *params.ChainConfig, posvCo
 			rewardForFoundation := new(big.Int).Mul(vr.Reward, new(big.Int).SetUint64(rewardFoundationPercent))
 			rewardForFoundation.Div(rewardForFoundation, common.Big100)
 			addBalance(stakeholderRewards, vicConfig.RewardFoundationAddress, rewardForFoundation)
+			addBalance(validatorNested, vicConfig.RewardFoundationAddress, new(big.Int).Set(rewardForFoundation))
 			distributedTotal.Add(distributedTotal, rewardForFoundation)
 		}
 
@@ -207,7 +212,8 @@ func CalcRewardsForStakeholders(c *posv.Posv, config *params.ChainConfig, posvCo
 		// 		logger.Warn("CalcRewardsForStakeholders: significant reward distribution mismatch", "validator", validator.Hex(), "totalReward", validatorRewardTotal.String(), "distributed", distributedTotal.String(), "missing", missing.String())
 		// 	}
 		// }
+		nestedRewards[validator] = validatorNested
 	}
 
-	return stakeholderRewards, nil
+	return stakeholderRewards, nestedRewards, nil
 }

--- a/internal/ethapi/api_viction.go
+++ b/internal/ethapi/api_viction.go
@@ -46,3 +46,7 @@ func (s *PublicVictionBlockChainAPI) GetBlockFinalityByHash(ctx context.Context,
 func (s *PublicVictionBlockChainAPI) GetBlockFinalityByNumber(ctx context.Context, number rpc.BlockNumber) (uint, error) {
 	return s.b.GetBlockFinalityByNumber(ctx, number)
 }
+
+func (s *PublicVictionBlockChainAPI) GetCandidates(ctx context.Context, epoch rpc.EpochNumber) (map[string]interface{}, error) {
+	return s.b.GetCandidates(ctx, epoch)
+}

--- a/internal/ethapi/backend_viction.go
+++ b/internal/ethapi/backend_viction.go
@@ -21,5 +21,6 @@ type BackendViction interface {
 	GetAttestorsPairsByNumber(ctx context.Context, number rpc.BlockNumber) (map[common.Address]common.Address, error)
 	GetBlockFinalityByHash(ctx context.Context, blockHash common.Hash) (uint, error)
 	GetBlockFinalityByNumber(ctx context.Context, blockNumber rpc.BlockNumber) (uint, error)
+	GetCandidates(ctx context.Context, epoch rpc.EpochNumber) (map[string]interface{}, error)
 	AreTwoBlockSamePath(hash1, hash2 common.Hash) bool
 }

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -988,6 +988,11 @@ web3._extend({
 			call: 'eth_getBlockFinalityByNumber',
 			params: 1
 		}),
+		new web3._extend.Method({
+			name: 'getCandidates',
+			call: 'eth_getCandidates',
+			params: 1
+		}),
 	]
 });
 `

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -67,11 +67,13 @@ type jsonWriter interface {
 }
 
 type BlockNumber int64
+type EpochNumber int64
 
 const (
 	PendingBlockNumber  = BlockNumber(-2)
 	LatestBlockNumber   = BlockNumber(-1)
 	EarliestBlockNumber = BlockNumber(0)
+	LatestEpochNumber   = EpochNumber(-1)
 )
 
 // UnmarshalJSON parses the given JSON fragment into a BlockNumber. It supports:
@@ -202,4 +204,32 @@ func BlockNumberOrHashWithHash(hash common.Hash, canonical bool) BlockNumberOrHa
 		BlockHash:        &hash,
 		RequireCanonical: canonical,
 	}
+}
+
+func (e *EpochNumber) UnmarshalJSON(data []byte) error {
+	input := strings.TrimSpace(string(data))
+	if len(input) >= 2 && input[0] == '"' && input[len(input)-1] == '"' {
+		input = input[1 : len(input)-1]
+	}
+
+	switch input {
+	case "latest":
+		*e = LatestEpochNumber
+		return nil
+	}
+
+	eNum, err := hexutil.DecodeUint64(input)
+	if err != nil {
+		return err
+	}
+	if eNum > math.MaxInt64 {
+		return fmt.Errorf("EpochNumber too high")
+	}
+
+	*e = EpochNumber(eNum)
+	return nil
+}
+
+func (e EpochNumber) Int64() int64 {
+	return (int64)(e)
 }


### PR DESCRIPTION
## Summary
- Add rpc api to get Candidates and their status

## Changes
**Add RPC methods:**
- `eth_getCandidates` : Can be used by clients and through IPC

## Example
```bash
curl -X POST http://localhost:8545 \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","method":"eth_getCandidates","params":["0xc9"],"id":1}'
```

