### PR TITLE
Fix/tracer

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -551,7 +551,7 @@ func (b *SimulatedBackend) callContract(ctx context.Context, call ethereum.CallM
 	vmEnv := vm.NewEVM(evmContext, txContext, stateDB, b.config, vm.Config{})
 	gasPool := new(core.GasPool).AddGas(math.MaxUint64)
 
-	return core.NewStateTransition(vmEnv, msg, gasPool).TransitionDb()
+	return core.NewStateTransition(vmEnv, msg, gasPool, nil).TransitionDb()
 }
 
 // SendTransaction updates the pending block to include the given transaction.

--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -157,7 +157,7 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig,
 		}
 		snapshot := statedb.Snapshot()
 		// (ret []byte, usedGas uint64, failed bool, err error)
-		msgResult, err := core.ApplyMessage(evm, msg, gaspool)
+		msgResult, err := core.ApplyMessage(evm, msg, gaspool, nil)
 		if err != nil {
 			statedb.RevertToSnapshot(snapshot)
 			log.Info("rejected tx", "index", i, "hash", tx.Hash(), "from", msg.From(), "error", err)

--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -90,6 +90,8 @@ func precacheTransaction(config *params.ChainConfig, bc ChainContext, author *co
 	txContext := NewEVMTxContext(msg)
 	vm := vm.NewEVM(context, txContext, statedb, config, cfg)
 
-	_, err = ApplyMessage(vm, msg, gaspool)
+	// Speculative warm-up only; no fee pool needed (sponsorship is irrelevant to
+	// prefetching, and this state is discarded).
+	_, err = ApplyMessage(vm, msg, gaspool, nil)
 	return err
 }

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -107,7 +107,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 		}
 
 		if !handled {
-			receipt, err = applyTransaction(msg, p.config, p.bc, nil, gp, statedb, header, tx, usedGas, vmenv)
+			receipt, err = applyTransaction(msg, p.config, p.bc, nil, gp, statedb, header, tx, usedGas, vmenv, p.victionState.feeProc.FeePool())
 			if err != nil {
 				return nil, nil, 0, err
 			}
@@ -131,7 +131,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	return receipts, allLogs, *usedGas, nil
 }
 
-func applyTransaction(msg types.Message, config *params.ChainConfig, bc ChainContext, author *common.Address, gp *GasPool, statedb *state.StateDB, header *types.Header, tx *types.Transaction, usedGas *uint64, evm *vm.EVM) (*types.Receipt, error) {
+func applyTransaction(msg types.Message, config *params.ChainConfig, bc ChainContext, author *common.Address, gp *GasPool, statedb *state.StateDB, header *types.Header, tx *types.Transaction, usedGas *uint64, evm *vm.EVM, feePool VictionFeePool) (*types.Receipt, error) {
 	// Create a new context to be used in the EVM environment
 	txContext := NewEVMTxContext(msg)
 	// Add addresses to access list if applicable
@@ -149,7 +149,7 @@ func applyTransaction(msg types.Message, config *params.ChainConfig, bc ChainCon
 	// Update the evm with the new transaction context.
 	evm.Reset(txContext, statedb)
 	// Apply the transaction to the current state (included in the env)
-	result, err := ApplyMessage(evm, msg, gp)
+	result, err := ApplyMessage(evm, msg, gp, feePool)
 	if err != nil {
 		return nil, err
 	}
@@ -208,5 +208,8 @@ func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *commo
 	// Create a new context to be used in the EVM environment
 	blockContext := NewEVMBlockContext(header, bc, author)
 	vmenv := vm.NewEVM(blockContext, vm.TxContext{}, statedb, config, cfg)
-	return applyTransaction(msg, config, bc, author, gp, statedb, header, tx, usedGas, vmenv)
+	// Standalone path (miner / chain_makers): no per-block fee pool is threaded,
+	// so sponsored VRC25 accounting is not applied here. Live blocks are all
+	// post-Atlas, where capacity is read directly from state in vrc25BuyGas.
+	return applyTransaction(msg, config, bc, author, gp, statedb, header, tx, usedGas, vmenv, nil)
 }

--- a/core/state_processor_viction.go
+++ b/core/state_processor_viction.go
@@ -137,8 +137,8 @@ type victionProcessorState struct {
 
 	// feeProc owns the pre-Atlas VRC25 fee accounting for this block: the running
 	// pool threaded into each transaction, the per-tx decrement, and the
-	// end-of-block flush. See VictionProcessor.
-	feeProc *VictionProcessor
+	// end-of-block flush. See VictionFeeProcessor.
+	feeProc *VictionFeeProcessor
 }
 
 // beforeProcess initialises Viction-specific per-block state and runs hardfork
@@ -150,7 +150,7 @@ func (p *StateProcessor) beforeProcess(block *types.Block, statedb *state.StateD
 
 	p.victionState = &victionProcessorState{
 		currentBlockNumber: new(big.Int).Set(header.Number),
-		feeProc:            NewVictionProcessor(p.config, statedb, header.Number),
+		feeProc:            NewVictionFeeProcessor(p.config, statedb, header.Number),
 	}
 
 	if p.config.TIPSigningBlock != nil && p.config.TIPSigningBlock.Cmp(header.Number) == 0 {
@@ -472,7 +472,7 @@ func (p *StateProcessor) afterApplyTransaction(tx *types.Transaction, msg types.
 	}
 
 	// Pre-Atlas: decrement the running fee pool and record the update for the
-	// afterProcess flush. Shared with the tracing API via VictionProcessor, so the
+	// afterProcess flush. Shared with the tracing API via VictionFeeProcessor, so the
 	// fee formula cannot drift.
 	failed := receipt.Status == types.ReceiptStatusFailed
 	p.victionState.feeProc.HandleFee(statedb, blockNum, tx, msg.From(), usedGas, failed)

--- a/core/state_processor_viction.go
+++ b/core/state_processor_viction.go
@@ -323,22 +323,30 @@ func (p *StateProcessor) afterProcess(block *types.Block, statedb *state.StateDB
 // balance override for specific accounts in early blocks, and blacklist
 // enforcement after TIPBlacklist.
 func (p *StateProcessor) beforeApplyTransaction(block *types.Block, tx *types.Transaction, msg types.Message, statedb *state.StateDB) error {
-	if p.config.Viction == nil {
+	return BeforeApplyTransaction(p.config, block, tx, msg, statedb)
+}
+
+// BeforeApplyTransaction is the exported entry point to the per-transaction
+// Viction pre-checks, so callers outside block import (e.g. the tracing API in
+// package eth) can reproduce the exact same balance-override state mutations and
+// blacklist enforcement before re-executing a transaction.
+func BeforeApplyTransaction(config *params.ChainConfig, block *types.Block, tx *types.Transaction, msg types.Message, statedb *state.StateDB) error {
+	if config.Viction == nil {
 		return nil
 	}
 	header := block.Header()
 
 	if header.Number.BitLen() <= 64 && header.Number.Uint64() <= 9147459 {
-		if val := p.config.Viction.GetVictionBypassBalance(header.Number.Uint64(), msg.From()); val != nil {
+		if val := config.Viction.GetVictionBypassBalance(header.Number.Uint64(), msg.From()); val != nil {
 			statedb.SetBalance(msg.From(), val)
 		}
 	}
 
-	if p.config.IsTIPBlacklist(block.Number()) {
-		if p.config.Viction.IsBlacklisted(msg.From()) {
+	if config.IsTIPBlacklist(block.Number()) {
+		if config.Viction.IsBlacklisted(msg.From()) {
 			return ErrBlacklistedAddress
 		}
-		if tx.To() != nil && p.config.Viction.IsBlacklisted(*tx.To()) {
+		if tx.To() != nil && config.Viction.IsBlacklisted(*tx.To()) {
 			return ErrBlacklistedAddress
 		}
 	}

--- a/core/state_processor_viction.go
+++ b/core/state_processor_viction.go
@@ -18,15 +18,6 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
-// activeFeeBalance holds the per-block running VRC25 fee capacity map for
-// the block currently being processed.  It is set by beforeProcess (via
-// victionProcessorState) and read by vrc25BuyGas during each transaction.
-// Protected by activeFeeBalanceMu.
-var (
-	activeFeeBalance   map[common.Address]*big.Int
-	activeFeeBalanceMu sync.RWMutex
-)
-
 // TradingEngine is the interface the TomoX engine must satisfy.
 // Defined here to avoid an import cycle between core and legacy/tomox.
 type TradingEngine interface {
@@ -144,11 +135,10 @@ type victionProcessorState struct {
 	// committedLendingRoot is the root returned by lendingStateDB.Commit() in afterProcess.
 	committedLendingRoot common.Hash
 
-	// Pre-Atlas VRC25 fee tracking: running balances per token, updated each tx,
-	// flushed to state in afterProcess.
-	feeBalance map[common.Address]*big.Int // token -> remaining capacity
-	feeUpdated map[common.Address]*big.Int // tokens with fees charged -> final capacity
-	totalFee   *big.Int                    // total fees charged this block
+	// feeProc owns the pre-Atlas VRC25 fee accounting for this block: the running
+	// pool threaded into each transaction, the per-tx decrement, and the
+	// end-of-block flush. See VictionProcessor.
+	feeProc *VictionProcessor
 }
 
 // beforeProcess initialises Viction-specific per-block state and runs hardfork
@@ -160,8 +150,7 @@ func (p *StateProcessor) beforeProcess(block *types.Block, statedb *state.StateD
 
 	p.victionState = &victionProcessorState{
 		currentBlockNumber: new(big.Int).Set(header.Number),
-		feeUpdated:         map[common.Address]*big.Int{},
-		totalFee:           new(big.Int),
+		feeProc:            NewVictionProcessor(p.config, statedb, header.Number),
 	}
 
 	if p.config.TIPSigningBlock != nil && p.config.TIPSigningBlock.Cmp(header.Number) == 0 {
@@ -176,19 +165,6 @@ func (p *StateProcessor) beforeProcess(block *types.Block, statedb *state.StateD
 		if p.config.IsSaigon(block.Number()) {
 			misc.ApplySaigonHardFork(statedb, p.config.Viction, p.config.SaigonBlock, block.Number())
 		}
-	}
-
-	// Pre-Atlas: snapshot all VRC25 token fee capacities for per-tx eligibility checks.
-	if !p.config.IsAtlas(header.Number) &&
-		p.config.Viction != nil && p.config.Viction.VRC25Contract != (common.Address{}) {
-		p.victionState.feeBalance = vrc25.GetAllFeeCapacities(statedb, p.config.Viction.VRC25Contract)
-		activeFeeBalanceMu.Lock()
-		activeFeeBalance = p.victionState.feeBalance
-		activeFeeBalanceMu.Unlock()
-	} else {
-		activeFeeBalanceMu.Lock()
-		activeFeeBalance = nil
-		activeFeeBalanceMu.Unlock()
 	}
 
 	// Open TomoX and TomoZ tries from the parent block.
@@ -256,17 +232,9 @@ func (p *StateProcessor) beforeProcess(block *types.Block, statedb *state.StateD
 // transaction embedded in the block. Called once after all transactions have
 // been applied.
 func (p *StateProcessor) afterProcess(block *types.Block, statedb *state.StateDB) error {
-	// Clear the package-level feeBalance pointer; it is only valid during
-	// block processing and must not leak to the next block.
-	activeFeeBalanceMu.Lock()
-	activeFeeBalance = nil
-	activeFeeBalanceMu.Unlock()
-
 	// Pre-Atlas: flush accumulated VRC25 fee updates to state.
-	if p.victionState != nil && !p.config.IsAtlas(block.Number()) &&
-		p.config.Viction != nil && p.config.Viction.VRC25Contract != (common.Address{}) &&
-		len(p.victionState.feeUpdated) > 0 {
-		vrc25.UpdateFeeCapacity(statedb, p.config.Viction.VRC25Contract, p.victionState.feeUpdated, p.victionState.totalFee)
+	if p.victionState != nil {
+		p.victionState.feeProc.Flush(statedb)
 	}
 
 	// Commit and verify the TomoX trading state root.
@@ -503,26 +471,11 @@ func (p *StateProcessor) afterApplyTransaction(tx *types.Transaction, msg types.
 		return nil
 	}
 
-	// Pre-Atlas: accumulate VRC25 fee deductions into feeUpdated; flushed in afterProcess.
-	if p.victionState.feeBalance != nil {
-		runningCap, ok := p.victionState.feeBalance[token]
-		if ok && runningCap != nil {
-			fee := new(big.Int).SetUint64(usedGas)
-			if p.config.TIPTRC21FeeBlock != nil && blockNum.Cmp(p.config.TIPTRC21FeeBlock) > 0 && vicCfg != nil && vicCfg.VRC25GasPrice != nil {
-				fee = new(big.Int).Mul(fee, (*big.Int)(vicCfg.VRC25GasPrice))
-			}
-			if runningCap.Cmp(fee) > 0 {
-				newCap := new(big.Int).Sub(runningCap, fee)
-				p.victionState.feeBalance[token] = newCap
-				p.victionState.feeUpdated[token] = newCap
-				p.victionState.totalFee.Add(p.victionState.totalFee, fee)
-
-				if receipt.Status == types.ReceiptStatusFailed {
-					vrc25.PayFeeWithVRC25(statedb, msg.From(), token)
-				}
-			}
-		}
-	}
+	// Pre-Atlas: decrement the running fee pool and record the update for the
+	// afterProcess flush. Shared with the tracing API via VictionProcessor, so the
+	// fee formula cannot drift.
+	failed := receipt.Status == types.ReceiptStatusFailed
+	p.victionState.feeProc.HandleFee(statedb, blockNum, tx, msg.From(), usedGas, failed)
 
 	return nil
 }

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -56,6 +56,7 @@ type StateTransition struct {
 	state      vm.StateDB
 	evm        *vm.EVM
 	payer      common.Address
+	feePool   map[common.Address]*big.Int
 }
 
 // Message represents a message sent to a contract.
@@ -145,7 +146,7 @@ func IntrinsicGas(data []byte, contractCreation, isHomestead bool, isEIP2028 boo
 }
 
 // NewStateTransition initialises and returns a new state transition object.
-func NewStateTransition(evm *vm.EVM, msg Message, gp *GasPool) *StateTransition {
+func NewStateTransition(evm *vm.EVM, msg Message, gp *GasPool, feePool map[common.Address]*big.Int) *StateTransition {
 	return &StateTransition{
 		gp:       gp,
 		evm:      evm,
@@ -154,6 +155,7 @@ func NewStateTransition(evm *vm.EVM, msg Message, gp *GasPool) *StateTransition 
 		value:    msg.Value(),
 		data:     msg.Data(),
 		state:    evm.StateDB,
+		feePool:  feePool,
 	}
 }
 
@@ -164,8 +166,8 @@ func NewStateTransition(evm *vm.EVM, msg Message, gp *GasPool) *StateTransition 
 // the gas used (which includes gas refunds) and an error if it failed. An error always
 // indicates a core error meaning that the message would always fail for that particular
 // state and would never be accepted within a block.
-func ApplyMessage(evm *vm.EVM, msg Message, gp *GasPool) (*ExecutionResult, error) {
-	return NewStateTransition(evm, msg, gp).TransitionDb()
+func ApplyMessage(evm *vm.EVM, msg Message, gp *GasPool, feePool map[common.Address]*big.Int) (*ExecutionResult, error) {
+	return NewStateTransition(evm, msg, gp, feePool).TransitionDb()
 }
 
 // to returns the recipient of the message.

--- a/core/state_transition_viction.go
+++ b/core/state_transition_viction.go
@@ -21,35 +21,19 @@ func (st *StateTransition) vrc25BuyGas() error {
 	blockNum := st.evm.Context.BlockNumber
 
 	if !st.evm.ChainConfig().IsAtlas(blockNum) {
-		// Pre-Atlas path: use the running activeFeeBalance map for eligibility.
-		// This map is loaded from state at block start (beforeProcess) and
-		// decremented after each VRC25 tx (afterApplyTransaction), ensuring
-		// correct capacity tracking across multiple txs to the same token.
-		activeFeeBalanceMu.RLock()
-		fb := activeFeeBalance
-		activeFeeBalanceMu.RUnlock()
-		if st.msg.To() == nil {
+		// Pre-Atlas path: eligibility comes from the running fee pool threaded into
+		// this StateTransition. Block import seeds it in beforeProcess and
+		// decrements it via afterApplyTransaction; the tracing API seeds and
+		// decrements its own instance. A nil pool means no sponsorship — treat as a
+		// regular VIC transaction.
+		fb := st.feePool
+		if st.msg.To() == nil || fb == nil {
 			return nil
 		}
-
-		var feeCap *big.Int
-		if fb != nil {
-			// Block-import path: eligibility comes from the per-block running map,
-			// which beforeProcess loaded and afterApplyTransaction decrements.
-			var ok bool
-			feeCap, ok = fb[*st.msg.To()]
-			if !ok || feeCap == nil {
-				// Token not in the registered list — treat as regular VIC tx.
-				return nil
-			}
-		} else {
-			// Trace / off-chain re-execution path: beforeProcess never ran, so the
-			// running map is nil. Read capacity directly from state instead so the
-			// tracer reproduces sponsorship rather than charging VIC to the sender.
-			feeCap = vrc25.GetFeeCapacity(st.state, victionConfig.VRC25Contract, st.msg.To())
-			if feeCap == nil || feeCap.Sign() == 0 {
-				return nil
-			}
+		feeCap, ok := fb[*st.msg.To()]
+		if !ok || feeCap == nil {
+			// Token not in the registered list — treat as regular VIC tx.
+			return nil
 		}
 
 		var effectiveGasPrice *big.Int

--- a/core/state_transition_viction.go
+++ b/core/state_transition_viction.go
@@ -28,13 +28,28 @@ func (st *StateTransition) vrc25BuyGas() error {
 		activeFeeBalanceMu.RLock()
 		fb := activeFeeBalance
 		activeFeeBalanceMu.RUnlock()
-		if st.msg.To() == nil || fb == nil {
+		if st.msg.To() == nil {
 			return nil
 		}
-		feeCap, ok := fb[*st.msg.To()]
-		if !ok || feeCap == nil {
-			// Token not in the registered list — treat as regular VIC tx.
-			return nil
+
+		var feeCap *big.Int
+		if fb != nil {
+			// Block-import path: eligibility comes from the per-block running map,
+			// which beforeProcess loaded and afterApplyTransaction decrements.
+			var ok bool
+			feeCap, ok = fb[*st.msg.To()]
+			if !ok || feeCap == nil {
+				// Token not in the registered list — treat as regular VIC tx.
+				return nil
+			}
+		} else {
+			// Trace / off-chain re-execution path: beforeProcess never ran, so the
+			// running map is nil. Read capacity directly from state instead so the
+			// tracer reproduces sponsorship rather than charging VIC to the sender.
+			feeCap = vrc25.GetFeeCapacity(st.state, victionConfig.VRC25Contract, st.msg.To())
+			if feeCap == nil || feeCap.Sign() == 0 {
+				return nil
+			}
 		}
 
 		var effectiveGasPrice *big.Int

--- a/core/viction_fee_processor.go
+++ b/core/viction_fee_processor.go
@@ -34,25 +34,25 @@ func CopyVictionFeePool(src VictionFeePool) VictionFeePool {
 	return dst
 }
 
-// VictionProcessor owns the pre-Atlas VRC25 fee accounting for a single
+// VictionFeeProcessor owns the pre-Atlas VRC25 fee accounting for a single
 // execution over one block. It is a plain value type deliberately decoupled from
 // StateProcessor (which needs the blockchain and consensus engine), so that the
 // tracing API — which re-executes transactions with only a StateDB — can create
 // and drive its own instance with the exact same seed/decrement/flush logic as
 // block import. This is the single source of truth for the fee formula; block
 // import and tracing share it and therefore cannot diverge.
-type VictionProcessor struct {
+type VictionFeeProcessor struct {
 	config     *params.ChainConfig
 	feePool    VictionFeePool // running per-token capacity; nil = no sponsorship
 	feeUpdated VictionFeePool // tokens charged this block -> final capacity (flush)
 	totalFee   *big.Int       // total fee charged this block (flush)
 }
 
-// NewVictionProcessor builds the fee processor for a block. On pre-Atlas Viction
+// NewVictionFeeProcessor builds the fee processor for a block. On pre-Atlas Viction
 // blocks with a VRC25 issuer configured it snapshots all token fee capacities;
 // otherwise feePool stays nil and every transaction is a regular VIC tx.
-func NewVictionProcessor(config *params.ChainConfig, statedb vm.StateDB, blockNum *big.Int) *VictionProcessor {
-	vp := &VictionProcessor{
+func NewVictionFeeProcessor(config *params.ChainConfig, statedb vm.StateDB, blockNum *big.Int) *VictionFeeProcessor {
+	vp := &VictionFeeProcessor{
 		config:     config,
 		feeUpdated: make(VictionFeePool),
 		totalFee:   new(big.Int),
@@ -66,7 +66,7 @@ func NewVictionProcessor(config *params.ChainConfig, statedb vm.StateDB, blockNu
 
 // FeePool returns the running fee-capacity map to thread into ApplyMessage.
 // Safe on a nil receiver (returns nil).
-func (vp *VictionProcessor) FeePool() VictionFeePool {
+func (vp *VictionFeeProcessor) FeePool() VictionFeePool {
 	if vp == nil {
 		return nil
 	}
@@ -80,7 +80,7 @@ func (vp *VictionProcessor) FeePool() VictionFeePool {
 //
 // No-op on a nil receiver, post-Atlas blocks, non-VRC25 transactions, contract
 // creations, or when the pool has no entry for the token.
-func (vp *VictionProcessor) HandleFee(statedb vm.StateDB, blockNum *big.Int, tx *types.Transaction, from common.Address, usedGas uint64, failed bool) {
+func (vp *VictionFeeProcessor) HandleFee(statedb vm.StateDB, blockNum *big.Int, tx *types.Transaction, from common.Address, usedGas uint64, failed bool) {
 	if vp == nil || vp.feePool == nil || tx.To() == nil || vp.config.IsAtlas(blockNum) {
 		return
 	}
@@ -109,7 +109,7 @@ func (vp *VictionProcessor) HandleFee(statedb vm.StateDB, blockNum *big.Int, tx 
 // Flush writes the accumulated pre-Atlas fee updates back to state. Called once
 // per block after all transactions (block import only; tracing never flushes).
 // No-op when nothing was charged.
-func (vp *VictionProcessor) Flush(statedb vm.StateDB) {
+func (vp *VictionFeeProcessor) Flush(statedb vm.StateDB) {
 	if vp == nil || vp.feePool == nil || len(vp.feeUpdated) == 0 || vp.config.Viction == nil {
 		return
 	}

--- a/core/viction_processor.go
+++ b/core/viction_processor.go
@@ -1,0 +1,117 @@
+// Copyright 2026 The Vic-geth Authors
+package core
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/core/vrc25"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// VictionFeePool is the per-execution running map of VRC25 token fee capacities,
+// keyed by token (transaction recipient). It is threaded explicitly through
+// ApplyMessage as the StateTransition's feePool, so block import and each tracing
+// re-execution own an independent instance and never share fee state. A nil pool
+// means "no sponsorship" — every transaction is treated as a regular VIC tx.
+type VictionFeePool = map[common.Address]*big.Int
+
+// CopyVictionFeePool returns an independent deep copy of src (keys and *big.Int
+// values cloned), or nil if src is nil. The parallel block tracer gives each task
+// its own copy so worker goroutines never mutate a shared map.
+func CopyVictionFeePool(src VictionFeePool) VictionFeePool {
+	if src == nil {
+		return nil
+	}
+	dst := make(VictionFeePool, len(src))
+	for k, v := range src {
+		if v != nil {
+			dst[k] = new(big.Int).Set(v)
+		}
+	}
+	return dst
+}
+
+// VictionProcessor owns the pre-Atlas VRC25 fee accounting for a single
+// execution over one block. It is a plain value type deliberately decoupled from
+// StateProcessor (which needs the blockchain and consensus engine), so that the
+// tracing API — which re-executes transactions with only a StateDB — can create
+// and drive its own instance with the exact same seed/decrement/flush logic as
+// block import. This is the single source of truth for the fee formula; block
+// import and tracing share it and therefore cannot diverge.
+type VictionProcessor struct {
+	config     *params.ChainConfig
+	feePool    VictionFeePool // running per-token capacity; nil = no sponsorship
+	feeUpdated VictionFeePool // tokens charged this block -> final capacity (flush)
+	totalFee   *big.Int       // total fee charged this block (flush)
+}
+
+// NewVictionProcessor builds the fee processor for a block. On pre-Atlas Viction
+// blocks with a VRC25 issuer configured it snapshots all token fee capacities;
+// otherwise feePool stays nil and every transaction is a regular VIC tx.
+func NewVictionProcessor(config *params.ChainConfig, statedb vm.StateDB, blockNum *big.Int) *VictionProcessor {
+	vp := &VictionProcessor{
+		config:     config,
+		feeUpdated: make(VictionFeePool),
+		totalFee:   new(big.Int),
+	}
+	if !config.IsAtlas(blockNum) && config.Viction != nil &&
+		config.Viction.VRC25Contract != (common.Address{}) {
+		vp.feePool = vrc25.GetAllFeeCapacities(statedb, config.Viction.VRC25Contract)
+	}
+	return vp
+}
+
+// FeePool returns the running fee-capacity map to thread into ApplyMessage.
+// Safe on a nil receiver (returns nil).
+func (vp *VictionProcessor) FeePool() VictionFeePool {
+	if vp == nil {
+		return nil
+	}
+	return vp.feePool
+}
+
+// HandleFee applies the pre-Atlas per-transaction fee accounting: it decrements
+// the running pool for tx's token by the fee charged, records the update for the
+// end-of-block flush, and for a failed sponsored transaction applies the same
+// PayFeeWithVRC25 balance mutation as block import.
+//
+// No-op on a nil receiver, post-Atlas blocks, non-VRC25 transactions, contract
+// creations, or when the pool has no entry for the token.
+func (vp *VictionProcessor) HandleFee(statedb vm.StateDB, blockNum *big.Int, tx *types.Transaction, from common.Address, usedGas uint64, failed bool) {
+	if vp == nil || vp.feePool == nil || tx.To() == nil || vp.config.IsAtlas(blockNum) {
+		return
+	}
+	token := *tx.To()
+	runningCap, ok := vp.feePool[token]
+	if !ok || runningCap == nil {
+		return
+	}
+	vicCfg := vp.config.Viction
+	fee := new(big.Int).SetUint64(usedGas)
+	if vp.config.TIPTRC21FeeBlock != nil && blockNum.Cmp(vp.config.TIPTRC21FeeBlock) > 0 &&
+		vicCfg != nil && vicCfg.VRC25GasPrice != nil {
+		fee = new(big.Int).Mul(fee, (*big.Int)(vicCfg.VRC25GasPrice))
+	}
+	if runningCap.Cmp(fee) > 0 {
+		newCap := new(big.Int).Sub(runningCap, fee)
+		vp.feePool[token] = newCap
+		vp.feeUpdated[token] = newCap
+		vp.totalFee.Add(vp.totalFee, fee)
+		if failed {
+			vrc25.PayFeeWithVRC25(statedb, from, token)
+		}
+	}
+}
+
+// Flush writes the accumulated pre-Atlas fee updates back to state. Called once
+// per block after all transactions (block import only; tracing never flushes).
+// No-op when nothing was charged.
+func (vp *VictionProcessor) Flush(statedb vm.StateDB) {
+	if vp == nil || vp.feePool == nil || len(vp.feeUpdated) == 0 || vp.config.Viction == nil {
+		return
+	}
+	vrc25.UpdateFeeCapacity(statedb, vp.config.Viction.VRC25Contract, vp.feeUpdated, vp.totalFee)
+}

--- a/eth/api.go
+++ b/eth/api.go
@@ -419,7 +419,7 @@ func (api *PrivateDebugAPI) StorageRangeAt(blockHash common.Hash, txIndex int, c
 	if block == nil {
 		return StorageRangeResult{}, fmt.Errorf("block %#x not found", blockHash)
 	}
-	_, _, statedb, err := api.computeTxEnv(block, txIndex, 0)
+	_, _, statedb, _, err := api.computeTxEnv(block, txIndex, 0)
 	if err != nil {
 		return StorageRangeResult{}, err
 	}

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -96,8 +96,9 @@ type blockTraceResult struct {
 // txTraceTask represents a single transaction trace task when an entire block
 // is being traced.
 type txTraceTask struct {
-	statedb *state.StateDB // Intermediate state prepped for tracing
-	index   int            // Transaction offset in the block
+	statedb *state.StateDB      // Intermediate state prepped for tracing
+	index   int                 // Transaction offset in the block
+	feePool core.VictionFeePool // Running VRC25 fee capacities as of this tx (copy)
 }
 
 // TraceChain returns the structured logs created during the execution of EVM
@@ -204,10 +205,13 @@ func (api *PrivateDebugAPI) traceChain(ctx context.Context, start, end *types.Bl
 			for task := range tasks {
 				signer := types.MakeSigner(api.eth.blockchain.Config(), task.block.Number())
 				blockCtx := core.NewEVMBlockContext(task.block.Header(), api.eth.blockchain, nil)
+				// Seed the running VRC25 fee pool from the block's opening state so
+				// sponsored transactions are reproduced during the chain trace.
+				feePool := core.NewVictionProcessor(api.eth.blockchain.Config(), task.statedb, task.block.Number()).FeePool()
 				// Trace all the transactions contained within
 				for i, tx := range task.block.Transactions() {
 					msg, _ := tx.AsMessage(signer)
-					res, err := api.traceTx(ctx, msg, blockCtx, task.statedb, config)
+					res, err := api.traceTx(ctx, msg, blockCtx, task.statedb, feePool, config)
 					if err != nil {
 						task.results[i] = &txTraceResult{Error: err.Error()}
 						log.Warn("Tracing failed", "hash", tx.Hash(), "block", task.block.NumberU64(), "err", err)
@@ -476,7 +480,7 @@ func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, 
 			// Fetch and execute the next transaction trace tasks
 			for task := range jobs {
 				msg, _ := txs[task.index].AsMessage(signer)
-				res, err := api.traceTx(ctx, msg, blockCtx, task.statedb, config)
+				res, err := api.traceTx(ctx, msg, blockCtx, task.statedb, task.feePool, config)
 				if err != nil {
 					results[task.index] = &txTraceResult{Error: err.Error()}
 					continue
@@ -486,26 +490,36 @@ func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, 
 		}()
 	}
 	// Feed the transactions into the tracers and return
+	cfg := api.eth.blockchain.Config()
+	// Running VRC25 fee pool for the block; each task gets a copy of its current
+	// state, and the driver decrements it as it advances the shared state — so a
+	// task sees the capacities as they stood just before its own transaction.
+	feeProc := core.NewVictionProcessor(cfg, statedb, block.Number())
+	feePool := feeProc.FeePool()
 	var failed error
 	for i, tx := range txs {
 		msg, _ := tx.AsMessage(signer)
 		// Reproduce Viction per-tx pre-checks (balance override + blacklist) on the
 		// shared state before snapshotting it for the tracer, mirroring block import.
-		if err := core.BeforeApplyTransaction(api.eth.blockchain.Config(), block, tx, msg, statedb); err != nil {
+		if err := core.BeforeApplyTransaction(cfg, block, tx, msg, statedb); err != nil {
 			failed = err
 			break
 		}
 		// Send the trace task over for execution
-		jobs <- &txTraceTask{statedb: statedb.Copy(), index: i}
+		jobs <- &txTraceTask{statedb: statedb.Copy(), index: i, feePool: core.CopyVictionFeePool(feePool)}
 
 		// Generate the next state snapshot fast without tracing
 		txContext := core.NewEVMTxContext(msg)
 
-		vmenv := vm.NewEVM(blockCtx, txContext, statedb, api.eth.blockchain.Config(), vm.Config{})
-		if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.Gas())); err != nil {
+		vmenv := vm.NewEVM(blockCtx, txContext, statedb, cfg, vm.Config{})
+		res, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.Gas()), feePool)
+		if err != nil {
 			failed = err
 			break
 		}
+		// Decrement the running fee pool exactly as block import does, so the next
+		// task's copy starts from post-drain capacities.
+		feeProc.HandleFee(statedb, block.Number(), tx, msg.From(), res.UsedGas, res.Failed())
 		// Finalize the state so any modifications are written to the trie
 		// Only delete empty objects if EIP158/161 (a.k.a Spurious Dragon) is in effect
 		statedb.Finalise(vmenv.ChainConfig().IsEIP158(block.Number()))
@@ -582,6 +596,10 @@ func (api *PrivateDebugAPI) standardTraceBlockToFile(ctx context.Context, block 
 			canon = false
 		}
 	}
+	// Running VRC25 fee pool for the block, decremented per tx as execution
+	// advances, so sponsored transactions are reproduced with correct capacities.
+	feeProc := core.NewVictionProcessor(chainConfig, statedb, block.Number())
+	feePool := feeProc.FeePool()
 	for i, tx := range block.Transactions() {
 		// Prepare the trasaction for un-traced execution
 		var (
@@ -620,13 +638,17 @@ func (api *PrivateDebugAPI) standardTraceBlockToFile(ctx context.Context, block 
 		}
 		// Execute the transaction and flush any traces to disk
 		vmenv := vm.NewEVM(vmctx, txContext, statedb, chainConfig, vmConf)
-		_, err = core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.Gas()))
+		res, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.Gas()), feePool)
 		if writer != nil {
 			writer.Flush()
 		}
 		if dump != nil {
 			dump.Close()
 			log.Info("Wrote standard trace", "file", dump.Name())
+		}
+		if err == nil {
+			// Decrement the running fee pool exactly as block import does.
+			feeProc.HandleFee(statedb, block.Number(), tx, msg.From(), res.UsedGas, res.Failed())
 		}
 		if err != nil {
 			return dumps, err
@@ -740,12 +762,12 @@ func (api *PrivateDebugAPI) TraceTransaction(ctx context.Context, hash common.Ha
 	if block == nil {
 		return nil, fmt.Errorf("block %#x not found", blockHash)
 	}
-	msg, vmctx, statedb, err := api.computeTxEnv(block, int(index), reexec)
+	msg, vmctx, statedb, feePool, err := api.computeTxEnv(block, int(index), reexec)
 	if err != nil {
 		return nil, err
 	}
 	// Trace the transaction and return
-	return api.traceTx(ctx, msg, vmctx, statedb, config)
+	return api.traceTx(ctx, msg, vmctx, statedb, feePool, config)
 }
 
 // TraceCall lets you trace a given eth_call. It collects the structured logs created during the execution of EVM
@@ -754,6 +776,9 @@ func (api *PrivateDebugAPI) TraceTransaction(ctx context.Context, hash common.Ha
 func (api *PrivateDebugAPI) TraceCall(ctx context.Context, args ethapi.CallArgs, blockNrOrHash rpc.BlockNumberOrHash, config *TraceConfig) (interface{}, error) {
 	// First try to retrieve the state
 	statedb, header, err := api.eth.APIBackend.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
+	// feePool is populated only when state is recomputed from a block below;
+	// nil otherwise (the live-state path needs no sponsorship pool).
+	var feePool core.VictionFeePool
 	if err != nil {
 		// Try to retrieve the specified block
 		var block *types.Block
@@ -770,7 +795,7 @@ func (api *PrivateDebugAPI) TraceCall(ctx context.Context, args ethapi.CallArgs,
 		if config != nil && config.Reexec != nil {
 			reexec = *config.Reexec
 		}
-		_, _, statedb, err = api.computeTxEnv(block, 0, reexec)
+		_, _, statedb, feePool, err = api.computeTxEnv(block, 0, reexec)
 		if err != nil {
 			return nil, err
 		}
@@ -779,13 +804,13 @@ func (api *PrivateDebugAPI) TraceCall(ctx context.Context, args ethapi.CallArgs,
 	// Execute the trace
 	msg := args.ToMessage(api.eth.APIBackend.RPCGasCap())
 	vmctx := core.NewEVMBlockContext(header, api.eth.blockchain, nil)
-	return api.traceTx(ctx, msg, vmctx, statedb, config)
+	return api.traceTx(ctx, msg, vmctx, statedb, feePool, config)
 }
 
 // traceTx configures a new tracer according to the provided configuration, and
 // executes the given message in the provided environment. The return value will
 // be tracer dependent.
-func (api *PrivateDebugAPI) traceTx(ctx context.Context, message core.Message, vmctx vm.BlockContext, statedb *state.StateDB, config *TraceConfig) (interface{}, error) {
+func (api *PrivateDebugAPI) traceTx(ctx context.Context, message core.Message, vmctx vm.BlockContext, statedb *state.StateDB, feePool core.VictionFeePool, config *TraceConfig) (interface{}, error) {
 	// Assemble the structured logger or the JavaScript tracer
 	var (
 		tracer    vm.Tracer
@@ -822,7 +847,7 @@ func (api *PrivateDebugAPI) traceTx(ctx context.Context, message core.Message, v
 	// Run the transaction with tracing enabled.
 	vmenv := vm.NewEVM(vmctx, txContext, statedb, api.eth.blockchain.Config(), vm.Config{Debug: true, Tracer: tracer})
 
-	result, err := core.ApplyMessage(vmenv, message, new(core.GasPool).AddGas(message.Gas()))
+	result, err := core.ApplyMessage(vmenv, message, new(core.GasPool).AddGas(message.Gas()), feePool)
 	if err != nil {
 		return nil, fmt.Errorf("tracing failed: %v", err)
 	}
@@ -849,46 +874,57 @@ func (api *PrivateDebugAPI) traceTx(ctx context.Context, message core.Message, v
 	}
 }
 
-// computeTxEnv returns the execution environment of a certain transaction.
-func (api *PrivateDebugAPI) computeTxEnv(block *types.Block, txIndex int, reexec uint64) (core.Message, vm.BlockContext, *state.StateDB, error) {
+// computeTxEnv returns the execution environment of a certain transaction. The
+// returned feePool is the running VRC25 fee pool decremented up to (but not
+// including) the target transaction, so the caller's traceTx reproduces its
+// sponsorship with the correct capacity.
+func (api *PrivateDebugAPI) computeTxEnv(block *types.Block, txIndex int, reexec uint64) (core.Message, vm.BlockContext, *state.StateDB, core.VictionFeePool, error) {
 	// Create the parent state database
 	parent := api.eth.blockchain.GetBlock(block.ParentHash(), block.NumberU64()-1)
 	if parent == nil {
-		return nil, vm.BlockContext{}, nil, fmt.Errorf("parent %#x not found", block.ParentHash())
+		return nil, vm.BlockContext{}, nil, nil, fmt.Errorf("parent %#x not found", block.ParentHash())
 	}
 	statedb, err := api.computeStateDB(parent, reexec)
 	if err != nil {
-		return nil, vm.BlockContext{}, nil, err
+		return nil, vm.BlockContext{}, nil, nil, err
 	}
 
 	if txIndex == 0 && len(block.Transactions()) == 0 {
-		return nil, vm.BlockContext{}, statedb, nil
+		return nil, vm.BlockContext{}, statedb, nil, nil
 	}
 
 	// Recompute transactions up to the target index.
-	signer := types.MakeSigner(api.eth.blockchain.Config(), block.Number())
+	cfg := api.eth.blockchain.Config()
+	signer := types.MakeSigner(cfg, block.Number())
+	// Running fee pool, decremented per replayed tx so the target tx sees the
+	// capacities as they stood just before it.
+	feeProc := core.NewVictionProcessor(cfg, statedb, block.Number())
+	feePool := feeProc.FeePool()
 
 	for idx, tx := range block.Transactions() {
 		// Assemble the transaction call message and return if the requested offset
 		msg, _ := tx.AsMessage(signer)
 		// Reproduce Viction per-tx pre-checks (balance override + blacklist) before
 		// executing or returning, mirroring block import.
-		if err := core.BeforeApplyTransaction(api.eth.blockchain.Config(), block, tx, msg, statedb); err != nil {
-			return nil, vm.BlockContext{}, nil, err
+		if err := core.BeforeApplyTransaction(cfg, block, tx, msg, statedb); err != nil {
+			return nil, vm.BlockContext{}, nil, nil, err
 		}
 		txContext := core.NewEVMTxContext(msg)
 		context := core.NewEVMBlockContext(block.Header(), api.eth.blockchain, nil)
 		if idx == txIndex {
-			return msg, context, statedb, nil
+			return msg, context, statedb, feePool, nil
 		}
 		// Not yet the searched for transaction, execute on top of the current state
-		vmenv := vm.NewEVM(context, txContext, statedb, api.eth.blockchain.Config(), vm.Config{})
-		if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(tx.Gas())); err != nil {
-			return nil, vm.BlockContext{}, nil, fmt.Errorf("transaction %#x failed: %v", tx.Hash(), err)
+		vmenv := vm.NewEVM(context, txContext, statedb, cfg, vm.Config{})
+		res, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(tx.Gas()), feePool)
+		if err != nil {
+			return nil, vm.BlockContext{}, nil, nil, fmt.Errorf("transaction %#x failed: %v", tx.Hash(), err)
 		}
+		// Decrement the running fee pool exactly as block import does.
+		feeProc.HandleFee(statedb, block.Number(), tx, msg.From(), res.UsedGas, res.Failed())
 		// Ensure any modifications are committed to the state
 		// Only delete empty objects if EIP158/161 (a.k.a Spurious Dragon) is in effect
 		statedb.Finalise(vmenv.ChainConfig().IsEIP158(block.Number()))
 	}
-	return nil, vm.BlockContext{}, nil, fmt.Errorf("transaction index %d out of range for block %#x", txIndex, block.Hash())
+	return nil, vm.BlockContext{}, nil, nil, fmt.Errorf("transaction index %d out of range for block %#x", txIndex, block.Hash())
 }

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -488,11 +488,17 @@ func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, 
 	// Feed the transactions into the tracers and return
 	var failed error
 	for i, tx := range txs {
+		msg, _ := tx.AsMessage(signer)
+		// Reproduce Viction per-tx pre-checks (balance override + blacklist) on the
+		// shared state before snapshotting it for the tracer, mirroring block import.
+		if err := core.BeforeApplyTransaction(api.eth.blockchain.Config(), block, tx, msg, statedb); err != nil {
+			failed = err
+			break
+		}
 		// Send the trace task over for execution
 		jobs <- &txTraceTask{statedb: statedb.Copy(), index: i}
 
 		// Generate the next state snapshot fast without tracing
-		msg, _ := tx.AsMessage(signer)
 		txContext := core.NewEVMTxContext(msg)
 
 		vmenv := vm.NewEVM(blockCtx, txContext, statedb, api.eth.blockchain.Config(), vm.Config{})
@@ -606,6 +612,11 @@ func (api *PrivateDebugAPI) standardTraceBlockToFile(ctx context.Context, block 
 				Tracer:                  vm.NewJSONLogger(&logConfig, writer),
 				EnablePreimageRecording: true,
 			}
+		}
+		// Reproduce Viction per-tx pre-checks (balance override + blacklist) before
+		// execution, mirroring block import.
+		if err = core.BeforeApplyTransaction(chainConfig, block, tx, msg, statedb); err != nil {
+			return dumps, err
 		}
 		// Execute the transaction and flush any traces to disk
 		vmenv := vm.NewEVM(vmctx, txContext, statedb, chainConfig, vmConf)
@@ -860,6 +871,11 @@ func (api *PrivateDebugAPI) computeTxEnv(block *types.Block, txIndex int, reexec
 	for idx, tx := range block.Transactions() {
 		// Assemble the transaction call message and return if the requested offset
 		msg, _ := tx.AsMessage(signer)
+		// Reproduce Viction per-tx pre-checks (balance override + blacklist) before
+		// executing or returning, mirroring block import.
+		if err := core.BeforeApplyTransaction(api.eth.blockchain.Config(), block, tx, msg, statedb); err != nil {
+			return nil, vm.BlockContext{}, nil, err
+		}
 		txContext := core.NewEVMTxContext(msg)
 		context := core.NewEVMBlockContext(block.Header(), api.eth.blockchain, nil)
 		if idx == txIndex {

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -207,7 +207,7 @@ func (api *PrivateDebugAPI) traceChain(ctx context.Context, start, end *types.Bl
 				blockCtx := core.NewEVMBlockContext(task.block.Header(), api.eth.blockchain, nil)
 				// Seed the running VRC25 fee pool from the block's opening state so
 				// sponsored transactions are reproduced during the chain trace.
-				feePool := core.NewVictionProcessor(api.eth.blockchain.Config(), task.statedb, task.block.Number()).FeePool()
+				feePool := core.NewVictionFeeProcessor(api.eth.blockchain.Config(), task.statedb, task.block.Number()).FeePool()
 				// Trace all the transactions contained within
 				for i, tx := range task.block.Transactions() {
 					msg, _ := tx.AsMessage(signer)
@@ -494,7 +494,7 @@ func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, 
 	// Running VRC25 fee pool for the block; each task gets a copy of its current
 	// state, and the driver decrements it as it advances the shared state — so a
 	// task sees the capacities as they stood just before its own transaction.
-	feeProc := core.NewVictionProcessor(cfg, statedb, block.Number())
+	feeProc := core.NewVictionFeeProcessor(cfg, statedb, block.Number())
 	feePool := feeProc.FeePool()
 	var failed error
 	for i, tx := range txs {
@@ -598,7 +598,7 @@ func (api *PrivateDebugAPI) standardTraceBlockToFile(ctx context.Context, block 
 	}
 	// Running VRC25 fee pool for the block, decremented per tx as execution
 	// advances, so sponsored transactions are reproduced with correct capacities.
-	feeProc := core.NewVictionProcessor(chainConfig, statedb, block.Number())
+	feeProc := core.NewVictionFeeProcessor(chainConfig, statedb, block.Number())
 	feePool := feeProc.FeePool()
 	for i, tx := range block.Transactions() {
 		// Prepare the trasaction for un-traced execution
@@ -898,7 +898,7 @@ func (api *PrivateDebugAPI) computeTxEnv(block *types.Block, txIndex int, reexec
 	signer := types.MakeSigner(cfg, block.Number())
 	// Running fee pool, decremented per replayed tx so the target tx sees the
 	// capacities as they stood just before it.
-	feeProc := core.NewVictionProcessor(cfg, statedb, block.Number())
+	feeProc := core.NewVictionFeeProcessor(cfg, statedb, block.Number())
 	feePool := feeProc.FeePool()
 
 	for idx, tx := range block.Transactions() {

--- a/eth/tracers/tracers_test.go
+++ b/eth/tracers/tracers_test.go
@@ -183,7 +183,7 @@ func TestPrestateTracerCreate2(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to prepare transaction for tracing: %v", err)
 	}
-	st := core.NewStateTransition(evm, msg, new(core.GasPool).AddGas(tx.Gas()))
+	st := core.NewStateTransition(evm, msg, new(core.GasPool).AddGas(tx.Gas()), nil)
 	if _, err = st.TransitionDb(); err != nil {
 		t.Fatalf("failed to execute transaction: %v", err)
 	}
@@ -258,7 +258,7 @@ func TestCallTracer(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to prepare transaction for tracing: %v", err)
 			}
-			st := core.NewStateTransition(evm, msg, new(core.GasPool).AddGas(tx.Gas()))
+			st := core.NewStateTransition(evm, msg, new(core.GasPool).AddGas(tx.Gas()), nil)
 			if _, err = st.TransitionDb(); err != nil {
 				t.Fatalf("failed to execute transaction: %v", err)
 			}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -878,7 +878,10 @@ func DoCall(ctx context.Context, b Backend, args CallArgs, blockNrOrHash rpc.Blo
 	// Setup the gas pool (also for unmetered requests)
 	// and apply the message.
 	gp := new(core.GasPool).AddGas(math.MaxUint64)
-	result, err := core.ApplyMessage(evm, msg, gp)
+	// Reproduce VRC25 sponsorship for this call: nil post-Atlas (capacity read
+	// from state) and for non-Viction chains; the pre-Atlas running map otherwise.
+	feePool := core.NewVictionProcessor(evm.ChainConfig(), state, header.Number).FeePool()
+	result, err := core.ApplyMessage(evm, msg, gp, feePool)
 	if err := vmError(); err != nil {
 		return nil, err
 	}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -651,10 +651,10 @@ func (s *PublicBlockChainAPI) GetHeaderByHash(ctx context.Context, hash common.H
 }
 
 // GetBlockByNumber returns the requested canonical block.
-// * When blockNr is -1 the chain head is returned.
-// * When blockNr is -2 the pending chain head is returned.
-// * When fullTx is true all transactions in the block are returned, otherwise
-//   only the transaction hash is returned.
+//   - When blockNr is -1 the chain head is returned.
+//   - When blockNr is -2 the pending chain head is returned.
+//   - When fullTx is true all transactions in the block are returned, otherwise
+//     only the transaction hash is returned.
 func (s *PublicBlockChainAPI) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber, fullTx bool) (map[string]interface{}, error) {
 	block, err := s.b.BlockByNumber(ctx, number)
 	if block != nil && err == nil {
@@ -880,7 +880,7 @@ func DoCall(ctx context.Context, b Backend, args CallArgs, blockNrOrHash rpc.Blo
 	gp := new(core.GasPool).AddGas(math.MaxUint64)
 	// Reproduce VRC25 sponsorship for this call: nil post-Atlas (capacity read
 	// from state) and for non-Viction chains; the pre-Atlas running map otherwise.
-	feePool := core.NewVictionProcessor(evm.ChainConfig(), state, header.Number).FeePool()
+	feePool := core.NewVictionFeeProcessor(evm.ChainConfig(), state, header.Number).FeePool()
 	result, err := core.ApplyMessage(evm, msg, gp, feePool)
 	if err := vmError(); err != nil {
 		return nil, err

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -651,10 +651,10 @@ func (s *PublicBlockChainAPI) GetHeaderByHash(ctx context.Context, hash common.H
 }
 
 // GetBlockByNumber returns the requested canonical block.
-//   - When blockNr is -1 the chain head is returned.
-//   - When blockNr is -2 the pending chain head is returned.
-//   - When fullTx is true all transactions in the block are returned, otherwise
-//     only the transaction hash is returned.
+// * When blockNr is -1 the chain head is returned.
+// * When blockNr is -2 the pending chain head is returned.
+// * When fullTx is true all transactions in the block are returned, otherwise
+//   only the transaction hash is returned.
 func (s *PublicBlockChainAPI) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber, fullTx bool) (map[string]interface{}, error) {
 	block, err := s.b.BlockByNumber(ctx, number)
 	if block != nil && err == nil {

--- a/les/odr_test.go
+++ b/les/odr_test.go
@@ -136,7 +136,7 @@ func odrContractCall(ctx context.Context, db ethdb.Database, config *params.Chai
 
 				//vmenv := core.NewEnv(statedb, config, bc, msg, header, vm.Config{})
 				gp := new(core.GasPool).AddGas(math.MaxUint64)
-				result, _ := core.ApplyMessage(vmenv, msg, gp)
+				result, _ := core.ApplyMessage(vmenv, msg, gp, nil)
 				res = append(res, result.Return()...)
 			}
 		} else {
@@ -148,7 +148,7 @@ func odrContractCall(ctx context.Context, db ethdb.Database, config *params.Chai
 			txContext := core.NewEVMTxContext(msg)
 			vmenv := vm.NewEVM(context, txContext, state, config, vm.Config{})
 			gp := new(core.GasPool).AddGas(math.MaxUint64)
-			result, _ := core.ApplyMessage(vmenv, msg, gp)
+			result, _ := core.ApplyMessage(vmenv, msg, gp, nil)
 			if state.Error() == nil {
 				res = append(res, result.Return()...)
 			}

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -200,7 +200,7 @@ func (t *StateTest) RunNoVerify(subtest StateSubtest, vmconfig vm.Config, snapsh
 	gaspool := new(core.GasPool)
 	gaspool.AddGas(block.GasLimit())
 	snapshot := statedb.Snapshot()
-	if _, err := core.ApplyMessage(evm, msg, gaspool); err != nil {
+	if _, err := core.ApplyMessage(evm, msg, gaspool, nil); err != nil {
 		statedb.RevertToSnapshot(snapshot)
 	}
 	// Commit block


### PR DESCRIPTION
## Fix Viction transaction tracing and pre-Atlas VRC25 fee accounting

### Problem
Tracing APIs (`debug_traceBlock*`, `debug_traceTransaction`) and `eth_call` re-execute
transactions without the Viction-specific processing that block import applies:
pre-Atlas sponsored (VRC25) fee-pool accounting and per-transaction Viction pre-checks.
Traces of pre-Atlas blocks with sponsored transactions produced wrong token balances.

### Changes
- `VictionFeeProcessor` (`core/viction_fee_processor.go`): owns the pre-Atlas VRC25
  fee pool (seed / HandleFee / Flush / Copy). One implementation shared by block import
  and every tracer path; per-goroutine `Copy()` keeps parallel tracing race-free.
- Tracer and `eth_call` paths now run Viction pre-checks (`BeforeApplyTransaction`)
  and thread the fee pool through re-execution (`eth/api_tracer.go`,
  `internal/ethapi/api.go`).
- `vrc25BuyGas` fee-capacity checks hardened.

### Verification
- `make geth` green; `go test ./core/ ./eth/tracers/...` — no new failures vs baseline.
- Trace output for pre-Atlas sponsored transactions now matches block-import accounting.
