### PR TITLE
fix: update GetCandidates method to handle latest and pending block 

### DIFF
--- a/eth/api_backend_viction.go
+++ b/eth/api_backend_viction.go
@@ -510,7 +510,10 @@ func (s *EthAPIBackend) GetCandidates(ctx context.Context, epoch rpc.EpochNumber
 	}
 	stateBlockNr := checkpointNumber
 	if epoch == rpc.LatestEpochNumber {
-		stateBlockNr = rpc.BlockNumber(s.eth.blockchain.CurrentBlock().Number().Uint64())
+		stateBlockNr = rpc.LatestBlockNumber
+		if block, state := s.eth.miner.Pending(); block != nil && state != nil {
+			stateBlockNr = rpc.PendingBlockNumber
+		}
 	}
 	candidates, err := s.loadValidatorCandidates(ctx, vicConfig, stateBlockNr)
 	if err != nil {
@@ -529,8 +532,11 @@ func (s *EthAPIBackend) GetCandidates(ctx context.Context, epoch rpc.EpochNumber
 
 	// First, Sort candidates by capacity
 	sortedCandidates := append([]posv.Masternode(nil), candidates...)
-	stateBlockNum := big.NewInt(int64(stateBlockNr))
-	if s.eth.blockchain.Config().IsAtlas(stateBlockNum) {
+	forkBlockNum := big.NewInt(int64(stateBlockNr))
+	if stateBlockNr == rpc.LatestBlockNumber || stateBlockNr == rpc.PendingBlockNumber {
+		forkBlockNum = s.eth.blockchain.CurrentBlock().Number()
+	}
+	if s.eth.blockchain.Config().IsAtlas(forkBlockNum) {
 		sort.SliceStable(sortedCandidates, func(i, j int) bool {
 			return sortedCandidates[i].Stake.Cmp(sortedCandidates[j].Stake) >= 0
 		})


### PR DESCRIPTION
## Summary

Fix `GetCandidates` for the latest epoch so it reads validator candidate state through the standard `LatestBlockNumber` / `PendingBlockNumber` path, and correct Atlas fork detection when those sentinel block numbers are used.

## Reason

When `epoch` is `LatestEpochNumber`, the old code passed the concrete current block number into `loadValidatorCandidates`. That bypassed the shared backend logic in `StateAndHeaderByNumber`, which knows how to resolve `LatestBlockNumber` and `PendingBlockNumber`.

As a result, `GetCandidates` always used committed chain state and ignored the miner's pending block, even when one was available. Candidate stake/capacity could be stale relative to other RPC methods (e.g. `eth_call`, balance queries) that include pending transactions.

After switching to sentinel block numbers, the Atlas fork check also needed a fix: passing `-1` or `-2` directly into `IsAtlas` would not reflect the actual chain head, so fork-dependent candidate sorting could be wrong.

## Change

In `eth/api_backend_viction.go`, inside `GetCandidates`:

- For `LatestEpochNumber`, set `stateBlockNr` to `rpc.LatestBlockNumber`, and to `rpc.PendingBlockNumber` when the miner has a pending block and state.
- When sorting candidates, resolve `LatestBlockNumber` / `PendingBlockNumber` to the current head block number before calling `IsAtlas`, so Atlas vs pre-Atlas sort behavior stays correct.