### PR TITLE
fix/align posv header marshaling with production format

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -35,7 +35,6 @@ import (
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/consensus/clique"
 	"github.com/ethereum/go-ethereum/consensus/ethash"
-	"github.com/ethereum/go-ethereum/consensus/posv"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/viction"
@@ -1150,17 +1149,9 @@ func RPCMarshalHeader(head *types.Header) map[string]interface{} {
 		"receiptsRoot":     head.ReceiptHash,
 	}
 	if head.Posv {
-		fields["posv"] = head.Posv
-		if len(head.NewAttestors) > 0 {
-			fields["newAttestors"] = posv.DecodeAttestorsFromHeader(head.NewAttestors)
-			fields["validators"] = posv.ExtractValidatorsFromCheckpointHeader(head) // only at checkpoint
-		}
-		if len(head.Attestor) > 0 {
-			fields["attestor"] = hexutil.Bytes(head.Attestor)
-		}
-		if len(head.Penalties) > 0 {
-			fields["penalties"] = posv.DecodePenaltiesFromHeader(head.Penalties)
-		}
+		fields["validators"] = hexutil.Bytes(head.NewAttestors)
+		fields["validator"] = hexutil.Bytes(head.Attestor)
+		fields["penalties"] = hexutil.Bytes(head.Penalties)
 	}
 	return fields
 }


### PR DESCRIPTION
## Summary
- Align PoSV header/block RPC marshaling with legacy Viction production response format.
- Restore field names and raw hex encoding expected by existing clients and explorers.

## Root Cause
`RPCMarshalHeader` was changed to emit a new decoded PoSV shape (`posv`, `attestor`, `newAttestors`, and address-array `validators`/`penalties`). Production nodes still return the legacy format (`validator`, `validators`, `penalties` as raw hex), so responses from `vic-geth` were incompatible with current consumers.

## Solution
Update `RPCMarshalHeader` to always marshal PoSV fields in the legacy production format:
- `validators` ← raw `NewAttestors` hex
- `validator` ← raw `Attestor` hex
- `penalties` ← raw `Penalties` hex

Remove the decoded/extra fields (`posv`, `attestor`, `newAttestors`) from this response path.