### PR TITLE
fix: return raw POSV header fields for Viction RPC compatibility

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -35,7 +35,6 @@ import (
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/consensus/clique"
 	"github.com/ethereum/go-ethereum/consensus/ethash"
-	"github.com/ethereum/go-ethereum/consensus/posv"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/viction"
@@ -1150,17 +1149,9 @@ func RPCMarshalHeader(head *types.Header) map[string]interface{} {
 		"receiptsRoot":     head.ReceiptHash,
 	}
 	if head.Posv {
-		fields["posv"] = head.Posv
-		if len(head.NewAttestors) > 0 {
-			fields["newAttestors"] = posv.DecodeAttestorsFromHeader(head.NewAttestors)
-			fields["validators"] = posv.ExtractValidatorsFromCheckpointHeader(head) // only at checkpoint
-		}
-		if len(head.Attestor) > 0 {
-			fields["attestor"] = hexutil.Bytes(head.Attestor)
-		}
-		if len(head.Penalties) > 0 {
-			fields["penalties"] = posv.DecodePenaltiesFromHeader(head.Penalties)
-		}
+		fields["newAttestors"] = hexutil.Bytes(head.NewAttestors)
+		fields["attestor"] = hexutil.Bytes(head.Attestor)
+		fields["penalties"] = hexutil.Bytes(head.Penalties)
 	}
 	return fields
 }


### PR DESCRIPTION
## Summary

Update `RPCMarshalHeader` so POSV header fields in block/header RPC responses (`newAttestors`, `attestor`, `penalties`) are returned as raw hex-encoded bytes, matching Viction's expected RPC shape.

## Root Cause

`RPCMarshalHeader` was decoding POSV header data before exposing it — turning `NewAttestors`/`Penalties` into address lists, adding a `validators` field from the checkpoint header, and emitting a `posv` flag. That diverged from Viction clients/tools that expect the original encoded byte fields from the header.

## Solution

When `head.Posv` is set, marshal `newAttestors`, `attestor`, and `penalties` directly as `hexutil.Bytes`, and drop the decoded `posv`/`validators` fields and POSV decode helpers from this path.