### PR TITLE
Implement Viction pre-checks in BeforeApplyTransaction for transaction tracing

### DIFF
--- a/core/state_processor_viction.go
+++ b/core/state_processor_viction.go
@@ -323,22 +323,30 @@ func (p *StateProcessor) afterProcess(block *types.Block, statedb *state.StateDB
 // balance override for specific accounts in early blocks, and blacklist
 // enforcement after TIPBlacklist.
 func (p *StateProcessor) beforeApplyTransaction(block *types.Block, tx *types.Transaction, msg types.Message, statedb *state.StateDB) error {
-	if p.config.Viction == nil {
+	return BeforeApplyTransaction(p.config, block, tx, msg, statedb)
+}
+
+// BeforeApplyTransaction is the exported entry point to the per-transaction
+// Viction pre-checks, so callers outside block import (e.g. the tracing API in
+// package eth) can reproduce the exact same balance-override state mutations and
+// blacklist enforcement before re-executing a transaction.
+func BeforeApplyTransaction(config *params.ChainConfig, block *types.Block, tx *types.Transaction, msg types.Message, statedb *state.StateDB) error {
+	if config.Viction == nil {
 		return nil
 	}
 	header := block.Header()
 
 	if header.Number.BitLen() <= 64 && header.Number.Uint64() <= 9147459 {
-		if val := p.config.Viction.GetVictionBypassBalance(header.Number.Uint64(), msg.From()); val != nil {
+		if val := config.Viction.GetVictionBypassBalance(header.Number.Uint64(), msg.From()); val != nil {
 			statedb.SetBalance(msg.From(), val)
 		}
 	}
 
-	if p.config.IsTIPBlacklist(block.Number()) {
-		if p.config.Viction.IsBlacklisted(msg.From()) {
+	if config.IsTIPBlacklist(block.Number()) {
+		if config.Viction.IsBlacklisted(msg.From()) {
 			return ErrBlacklistedAddress
 		}
-		if tx.To() != nil && p.config.Viction.IsBlacklisted(*tx.To()) {
+		if tx.To() != nil && config.Viction.IsBlacklisted(*tx.To()) {
 			return ErrBlacklistedAddress
 		}
 	}

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -488,11 +488,17 @@ func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, 
 	// Feed the transactions into the tracers and return
 	var failed error
 	for i, tx := range txs {
+		msg, _ := tx.AsMessage(signer)
+		// Reproduce Viction per-tx pre-checks (balance override + blacklist) on the
+		// shared state before snapshotting it for the tracer, mirroring block import.
+		if err := core.BeforeApplyTransaction(api.eth.blockchain.Config(), block, tx, msg, statedb); err != nil {
+			failed = err
+			break
+		}
 		// Send the trace task over for execution
 		jobs <- &txTraceTask{statedb: statedb.Copy(), index: i}
 
 		// Generate the next state snapshot fast without tracing
-		msg, _ := tx.AsMessage(signer)
 		txContext := core.NewEVMTxContext(msg)
 
 		vmenv := vm.NewEVM(blockCtx, txContext, statedb, api.eth.blockchain.Config(), vm.Config{})
@@ -606,6 +612,11 @@ func (api *PrivateDebugAPI) standardTraceBlockToFile(ctx context.Context, block 
 				Tracer:                  vm.NewJSONLogger(&logConfig, writer),
 				EnablePreimageRecording: true,
 			}
+		}
+		// Reproduce Viction per-tx pre-checks (balance override + blacklist) before
+		// execution, mirroring block import.
+		if err = core.BeforeApplyTransaction(chainConfig, block, tx, msg, statedb); err != nil {
+			return dumps, err
 		}
 		// Execute the transaction and flush any traces to disk
 		vmenv := vm.NewEVM(vmctx, txContext, statedb, chainConfig, vmConf)
@@ -860,6 +871,11 @@ func (api *PrivateDebugAPI) computeTxEnv(block *types.Block, txIndex int, reexec
 	for idx, tx := range block.Transactions() {
 		// Assemble the transaction call message and return if the requested offset
 		msg, _ := tx.AsMessage(signer)
+		// Reproduce Viction per-tx pre-checks (balance override + blacklist) before
+		// executing or returning, mirroring block import.
+		if err := core.BeforeApplyTransaction(api.eth.blockchain.Config(), block, tx, msg, statedb); err != nil {
+			return nil, vm.BlockContext{}, nil, err
+		}
 		txContext := core.NewEVMTxContext(msg)
 		context := core.NewEVMBlockContext(block.Header(), api.eth.blockchain, nil)
 		if idx == txIndex {


### PR DESCRIPTION
This PR refactors and centralizes the Viction pre-transaction checks (balance override and blacklist enforcement) into a new exported function `BeforeApplyTransaction`. This enables consistent enforcement of these rules both during block import and when tracing or re-executing transactions via the debug API. The main changes are the introduction of the new function and its integration into all relevant tracing and execution code paths.
