### PR TITLE
fix: improve error handling and logging in Viction state management

### DIFF
--- a/core/blockchain_viction.go
+++ b/core/blockchain_viction.go
@@ -50,18 +50,18 @@ func (bc *BlockChain) commitVictionStateDirect(block *types.Block) error {
 		tradingRoot := sp.viction.CommittedTradingRoot()
 		if tradingRoot != (common.Hash{}) {
 			if err := sp.viction.TradingEngine().GetStateCache().TrieDB().Commit(tradingRoot, false, nil); err != nil {
-				return fmt.Errorf("TomoX: trading trieDB.Commit(archive) failed at block %d: %w", block.NumberU64(), err)
+				return fmt.Errorf("[TomoX]: trading trieDB.Commit(archive) failed at block %d: %w", block.NumberU64(), err)
 			}
-			log.Trace("TomoX: trading trie flushed to disk (archive)", "block", block.NumberU64(), "root", tradingRoot.Hex())
+			log.Trace("[TomoX]: trading trie flushed to disk (archive)", "block", block.NumberU64(), "root", tradingRoot.Hex())
 		}
 	}
 	if sp.viction.HasLendingState() && sp.viction.LendingEngine() != nil {
 		lendingRoot := sp.viction.CommittedLendingRoot()
 		if lendingRoot != (common.Hash{}) {
 			if err := sp.viction.LendingEngine().GetStateCache().TrieDB().Commit(lendingRoot, false, nil); err != nil {
-				return fmt.Errorf("TomoZ: lending trieDB.Commit(archive) failed at block %d: %w", block.NumberU64(), err)
+				return fmt.Errorf("[TomoZ]: lending trieDB.Commit(archive) failed at block %d: %w", block.NumberU64(), err)
 			}
-			log.Trace("TomoZ: lending trie flushed to disk (archive)", "block", block.NumberU64(), "root", lendingRoot.Hex())
+			log.Trace("[TomoZ]: lending trie flushed to disk (archive)", "block", block.NumberU64(), "root", lendingRoot.Hex())
 		}
 	}
 	return nil
@@ -94,10 +94,13 @@ func (bc *BlockChain) commitVictionStateDeferred(block *types.Block) error {
 			tradingTrieDB.Reference(tradingRoot, common.Hash{})
 			sp.tradingTriegc.Push(tradingRoot, -int64(current))
 
-			if err := tradingTrieDB.Commit(tradingRoot, true, nil); err != nil {
-				log.Error("TomoX: trading trieDB.Commit failed", "block", current, "err", err)
+			// report=false: this runs on every block, so an Info-level flush
+			// summary here would spam the log (upstream reserves report=true for
+			// the once-per-TriesInMemory EVM flush).
+			if err := tradingTrieDB.Commit(tradingRoot, false, nil); err != nil {
+				log.Error("[TomoX]: trading trieDB.Commit failed", "block", current, "err", err)
 			} else {
-				log.Trace("TomoX: trading trie flushed to disk", "block", current, "root", tradingRoot)
+				log.Trace("[TomoX]: trading trie flushed to disk", "block", current, "root", tradingRoot)
 			}
 
 			// Dereference roots old enough to no longer need keeping in memory.
@@ -123,10 +126,11 @@ func (bc *BlockChain) commitVictionStateDeferred(block *types.Block) error {
 			lendingTrieDB.Reference(lendingRoot, common.Hash{})
 			sp.lendingTriegc.Push(lendingRoot, -int64(current))
 
-			if err := lendingTrieDB.Commit(lendingRoot, true, nil); err != nil {
-				log.Error("TomoZ: lending trieDB.Commit failed", "block", current, "err", err)
+			// report=false, same reasoning as the trading trie above.
+			if err := lendingTrieDB.Commit(lendingRoot, false, nil); err != nil {
+				log.Error("[TomoZ]: lending trieDB.Commit failed", "block", current, "err", err)
 			} else {
-				log.Trace("TomoZ: lending trie flushed to disk", "block", current, "root", lendingRoot)
+				log.Trace("[TomoZ]: lending trie flushed to disk", "block", current, "root", lendingRoot)
 			}
 
 			if current > TriesInMemory {
@@ -154,17 +158,18 @@ func (bc *BlockChain) stopViction() {
 		return // archive mode commits every block; nothing to flush here
 	}
 	sp, ok := bc.processor.(*StateProcessor)
-	if !ok || sp == nil {
+	if !ok || sp == nil || sp.viction == nil {
 		return
 	}
 
 	// Flush all remaining trading trie roots to LevelDB.
 	if sp.viction.TradingEngine() != nil {
 		tradingTrieDB := sp.viction.TradingEngine().GetStateCache().TrieDB()
+		log.Info("[TomoX]: Flushing remaining trading trie roots to LevelDB", "count", sp.tradingTriegc.Size())
 		for !sp.tradingTriegc.Empty() {
 			root := sp.tradingTriegc.PopItem().(common.Hash)
-			if err := tradingTrieDB.Commit(root, true, nil); err != nil {
-				log.Error("TomoX: trading trieDB.Commit(shutdown) failed", "root", root, "err", err)
+			if err := tradingTrieDB.Commit(root, false, nil); err != nil {
+				log.Error("[TomoX]: trading trieDB.Commit(shutdown) failed", "root", root, "err", err)
 			}
 			tradingTrieDB.Dereference(root)
 		}
@@ -173,10 +178,11 @@ func (bc *BlockChain) stopViction() {
 	// Flush all remaining lending trie roots to LevelDB.
 	if sp.viction.LendingEngine() != nil {
 		lendingTrieDB := sp.viction.LendingEngine().GetStateCache().TrieDB()
+		log.Info("[TomoZ]: Flushing remaining lending trie roots to LevelDB", "count", sp.lendingTriegc.Size())
 		for !sp.lendingTriegc.Empty() {
 			root := sp.lendingTriegc.PopItem().(common.Hash)
-			if err := lendingTrieDB.Commit(root, true, nil); err != nil {
-				log.Error("TomoZ: lending trieDB.Commit(shutdown) failed", "root", root, "err", err)
+			if err := lendingTrieDB.Commit(root, false, nil); err != nil {
+				log.Error("[TomoZ]: lending trieDB.Commit(shutdown) failed", "root", root, "err", err)
 			}
 			lendingTrieDB.Dereference(root)
 		}

--- a/core/viction/processor.go
+++ b/core/viction/processor.go
@@ -508,9 +508,12 @@ func (vp *Processor) applyTomoXTx(statedb *state.StateDB, tx *types.Transaction,
 		// not header.Coinbase which is zeroed in PoSV blocks. The author is
 		// the address passed to ValidateTradingOrder -> DoSettleBalance for
 		// masternode fee accounting.
+		//
+		// A recovery failure is fatal: settling to the zero address would burn
+		// the matching fees and produce a root no other node reproduces.
 		coinbase, err := vp.engine.Author(header)
 		if err != nil {
-			log.Warn("TomoX: failed to recover block author, using zero address", "err", err)
+			return true, nil, 0, fmt.Errorf("TomoX: failed to resolve block author at block %d: %w", header.Number.Uint64(), err), nil
 		}
 		tradingEngine := vp.tradingEngine
 		tradingStateDB := vp.tradingStateDB
@@ -575,9 +578,11 @@ func (vp *Processor) applyLendingTx(statedb *state.StateDB, tx *types.Transactio
 		// not header.Coinbase which is zeroed in PoSV blocks. The author is
 		// the address passed to ValidateLendingOrder -> DoSettleBalance for
 		// masternode fee accounting.
+		//
+		// Fatal on failure, for the same reason as applyTomoXTx.
 		coinbase, err := vp.engine.Author(header)
 		if err != nil {
-			log.Warn("TomoZ: failed to recover block author, using zero address", "err", err)
+			return true, nil, 0, fmt.Errorf("TomoZ: failed to resolve block author at block %d: %w", header.Number.Uint64(), err), nil
 		}
 		lendingStateDB := vp.lendingStateDB
 		tradingStateDB := vp.tradingStateDB

--- a/eth/backend_viction.go
+++ b/eth/backend_viction.go
@@ -309,10 +309,14 @@ func (eth *Ethereum) setupPosvBackend(chainConfig *params.ChainConfig, stack *no
 	// Initialize legacy TomoX/TomoZ engines for historical block replay.
 	// Both share a single LevelDB ("tomox") since TradingStateDB and LendingStateDB
 	// use independent trie roots and their key-spaces never collide.
+	// A PoSV node that cannot open the TomoX database must refuse to start:
+	// running on with nil trading/lending engines means BeforeProcess never opens
+	// the order-book tries and AfterProcess skips 0x92 state-root verification,
+	// so blocks in the TomoX window import without settlement and without
+	// validation — silent divergence rather than a visible failure.
 	tomoxDb, err := openTomoXDatabase(eth.config, stack)
 	if err != nil {
-		log.Error("Failed to open TomoX database", "err", err)
-		return nil
+		return fmt.Errorf("failed to open TomoX database: %w", err)
 	}
 	tomoxEngine := tomox.NewWithDB(tomoxDb, eth.blockchain.Config())
 	eth.blockchain.SetTradingEngine(tomoxEngine)


### PR DESCRIPTION
This pull request makes several improvements to error handling and logging for TomoX and TomoZ trading and lending state management in the blockchain codebase. The main focus is to make failures more visible and fatal where necessary, clarify log messages, and ensure that the system does not silently continue in an invalid state.

**Error handling improvements:**

* In `core/viction/processor.go`, failures to recover the block author in both `applyTomoXTx` and `applyLendingTx` are now treated as fatal errors, returning an error instead of logging a warning and using the zero address. This prevents silent state divergence. [[1]](diffhunk://#diff-da2cec2f103bd3a9f910718a4e91d4a16ee5ce483125a93799418c6c06d75446R511-R516) [[2]](diffhunk://#diff-da2cec2f103bd3a9f910718a4e91d4a16ee5ce483125a93799418c6c06d75446R581-R585)
* In `eth/backend_viction.go`, failure to open the TomoX database now returns a fatal error instead of logging and continuing, ensuring the node does not run in an unsafe state.

**Logging and reporting improvements:**

* All TomoX and TomoZ log messages are now prefixed with `[TomoX]:` or `[TomoZ]:` for clarity, and error messages are more descriptive. [[1]](diffhunk://#diff-9da594a21efb92747298af87596812bf06bc687320e26976a80620d8388b71f0L53-R64) [[2]](diffhunk://#diff-9da594a21efb92747298af87596812bf06bc687320e26976a80620d8388b71f0L97-R103) [[3]](diffhunk://#diff-9da594a21efb92747298af87596812bf06bc687320e26976a80620d8388b71f0L126-R133) [[4]](diffhunk://#diff-9da594a21efb92747298af87596812bf06bc687320e26976a80620d8388b71f0L157-R172) [[5]](diffhunk://#diff-9da594a21efb92747298af87596812bf06bc687320e26976a80620d8388b71f0R181-R185)
* Added `Info`-level log entries when flushing remaining trie roots to disk during shutdown, including the count of roots to flush. [[1]](diffhunk://#diff-9da594a21efb92747298af87596812bf06bc687320e26976a80620d8388b71f0L157-R172) [[2]](diffhunk://#diff-9da594a21efb92747298af87596812bf06bc687320e26976a80620d8388b71f0R181-R185)

**State commit behavior:**

* The trie commit operations in deferred and shutdown paths now use `report=false` to avoid excessive log spam, with comments explaining the rationale. [[1]](diffhunk://#diff-9da594a21efb92747298af87596812bf06bc687320e26976a80620d8388b71f0L97-R103) [[2]](diffhunk://#diff-9da594a21efb92747298af87596812bf06bc687320e26976a80620d8388b71f0L126-R133) [[3]](diffhunk://#diff-9da594a21efb92747298af87596812bf06bc687320e26976a80620d8388b71f0L157-R172) [[4]](diffhunk://#diff-9da594a21efb92747298af87596812bf06bc687320e26976a80620d8388b71f0R181-R185)

These changes collectively improve the reliability and maintainability of the TomoX/TomoZ state handling by making errors explicit and logs more actionable.